### PR TITLE
optimism: dynamic gas limit - engine API extension

### DIFF
--- a/consensus/misc/eip1559.go
+++ b/consensus/misc/eip1559.go
@@ -35,8 +35,10 @@ func VerifyEip1559Header(config *params.ChainConfig, parent, header *types.Heade
 	if !config.IsLondon(parent.Number) {
 		parentGasLimit = parent.GasLimit * config.ElasticityMultiplier()
 	}
-	if err := VerifyGaslimit(parentGasLimit, header.GasLimit); err != nil {
-		return err
+	if config.Optimism == nil { // gasLimit can adjust instantly in optimism
+		if err := VerifyGaslimit(parentGasLimit, header.GasLimit); err != nil {
+			return err
+		}
 	}
 	// Verify the header is not malformed
 	if header.BaseFee == nil {

--- a/core/beacon/gen_blockparams.go
+++ b/core/beacon/gen_blockparams.go
@@ -20,6 +20,7 @@ func (p PayloadAttributesV1) MarshalJSON() ([]byte, error) {
 		SuggestedFeeRecipient common.Address  `json:"suggestedFeeRecipient"  gencodec:"required"`
 		Transactions          []hexutil.Bytes `json:"transactions,omitempty"  gencodec:"optional"`
 		NoTxPool              bool            `json:"noTxPool,omitempty" gencodec:"optional"`
+		GasLimit              *hexutil.Uint64 `json:"gasLimit,omitempty" gencodec:"optional"`
 	}
 	var enc PayloadAttributesV1
 	enc.Timestamp = hexutil.Uint64(p.Timestamp)
@@ -32,6 +33,7 @@ func (p PayloadAttributesV1) MarshalJSON() ([]byte, error) {
 		}
 	}
 	enc.NoTxPool = p.NoTxPool
+	enc.GasLimit = (*hexutil.Uint64)(p.GasLimit)
 	return json.Marshal(&enc)
 }
 
@@ -43,6 +45,7 @@ func (p *PayloadAttributesV1) UnmarshalJSON(input []byte) error {
 		SuggestedFeeRecipient *common.Address `json:"suggestedFeeRecipient"  gencodec:"required"`
 		Transactions          []hexutil.Bytes `json:"transactions,omitempty"  gencodec:"optional"`
 		NoTxPool              *bool           `json:"noTxPool,omitempty" gencodec:"optional"`
+		GasLimit              *hexutil.Uint64 `json:"gasLimit,omitempty" gencodec:"optional"`
 	}
 	var dec PayloadAttributesV1
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -68,6 +71,9 @@ func (p *PayloadAttributesV1) UnmarshalJSON(input []byte) error {
 	}
 	if dec.NoTxPool != nil {
 		p.NoTxPool = *dec.NoTxPool
+	}
+	if dec.GasLimit != nil {
+		p.GasLimit = (*uint64)(dec.GasLimit)
 	}
 	return nil
 }

--- a/core/beacon/types.go
+++ b/core/beacon/types.go
@@ -39,12 +39,15 @@ type PayloadAttributesV1 struct {
 	// NoTxPool is a field for rollups: if true, the no transactions are taken out of the tx-pool,
 	// only transactions from the above Transactions list will be included.
 	NoTxPool bool `json:"noTxPool,omitempty" gencodec:"optional"`
+	// GasLimit is a field for rollups: if set, this sets the exact gas limit the block produced with.
+	GasLimit *uint64 `json:"gasLimit,omitempty" gencodec:"optional"`
 }
 
 // JSON type overrides for PayloadAttributesV1.
 type payloadAttributesMarshaling struct {
 	Timestamp    hexutil.Uint64
 	Transactions []hexutil.Bytes
+	GasLimit     *hexutil.Uint64
 }
 
 //go:generate go run github.com/fjl/gencodec -type ExecutableDataV1 -field-override executableDataMarshaling -out gen_ed.go

