### PR TITLE
optimism: post-merge network should not log warnings about missing tr…

### DIFF
--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -136,6 +136,9 @@ func NewConsensusAPI(eth *eth.Ethereum) *ConsensusAPI {
 		invalidTipsets:    make(map[common.Hash]*types.Header),
 	}
 	eth.Downloader().SetBadBlockCallback(api.setInvalidAncestor)
+	if api.eth.BlockChain().Config().Optimism != nil { // don't start the api heartbeat, there is no transition
+		return api
+	}
 	go api.heartbeat()
 
 	return api


### PR DESCRIPTION
Optimism starts in a post-merge setting, without PoW transition. So we init the time check, so it does not complain no beacon node has been seen.