### PR TITLE
Simulated backend - enable proof of stake consensus type and fix performance issue

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/consensus/ethash"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/bloombits"
@@ -63,6 +64,8 @@ type SimulatedBackend struct {
 	database   ethdb.Database   // In memory database to store our testing data
 	blockchain *core.BlockChain // Ethereum blockchain to handle the consensus
 
+	consensusEngine consensus.Engine
+
 	mu              sync.Mutex
 	pendingBlock    *types.Block   // Currently pending block that will be imported on request
 	pendingState    *state.StateDB // Currently pending state that will be the active on request
@@ -93,6 +96,7 @@ type simulatedBackendConfig struct {
 	cacheConfig *core.CacheConfig
 	database    ethdb.Database
 	vmConfig    vm.Config
+	consensus   consensus.Engine
 }
 
 type SimulatedBackendOpt func(s *simulatedBackendConfig)
@@ -133,13 +137,20 @@ func WithVMConfig(vmConfig vm.Config) SimulatedBackendOpt {
 	}
 }
 
+func WithConsensus(consensus consensus.Engine) SimulatedBackendOpt {
+	return func(s *simulatedBackendConfig) {
+		s.consensus = consensus
+	}
+}
+
 // NewSimulatedBackendWithOpts creates a new binding backend based on the given database
 // and uses a simulated blockchain for testing purposes. It exposes additional configuration
 // options that are useful to
 func NewSimulatedBackendWithOpts(opts ...SimulatedBackendOpt) *SimulatedBackend {
 	config := &simulatedBackendConfig{
-		genesis:  core.Genesis{Config: params.AllEthashProtocolChanges, GasLimit: 100000000, Alloc: make(core.GenesisAlloc)},
-		database: rawdb.NewMemoryDatabase(),
+		genesis:   core.Genesis{Config: params.AllEthashProtocolChanges, GasLimit: 100000000, Alloc: make(core.GenesisAlloc)},
+		database:  rawdb.NewMemoryDatabase(),
+		consensus: ethash.NewFaker(),
 	}
 
 	for _, opt := range opts {
@@ -147,12 +158,13 @@ func NewSimulatedBackendWithOpts(opts ...SimulatedBackendOpt) *SimulatedBackend 
 	}
 
 	config.genesis.MustCommit(config.database)
-	blockchain, _ := core.NewBlockChain(config.database, config.cacheConfig, &config.genesis, nil, ethash.NewFaker(), config.vmConfig, nil, nil)
+	blockchain, _ := core.NewBlockChain(config.database, config.cacheConfig, &config.genesis, nil, config.consensus, config.vmConfig, nil, nil)
 
 	backend := &SimulatedBackend{
-		database:   config.database,
-		blockchain: blockchain,
-		config:     config.genesis.Config,
+		database:        config.database,
+		blockchain:      blockchain,
+		config:          config.genesis.Config,
+		consensusEngine: config.consensus,
 	}
 
 	filterBackend := &filterBackend{config.database, blockchain, backend}
@@ -178,6 +190,8 @@ func (b *SimulatedBackend) Commit() common.Hash {
 	if _, err := b.blockchain.InsertChain([]*types.Block{b.pendingBlock}); err != nil {
 		panic(err) // This cannot happen unless the simulator is wrong, fail in that case
 	}
+	// Don't wait for the async tx indexing
+	rawdb.WriteTxLookupEntriesByBlock(b.database, b.pendingBlock)
 	blockHash := b.pendingBlock.Hash()
 
 	// Using the last inserted block here makes it possible to build on a side
@@ -196,7 +210,7 @@ func (b *SimulatedBackend) Rollback() {
 }
 
 func (b *SimulatedBackend) rollback(parent *types.Block) {
-	blocks, _ := core.GenerateChain(b.config, parent, ethash.NewFaker(), b.database, 1, func(int, *core.BlockGen) {})
+	blocks, _ := core.GenerateChain(b.config, parent, b.consensusEngine, b.database, 1, func(int, *core.BlockGen) {})
 
 	b.pendingBlock = blocks[0]
 	b.pendingState, _ = state.New(b.pendingBlock.Root(), b.blockchain.StateCache(), nil)
@@ -733,7 +747,7 @@ func (b *SimulatedBackend) SendTransaction(ctx context.Context, tx *types.Transa
 		return fmt.Errorf("invalid transaction nonce: got %d, want %d", tx.Nonce(), nonce)
 	}
 	// Include tx in chain
-	blocks, receipts := core.GenerateChain(b.config, block, ethash.NewFaker(), b.database, 1, func(number int, block *core.BlockGen) {
+	blocks, receipts := core.GenerateChain(b.config, block, b.consensusEngine, b.database, 1, func(number int, block *core.BlockGen) {
 		for _, tx := range b.pendingBlock.Transactions() {
 			block.AddTxWithChain(b.blockchain, tx)
 		}
@@ -852,7 +866,7 @@ func (b *SimulatedBackend) AdjustTime(adjustment time.Duration) error {
 		return errors.New("Could not adjust time on non-empty block")
 	}
 
-	blocks, _ := core.GenerateChain(b.config, b.blockchain.CurrentBlock(), ethash.NewFaker(), b.database, 1, func(number int, block *core.BlockGen) {
+	blocks, _ := core.GenerateChain(b.config, b.blockchain.CurrentBlock(), b.consensusEngine, b.database, 1, func(number int, block *core.BlockGen) {
 		block.OffsetTime(int64(adjustment.Seconds()))
 	})
 	stateDB, _ := b.blockchain.State()

--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -422,6 +422,9 @@ func IsTTDReached(chain consensus.ChainHeaderReader, parentHash common.Hash, num
 	if chain.Config().TerminalTotalDifficulty == nil {
 		return false, nil
 	}
+	if common.Big0.Cmp(chain.Config().TerminalTotalDifficulty) == 0 { // in case TTD is reached at genesis.
+		return true, nil
+	}
 	td := chain.GetTd(parentHash, number)
 	if td == nil {
 		return false, consensus.ErrUnknownAncestor


### PR DESCRIPTION
**Description**

This PR:
- Adds a `consensus.Engine` option to the simulated backend. This enables us to use the proof of stake consensus.
  - Note that the proof of stake consensus does not have the same timestamp range issues, unlike clique and ethash:
    - clique header verification checks timestamp with 0s margin
    - ethash header verification checks timestamp with 15s margin
  - Since the simulated backend uses a 10s block time internally, the above is a big issue, causing blocks to get stuck until the `futureBlocks` in the `Blockchain` is emptied. This used to force us to wait until the background job clears that queue, and the polling was slow with a second interval.
- Updated the `Commit` in simulated backend to immediately index the transactions. The receipts and block are indexed already, assuming the block does not end up in the future blocks queue. Indexing txs of future blocks is not dangerous; the same can happen with orphaned blocks etc.
- Fix `IsTTDReached` in case of Merge activation at genesis. This is used in difficulty calculation in the testing chain/block building code.
  - Note that the test block builder doesn't even pass the proper parent header, but a half-initialized partial parent header, and the "chain reader" is a chain reader that can't read TD values from the db. So instead of using those input arguments, we just fall back to the simple case "if TTD is 0, then everything passed TTD", even though it doesn't strictly cover everything.

**Tests**

This modifies testing code.

**Additional context**

Tested against op-e2e and new action testing draft. Makes the genesis setup instant, no polling for receipts anymore.


**Metadata**

Part of ENG-2755
