### PR TITLE
Add historical endpoint to TraceCall

### DIFF
--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/ethereum/go-ethereum/node"
 	"math/big"
 	"net"
 	"net/http"


### PR DESCRIPTION
**Description**

Add historical endpoint to TraceCall

**Tests**

A test was added to verify that the call happens to the historical RPC, and that it's response is returned correctly.
