### PR TITLE
Use the pre-existing ethereum.NotFound error

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -19,6 +19,7 @@ package eth
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/big"
 	"time"
 
@@ -36,7 +37,6 @@ import (
 	"github.com/ethereum/go-ethereum/eth/gasprice"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/ethereum/go-ethereum/internal/ethapi"
 	"github.com/ethereum/go-ethereum/miner"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -172,7 +172,7 @@ func (b *EthAPIBackend) StateAndHeaderByNumber(ctx context.Context, number rpc.B
 		return nil, nil, err
 	}
 	if header == nil {
-		return nil, nil, ethapi.ErrHeaderNotFound
+		return nil, nil, fmt.Errorf("header %w", ethereum.NotFound)
 	}
 	stateDb, err := b.eth.BlockChain().StateAt(header.Root)
 	return stateDb, header, err
@@ -188,7 +188,7 @@ func (b *EthAPIBackend) StateAndHeaderByNumberOrHash(ctx context.Context, blockN
 			return nil, nil, err
 		}
 		if header == nil {
-			return nil, nil, errors.New("header for hash not found")
+			return nil, nil, fmt.Errorf("header for hash %w", ethereum.NotFound)
 		}
 		if blockNrOrHash.RequireCanonical && b.eth.blockchain.GetCanonicalHash(header.Number.Uint64()) != hash {
 			return nil, nil, errors.New("hash is not currently canonical")

--- a/ethclient/ethclient_test.go
+++ b/ethclient/ethclient_test.go
@@ -223,7 +223,7 @@ func (m *mockHistoricalBackend) Call(ctx context.Context, args ethapi.Transactio
 	if ok && num == 100 {
 		return hexutil.Bytes("test"), nil
 	}
-	return nil, ethapi.ErrHeaderNotFound
+	return nil, ethereum.NotFound
 }
 
 func (m *mockHistoricalBackend) EstimateGas(ctx context.Context, args ethapi.TransactionArgs, blockNrOrHash *rpc.BlockNumberOrHash) (hexutil.Uint64, error) {
@@ -231,7 +231,7 @@ func (m *mockHistoricalBackend) EstimateGas(ctx context.Context, args ethapi.Tra
 	if ok && num == 100 {
 		return hexutil.Uint64(12345), nil
 	}
-	return 0, ethapi.ErrHeaderNotFound
+	return 0, ethereum.NotFound
 }
 
 func newMockHistoricalBackend(t *testing.T) string {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
@@ -47,8 +48,6 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/tyler-smith/go-bip39"
 )
-
-var ErrHeaderNotFound = errors.New("header not found")
 
 // EthereumAPI provides an API to access Ethereum related information.
 type EthereumAPI struct {
@@ -1016,7 +1015,7 @@ func (e *revertError) ErrorData() interface{} {
 // useful to execute and retrieve values.
 func (s *BlockChainAPI) Call(ctx context.Context, args TransactionArgs, blockNrOrHash rpc.BlockNumberOrHash, overrides *StateOverride) (hexutil.Bytes, error) {
 	result, err := DoCall(ctx, s.b, args, blockNrOrHash, overrides, s.b.RPCEVMTimeout(), s.b.RPCGasCap())
-	if errors.Is(err, ErrHeaderNotFound) && s.b.HistoricalRPCService() != nil {
+	if errors.Is(err, ethereum.NotFound) && s.b.HistoricalRPCService() != nil {
 		var histResult hexutil.Bytes
 		err = s.b.HistoricalRPCService().CallContext(ctx, &histResult, "eth_call", args, blockNrOrHash, overrides)
 		return histResult, err
@@ -1159,7 +1158,7 @@ func (s *BlockChainAPI) EstimateGas(ctx context.Context, args TransactionArgs, b
 	}
 
 	res, err := DoEstimateGas(ctx, s.b, args, bNrOrHash, s.b.RPCGasCap())
-	if errors.Is(err, ErrHeaderNotFound) && s.b.HistoricalRPCService() != nil {
+	if errors.Is(err, ethereum.NotFound) && s.b.HistoricalRPCService() != nil {
 		var result hexutil.Uint64
 		err := s.b.HistoricalRPCService().CallContext(ctx, &result, "eth_estimateGas", args, blockNrOrHash)
 		return result, err


### PR DESCRIPTION
**Description**

Wraps the `ethereum.NotFound` error for error handling in the daisy chain.

This approach should also reduce the diff.