### PR TITLE
Fix OPB-6: use IsDepositTx instead of artificial nonce value check

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -876,7 +876,6 @@ type callMsg struct {
 func (m callMsg) From() common.Address         { return m.CallMsg.From }
 func (m callMsg) Nonce() uint64                { return 0 }
 func (m callMsg) IsFake() bool                 { return true }
-func (m callMsg) IsSystemTx() bool             { return false }
 func (m callMsg) To() *common.Address          { return m.CallMsg.To }
 func (m callMsg) GasPrice() *big.Int           { return m.CallMsg.GasPrice }
 func (m callMsg) GasFeeCap() *big.Int          { return m.CallMsg.GasFeeCap }
@@ -885,6 +884,8 @@ func (m callMsg) Gas() uint64                  { return m.CallMsg.Gas }
 func (m callMsg) Value() *big.Int              { return m.CallMsg.Value }
 func (m callMsg) Data() []byte                 { return m.CallMsg.Data }
 func (m callMsg) AccessList() types.AccessList { return m.CallMsg.AccessList }
+func (m callMsg) IsSystemTx() bool             { return false }
+func (m callMsg) IsDepositTx() bool            { return false }
 func (m callMsg) Mint() *big.Int               { return nil }
 func (m callMsg) RollupDataGas() uint64        { return 0 }
 

--- a/core/rollup_l1_cost.go
+++ b/core/rollup_l1_cost.go
@@ -20,7 +20,6 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/params"
 )
@@ -47,7 +46,7 @@ func NewL1CostFunc(config *params.ChainConfig, statedb vm.StateDB) vm.L1CostFunc
 	var l1BaseFee, overhead, scalar, decimals, divisor *big.Int
 	return func(blockNum uint64, msg vm.RollupMessage) *big.Int {
 		rollupDataGas := msg.RollupDataGas() // Only fake txs for RPC view-calls are 0.
-		if config.Optimism == nil || msg.Nonce() == types.DepositsNonce || rollupDataGas == 0 {
+		if config.Optimism == nil || msg.IsDepositTx() || rollupDataGas == 0 {
 			return nil
 		}
 		if blockNum != cacheBlockNum {

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -74,13 +74,13 @@ type Message interface {
 	Gas() uint64
 	Value() *big.Int
 
-	// Mint is nil if there is no minting
-	Mint() *big.Int
-	RollupDataGas() uint64
+	IsSystemTx() bool      // IsSystemTx indicates the message, if also a deposit, does not emit gas usage.
+	IsDepositTx() bool     // IsDepositTx indicates the message is force-included and can persist a mint.
+	Mint() *big.Int        // Mint is the amount to mint before EVM processing, or nil if there is no minting.
+	RollupDataGas() uint64 // RollupDataGas indicates the rollup cost of the message, 0 if not a rollup or no cost.
 
 	Nonce() uint64
 	IsFake() bool
-	IsSystemTx() bool
 	Data() []byte
 	AccessList() types.AccessList
 }
@@ -229,7 +229,7 @@ func (st *StateTransition) buyGas() error {
 }
 
 func (st *StateTransition) preCheck() error {
-	if st.msg.Nonce() == types.DepositsNonce {
+	if st.msg.IsDepositTx() {
 		// No fee fields to check, no nonce to check, and no need to check if EOA (L1 already verified it for us)
 		// Gas is free, but no refunds!
 		st.initialGas = st.msg.Gas()
@@ -309,7 +309,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	result, err := st.innerTransitionDb()
 	// Failed deposits must still be included. Unless we cannot produce the block at all due to the gas limit.
 	// On deposit failure, we rewind any state changes from after the minting, and increment the nonce.
-	if err != nil && err != ErrGasLimitReached && st.msg.Nonce() == types.DepositsNonce {
+	if err != nil && err != ErrGasLimitReached && st.msg.IsDepositTx() {
 		st.state.RevertToSnapshot(snap)
 		// Even though we revert the state changes, always increment the nonce for the next deposit transaction
 		st.state.SetNonce(st.msg.From(), st.state.GetNonce(st.msg.From())+1)
@@ -391,7 +391,7 @@ func (st *StateTransition) innerTransitionDb() (*ExecutionResult, error) {
 	}
 
 	// if deposit: skip refunds, skip tipping coinbase
-	if st.msg.Nonce() == types.DepositsNonce {
+	if st.msg.IsDepositTx() {
 		// Record deposits as using all their gas (matches the gas pool)
 		// System Transactions are special & are not recorded as using any gas (anywhere)
 		gasUsed := st.msg.Gas()

--- a/core/types/deposit_tx.go
+++ b/core/types/deposit_tx.go
@@ -64,10 +64,6 @@ func (tx *DepositTx) copy() TxData {
 	return cpy
 }
 
-// DepositsNonce identifies a deposit, since go-ethereum abstracts all transaction types to a core.Message.
-// Deposits do not set a nonce, deposits are included by the system and cannot be repeated or included elsewhere.
-const DepositsNonce uint64 = 0xffff_ffff_ffff_fffd
-
 // accessors for innerTx.
 func (tx *DepositTx) txType() byte           { return DepositTxType }
 func (tx *DepositTx) chainID() *big.Int      { return common.Big0 }
@@ -78,7 +74,7 @@ func (tx *DepositTx) gasFeeCap() *big.Int    { return new(big.Int) }
 func (tx *DepositTx) gasTipCap() *big.Int    { return new(big.Int) }
 func (tx *DepositTx) gasPrice() *big.Int     { return new(big.Int) }
 func (tx *DepositTx) value() *big.Int        { return tx.Value }
-func (tx *DepositTx) nonce() uint64          { return DepositsNonce }
+func (tx *DepositTx) nonce() uint64          { return 0 }
 func (tx *DepositTx) to() *common.Address    { return tx.To }
 func (tx *DepositTx) isSystemTx() bool       { return tx.IsSystemTransaction }
 

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -21,10 +21,11 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/holiman/uint256"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
-	"github.com/holiman/uint256"
 )
 
 // emptyCodeHash is used by create to ensure deployment is disallowed to already
@@ -34,6 +35,7 @@ var emptyCodeHash = crypto.Keccak256Hash(nil)
 type RollupMessage interface {
 	Nonce() uint64
 	RollupDataGas() uint64
+	IsDepositTx() bool
 }
 
 type (


### PR DESCRIPTION
This PR:
- Adds `IsDepositTx() bool` to the `Message` interface: for API calls and regular txs going through EVM.
- Adds `IsDepositTx() bool` to the `*Transaction` type: to fit the same rollup message interface as an EVM message, to directly compute rollup tx cost from a tx (as done in the tx pool).
- Cleans up the ordering of the fields/methods to group together the related optimism changes.
- Replace any usage of the previous artificial nonce value check with proper `IsDepositTx` check.

This should fix issue OPB-6 as reported by Sigma Prime.

Fix ENG-2618