### PR TITLE
Flags and interfaces for historical RPC requests

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -155,6 +155,7 @@ var (
 		utils.MinerNotifyFullFlag,
 		utils.IgnoreLegacyReceiptsFlag,
 		utils.RollupSequencerHTTPFlag,
+		utils.RollupHistoricalRPCFlag,
 		utils.RollupDisableTxPoolGossipFlag,
 		configFileFlag,
 	}, utils.NetworkFlags, utils.DatabasePathFlags)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -889,6 +889,12 @@ var (
 		Category: flags.RollupCategory,
 	}
 
+	RollupHistoricalRPCFlag = &cli.StringFlag{
+		Name:     "rollup.historicalrpc",
+		Usage:    "RPC endpoint for historical data.",
+		Category: flags.RollupCategory,
+	}
+
 	RollupDisableTxPoolGossipFlag = &cli.BoolFlag{
 		Name:     "rollup.disabletxpoolgossip",
 		Usage:    "Disable transaction pool gossip.",
@@ -1875,6 +1881,9 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	// Only configure sequencer http flag if we're running in verifier mode i.e. --mine is disabled.
 	if ctx.IsSet(RollupSequencerHTTPFlag.Name) && !ctx.IsSet(MiningEnabledFlag.Name) {
 		cfg.RollupSequencerHTTP = ctx.String(RollupSequencerHTTPFlag.Name)
+	}
+	if ctx.IsSet(RollupHistoricalRPCFlag.Name) {
+		cfg.RollupHistoricalRPC = ctx.String(RollupHistoricalRPCFlag.Name)
 	}
 	cfg.RollupDisableTxPoolGossip = ctx.Bool(RollupDisableTxPoolGossipFlag.Name)
 	// Override any default configs for hard coded networks.

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -381,3 +381,11 @@ func (b *EthAPIBackend) StateAtBlock(ctx context.Context, block *types.Block, re
 func (b *EthAPIBackend) StateAtTransaction(ctx context.Context, block *types.Block, txIndex int, reexec uint64) (core.Message, vm.BlockContext, *state.StateDB, error) {
 	return b.eth.stateAtTransaction(block, txIndex, reexec)
 }
+
+func (b *EthAPIBackend) SequencerRPCService() *rpc.Client {
+	return b.eth.seqRPCService
+}
+
+func (b *EthAPIBackend) Genesis() *types.Block {
+	return b.eth.blockchain.Genesis()
+}

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -216,6 +216,7 @@ type Config struct {
 	OverrideTerminalTotalDifficultyPassed *bool `toml:",omitempty"`
 
 	RollupSequencerHTTP string
+	RollupHistoricalRPC string
 
 	RollupDisableTxPoolGossip bool
 }

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -86,6 +86,8 @@ type Backend interface {
 
 	ChainConfig() *params.ChainConfig
 	Engine() consensus.Engine
+	SequencerRPCService() *rpc.Client
+	Genesis() *types.Block
 
 	// eth/filters needs to be initialized from this backend type, so methods needed by
 	// it must also be included here.

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -339,4 +339,6 @@ func (b *backendMock) SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent)
 	return nil
 }
 
-func (b *backendMock) Engine() consensus.Engine { return nil }
+func (b *backendMock) Engine() consensus.Engine         { return nil }
+func (b *backendMock) SequencerRPCService() *rpc.Client { return nil }
+func (b *backendMock) Genesis() *types.Block            { return nil }

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -329,3 +329,11 @@ func (b *LesApiBackend) StateAtBlock(ctx context.Context, block *types.Block, re
 func (b *LesApiBackend) StateAtTransaction(ctx context.Context, block *types.Block, txIndex int, reexec uint64) (core.Message, vm.BlockContext, *state.StateDB, error) {
 	return b.eth.stateAtTransaction(ctx, block, txIndex, reexec)
 }
+
+func (b *LesApiBackend) SequencerRPCService() *rpc.Client {
+	return b.eth.seqRPCService
+}
+
+func (b *LesApiBackend) Genesis() *types.Block {
+	return b.eth.blockchain.Genesis()
+}

--- a/les/client.go
+++ b/les/client.go
@@ -18,6 +18,7 @@
 package les
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -65,6 +66,9 @@ type LightEthereum struct {
 	serverPoolIterator enode.Iterator
 	pruner             *pruner
 	merger             *consensus.Merger
+
+	seqRPCService        *rpc.Client
+	historicalRPCService *rpc.Client
 
 	bloomRequests chan chan *bloombits.Retrieval // Channel receiving bloom data retrieval requests
 	bloomIndexer  *core.ChainIndexer             // Bloom indexer operating during block imports
@@ -193,6 +197,26 @@ func New(stack *node.Node, config *ethconfig.Config) (*LightEthereum, error) {
 	if leth.handler.ulc != nil {
 		log.Warn("Ultra light client is enabled", "trustedNodes", len(leth.handler.ulc.keys), "minTrustedFraction", leth.handler.ulc.fraction)
 		leth.blockchain.DisableCheckFreq()
+	}
+
+	if config.RollupSequencerHTTP != "" {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		client, err := rpc.DialContext(ctx, config.RollupSequencerHTTP)
+		cancel()
+		if err != nil {
+			return nil, err
+		}
+		leth.seqRPCService = client
+	}
+
+	if config.RollupHistoricalRPC != "" {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		client, err := rpc.DialContext(ctx, config.RollupHistoricalRPC)
+		cancel()
+		if err != nil {
+			return nil, err
+		}
+		leth.historicalRPCService = client
 	}
 
 	leth.netRPCService = ethapi.NewNetAPI(leth.p2pServer, leth.config.NetworkId)


### PR DESCRIPTION
**Description**

This PR builds on #10. 

Adds two methods to the `EthAPIBackend` and `LesApiBackend`: 
- `GetSequencerRPCService`
- `GetGenesis`

These methods will be used in a future PR to support redirecting pre-bedrock blocks to a historical node.