### PR TITLE
eth/catalyst: update payload id computation [optimism bedrock]

### DIFF
--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -445,6 +445,14 @@ func computePayloadId(headBlockHash common.Hash, params *beacon.PayloadAttribute
 	binary.Write(hasher, binary.BigEndian, params.Timestamp)
 	hasher.Write(params.Random[:])
 	hasher.Write(params.SuggestedFeeRecipient[:])
+	if params.NoTxPool || len(params.Transactions) > 0 { // extend if extra payload attributes are used
+		binary.Write(hasher, binary.BigEndian, params.NoTxPool)
+		binary.Write(hasher, binary.BigEndian, uint64(len(params.Transactions)))
+		for _, tx := range params.Transactions {
+			binary.Write(hasher, binary.BigEndian, uint64(len(tx)))
+			hasher.Write(tx)
+		}
+	}
 	var out beacon.PayloadID
 	copy(out[:], hasher.Sum(nil)[:8])
 	return out


### PR DESCRIPTION
The chances of a collision here are very rare, as the payload ids are used in FIFO order, and one at a time, but it doesn't hurt to update the payload ID computation to match all payload attributes. Long-term these payload IDs may be used for other block building software.


