### PR TITLE
Rename sequencer flag from http to rpc

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -154,7 +154,7 @@ var (
 		utils.GpoIgnoreGasPriceFlag,
 		utils.MinerNotifyFullFlag,
 		utils.IgnoreLegacyReceiptsFlag,
-		utils.RollupSequencerHTTPFlag,
+		utils.RollupSequencerRPCFlag,
 		utils.RollupDisableTxPoolGossipFlag,
 		configFileFlag,
 	}, utils.NetworkFlags, utils.DatabasePathFlags)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -883,9 +883,9 @@ var (
 	}
 
 	// Rollup Flags
-	RollupSequencerHTTPFlag = &cli.StringFlag{
-		Name:     "rollup.sequencerhttp",
-		Usage:    "HTTP endpoint for the sequencer mempool",
+	RollupSequencerRPCFlag = &cli.StringFlag{
+		Name:     "rollup.sequencerrpc",
+		Usage:    "RPC endpoint for the sequencer mempool",
 		Category: flags.RollupCategory,
 	}
 
@@ -1872,9 +1872,9 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 			cfg.EthDiscoveryURLs = SplitAndTrim(urls)
 		}
 	}
-	// Only configure sequencer http flag if we're running in verifier mode i.e. --mine is disabled.
-	if ctx.IsSet(RollupSequencerHTTPFlag.Name) && !ctx.IsSet(MiningEnabledFlag.Name) {
-		cfg.RollupSequencerHTTP = ctx.String(RollupSequencerHTTPFlag.Name)
+	// Only configure sequencer rpc flag if we're running in verifier mode i.e. --mine is disabled.
+	if ctx.IsSet(RollupSequencerRPCFlag.Name) && !ctx.IsSet(MiningEnabledFlag.Name) {
+		cfg.RollupSequencerRPC = ctx.String(RollupSequencerRPCFlag.Name)
 	}
 	cfg.RollupDisableTxPoolGossip = ctx.Bool(RollupDisableTxPoolGossipFlag.Name)
 	// Override any default configs for hard coded networks.

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -260,9 +260,9 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		return nil, err
 	}
 
-	if config.RollupSequencerHTTP != "" {
+	if config.RollupSequencerRPC != "" {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		client, err := rpc.DialContext(ctx, config.RollupSequencerHTTP)
+		client, err := rpc.DialContext(ctx, config.RollupSequencerRPC)
 		cancel()
 		if err != nil {
 			return nil, err

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -215,7 +215,7 @@ type Config struct {
 	// OverrideTerminalTotalDifficultyPassed (TODO: remove after the fork)
 	OverrideTerminalTotalDifficultyPassed *bool `toml:",omitempty"`
 
-	RollupSequencerHTTP string
+	RollupSequencerRPC string
 
 	RollupDisableTxPoolGossip bool
 }


### PR DESCRIPTION
**Description**

Addresses [the comment](https://github.com/ethereum-optimism/op-geth/pull/10#discussion_r996358249) on PR #10 

> Can we remove "http" from the name? Maybe just name it RPC?
The same holds for the old RollupSequencerHTTPFlag which slipped through; websockets and IPC are valid too, it's not always http.