--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -603,7 +603,7 @@ func TestNewPayloadOnInvalidChain(t *testing.T) {
 }
 
 func assembleBlock(api *ConsensusAPI, parentHash common.Hash, params *beacon.PayloadAttributesV1) (*beacon.ExecutableDataV1, error) {
-	block, err := api.eth.Miner().GetSealingBlockSync(parentHash, params.Timestamp, params.SuggestedFeeRecipient, params.Random, false, nil)
+	block, err := api.eth.Miner().GetSealingBlockSync(parentHash, params.Timestamp, params.SuggestedFeeRecipient, params.Random, false, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -846,7 +846,7 @@ func TestNewPayloadOnInvalidTerminalBlock(t *testing.T) {
 		Random:                crypto.Keccak256Hash([]byte{byte(1)}),
 		SuggestedFeeRecipient: parent.Coinbase(),
 	}
-	empty, err := api.eth.Miner().GetSealingBlockSync(parent.Hash(), params.Timestamp, params.SuggestedFeeRecipient, params.Random, true, nil)
+	empty, err := api.eth.Miner().GetSealingBlockSync(parent.Hash(), params.Timestamp, params.SuggestedFeeRecipient, params.Random, true, nil, nil)
 	if err != nil {
 		t.Fatalf("error preparing payload, err=%v", err)
 	}

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -246,8 +246,8 @@ func (miner *Miner) SubscribePendingLogs(ch chan<- []*types.Log) event.Subscript
 // there is always a result that will be returned through the result channel.
 // The difference is that if the execution fails, the returned result is nil
 // and the concrete error is dropped silently.
-func (miner *Miner) GetSealingBlockAsync(parent common.Hash, timestamp uint64, coinbase common.Address, random common.Hash, noTxs bool, forceTxs types.Transactions) (chan *types.Block, error) {
-	resCh, _, err := miner.worker.getSealingBlock(parent, timestamp, coinbase, random, noTxs, forceTxs)
+func (miner *Miner) GetSealingBlockAsync(parent common.Hash, timestamp uint64, coinbase common.Address, random common.Hash, noTxs bool, forceTxs types.Transactions, gasLimit *uint64) (chan *types.Block, error) {
+	resCh, _, err := miner.worker.getSealingBlock(parent, timestamp, coinbase, random, noTxs, forceTxs, gasLimit)
 	if err != nil {
 		return nil, err
 	}
@@ -257,8 +257,8 @@ func (miner *Miner) GetSealingBlockAsync(parent common.Hash, timestamp uint64, c
 // GetSealingBlockSync creates a sealing block according to the given parameters.
 // If the generation is failed or the underlying work is already closed, an error
 // will be returned.
-func (miner *Miner) GetSealingBlockSync(parent common.Hash, timestamp uint64, coinbase common.Address, random common.Hash, noTxs bool, forceTxs types.Transactions) (*types.Block, error) {
-	resCh, errCh, err := miner.worker.getSealingBlock(parent, timestamp, coinbase, random, noTxs, forceTxs)
+func (miner *Miner) GetSealingBlockSync(parent common.Hash, timestamp uint64, coinbase common.Address, random common.Hash, noTxs bool, forceTxs types.Transactions, gasLimit *uint64) (*types.Block, error) {
+	resCh, errCh, err := miner.worker.getSealingBlock(parent, timestamp, coinbase, random, noTxs, forceTxs, gasLimit)
 	if err != nil {
 		return nil, err
 	}

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -637,7 +637,7 @@ func testGetSealingWork(t *testing.T, chainConfig *params.ChainConfig, engine co
 
 	// This API should work even when the automatic sealing is not enabled
 	for _, c := range cases {
-		resChan, errChan, _ := w.getSealingBlock(c.parent, timestamp, c.coinbase, c.random, false, nil)
+		resChan, errChan, _ := w.getSealingBlock(c.parent, timestamp, c.coinbase, c.random, false, nil, nil)
 		block := <-resChan
 		err := <-errChan
 		if c.expectErr {
@@ -655,7 +655,7 @@ func testGetSealingWork(t *testing.T, chainConfig *params.ChainConfig, engine co
 	// This API should work even when the automatic sealing is enabled
 	w.start()
 	for _, c := range cases {
-		resChan, errChan, _ := w.getSealingBlock(c.parent, timestamp, c.coinbase, c.random, false, nil)
+		resChan, errChan, _ := w.getSealingBlock(c.parent, timestamp, c.coinbase, c.random, false, nil, nil)
 		block := <-resChan
 		err := <-errChan
 		if c.expectErr {


### PR DESCRIPTION
PR changes:
- Allow gas limit to instantly change when optimism config is active, instead of the `1/1024` adjustment factor that L1 uses.
- Add optional gaslimit field to payload attributes
- Add optional gaslimit field to internal block building parameters
- Override gaslimit in template header if block building params has gaslimit
- Check if gaslimit field is present in payload attributes if optimism config is active

Testing through monorepo e2e tests.

This enables the op-node to change the gaslimit based on block derivation.
