### PR TITLE
config: Add historical-data rpc fallback

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -155,6 +155,7 @@ var (
 		utils.MinerNotifyFullFlag,
 		utils.IgnoreLegacyReceiptsFlag,
 		utils.RollupSequencerHTTPFlag,
+		utils.RollupHistoricalRPCFlag,
 		utils.RollupDisableTxPoolGossipFlag,
 		configFileFlag,
 	}, utils.NetworkFlags, utils.DatabasePathFlags)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -889,6 +889,12 @@ var (
 		Category: flags.RollupCategory,
 	}
 
+	RollupHistoricalRPCFlag = &cli.StringFlag{
+		Name:     "rollup.historicalrpc",
+		Usage:    "RPC endpoint for historical data.",
+		Category: flags.RollupCategory,
+	}
+
 	RollupDisableTxPoolGossipFlag = &cli.BoolFlag{
 		Name:     "rollup.disabletxpoolgossip",
 		Usage:    "Disable transaction pool gossip.",
@@ -1875,6 +1881,9 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	// Only configure sequencer http flag if we're running in verifier mode i.e. --mine is disabled.
 	if ctx.IsSet(RollupSequencerHTTPFlag.Name) && !ctx.IsSet(MiningEnabledFlag.Name) {
 		cfg.RollupSequencerHTTP = ctx.String(RollupSequencerHTTPFlag.Name)
+	}
+	if ctx.IsSet(RollupHistoricalRPCFlag.Name) {
+		cfg.RollupHistoricalRPC = ctx.String(RollupHistoricalRPCFlag.Name)
 	}
 	cfg.RollupDisableTxPoolGossip = ctx.Bool(RollupDisableTxPoolGossipFlag.Name)
 	// Override any default configs for hard coded networks.

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -216,6 +216,7 @@ type Config struct {
 	OverrideTerminalTotalDifficultyPassed *bool `toml:",omitempty"`
 
 	RollupSequencerHTTP string
+	RollupHistoricalRPC string
 
 	RollupDisableTxPoolGossip bool
 }


### PR DESCRIPTION
**Description**

Adds a flag for specifying the rpc endpoint to query historical data.

#12 builds on this PR.

**Metadata**
- Fixes ENG-2887
