### PR TITLE
Add historical endpoint to TraceBlockByNumber and TraceBlockByHash

### DIFF
--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -80,6 +80,8 @@ type Backend interface {
 	// so this method should be called with the parent.
 	StateAtBlock(ctx context.Context, block *types.Block, reexec uint64, base *state.StateDB, checkLive, preferDisk bool) (*state.StateDB, error)
 	StateAtTransaction(ctx context.Context, block *types.Block, txIndex int, reexec uint64) (core.Message, vm.BlockContext, *state.StateDB, error)
+
+	HistoricalRPCService() *rpc.Client
 }
 
 // API is the collection of tracing APIs exposed over the private debugging endpoint.

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -32,6 +32,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/consensus"
@@ -297,7 +298,7 @@ func TestTraceCall(t *testing.T) {
 				Value: (*hexutil.Big)(big.NewInt(1000)),
 			},
 			config:    nil,
-			expectErr: fmt.Errorf("block #%d not found", genBlocks+1),
+			expectErr: fmt.Errorf("block #%d %w", genBlocks+1, ethereum.NotFound),
 			//expect:    nil,
 		},
 		// Standard JSON trace upon the latest block
@@ -450,7 +451,7 @@ func TestTraceBlock(t *testing.T) {
 		// Trace non-existent block
 		{
 			blockNumber: rpc.BlockNumber(genBlocks + 1),
-			expectErr:   fmt.Errorf("block #%d not found", genBlocks+1),
+			expectErr:   fmt.Errorf("block #%d %w", genBlocks+1, ethereum.NotFound),
 		},
 		// Trace latest block
 		{

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/ethereum/go-ethereum/node"
 	"math/big"
 	"net"
 	"net/http"
@@ -31,6 +30,8 @@ import (
 	"sort"
 	"testing"
 	"time"
+
+	"github.com/ethereum/go-ethereum/node"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
@@ -346,7 +347,7 @@ func TestTraceCall(t *testing.T) {
 				t.Errorf("test %d: expect error %v, got nothing", i, testspec.expectErr)
 				continue
 			}
-			if !reflect.DeepEqual(err, testspec.expectErr) {
+			if err.Error() != testspec.expectErr.Error() {
 				t.Errorf("test %d: error mismatch, want %v, git %v", i, testspec.expectErr, err)
 			}
 		} else {
@@ -471,7 +472,7 @@ func TestTraceBlock(t *testing.T) {
 				t.Errorf("test %d, want error %v", i, tc.expectErr)
 				continue
 			}
-			if !reflect.DeepEqual(err, tc.expectErr) {
+			if err.Error() != tc.expectErr.Error() {
 				t.Errorf("test %d: error mismatch, want %v, get %v", i, tc.expectErr, err)
 			}
 			continue

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -49,6 +49,8 @@ import (
 	"github.com/tyler-smith/go-bip39"
 )
 
+var ErrHeaderNotFound = fmt.Errorf("header %w", ethereum.NotFound)
+
 // EthereumAPI provides an API to access Ethereum related information.
 type EthereumAPI struct {
 	b Backend


### PR DESCRIPTION
**Description**

Adds fallback to the Historical RPC endpoint to 
- `debug_traceBlockByNumber`
- `debug_traceBlockByHash`

**Tests**

A test was added for the historical case of `debug_traceBlockByNumber`. No tests yet exist for `debug_traceBlockByHash`, so they will be added in op-e2e instead.
