### PR TITLE
Add historical endpoint to TraceTransaction

### DIFF
--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -28,6 +28,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/consensus"
@@ -132,7 +133,7 @@ func (api *API) blockByNumber(ctx context.Context, number rpc.BlockNumber) (*typ
 		return nil, err
 	}
 	if block == nil {
-		return nil, fmt.Errorf("block #%d not found", number)
+		return nil, fmt.Errorf("block #%d %w", number, ethereum.NotFound)
 	}
 	return block, nil
 }
@@ -145,7 +146,7 @@ func (api *API) blockByHash(ctx context.Context, hash common.Hash) (*types.Block
 		return nil, err
 	}
 	if block == nil {
-		return nil, fmt.Errorf("block %s not found", hash.Hex())
+		return nil, fmt.Errorf("block %s %w", hash.Hex(), ethereum.NotFound)
 	}
 	return block, nil
 }
@@ -438,7 +439,14 @@ func (api *API) traceChain(ctx context.Context, start, end *types.Block, config 
 // EVM and returns them as a JSON object.
 func (api *API) TraceBlockByNumber(ctx context.Context, number rpc.BlockNumber, config *TraceConfig) ([]*txTraceResult, error) {
 	block, err := api.blockByNumber(ctx, number)
-	if err != nil {
+	if errors.Is(err, ethereum.NotFound) && api.backend.HistoricalRPCService() != nil {
+		var histResult []*txTraceResult
+		err = api.backend.HistoricalRPCService().CallContext(ctx, &histResult, "debug_traceBlockByNumber", number, config)
+		if err != nil && err.Error() == "not found" {
+			return nil, fmt.Errorf("block #%d %w", number, ethereum.NotFound)
+		}
+		return histResult, err
+	} else if err != nil {
 		return nil, err
 	}
 	return api.traceBlock(ctx, block, config)
@@ -448,7 +456,14 @@ func (api *API) TraceBlockByNumber(ctx context.Context, number rpc.BlockNumber, 
 // EVM and returns them as a JSON object.
 func (api *API) TraceBlockByHash(ctx context.Context, hash common.Hash, config *TraceConfig) ([]*txTraceResult, error) {
 	block, err := api.blockByHash(ctx, hash)
-	if err != nil {
+	if errors.Is(err, ethereum.NotFound) && api.backend.HistoricalRPCService() != nil {
+		var histResult []*txTraceResult
+		err = api.backend.HistoricalRPCService().CallContext(ctx, &histResult, "debug_traceBlockByHash", hash, config)
+		if err != nil && err.Error() == "not found" {
+			return nil, fmt.Errorf("block #%d %w", hash, ethereum.NotFound)
+		}
+		return histResult, err
+	} else if err != nil {
 		return nil, err
 	}
 	return api.traceBlock(ctx, block, config)

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/ethereum/go-ethereum/node"
 	"math/big"
 	"net"
 	"net/http"
@@ -31,8 +30,6 @@ import (
 	"sort"
 	"testing"
 	"time"
-
-	"github.com/ethereum/go-ethereum/node"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
@@ -48,6 +45,7 @@ import (
 	"github.com/ethereum/go-ethereum/eth/tracers/logger"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/internal/ethapi"
+	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
 )

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/ethereum/go-ethereum/node"
 	"math/big"
 	"net"
 	"net/http"


### PR DESCRIPTION
**Description**

This PR builds on #19. 
It adds history support to `debug_TraceTransaction`.

**Tests**

A test case was added for transactions which are not found locally. 

