### PR TITLE
op-geth: add hardcoded addresses for fee payouts

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -427,9 +427,9 @@ func (st *StateTransition) innerTransitionDb() (*ExecutionResult, error) {
 	}
 
 	if optimismConfig := st.evm.ChainConfig().Optimism; optimismConfig != nil {
-		st.state.AddBalance(optimismConfig.BaseFeeRecipient, new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), st.evm.Context.BaseFee))
+		st.state.AddBalance(params.OptimismBaseFeeRecipient, new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), st.evm.Context.BaseFee))
 		if cost := st.evm.Context.L1CostFunc(st.evm.Context.BlockNumber.Uint64(), st.msg); cost != nil {
-			st.state.AddBalance(optimismConfig.L1FeeRecipient, cost)
+			st.state.AddBalance(params.OptimismL1FeeRecipient, cost)
 		}
 	}
 

--- a/params/config.go
+++ b/params/config.go
@@ -411,10 +411,8 @@ func (c *CliqueConfig) String() string {
 
 // OptimismConfig is the optimism config.
 type OptimismConfig struct {
-	BaseFeeRecipient   common.Address `json:"baseFeeRecipient"`
-	L1FeeRecipient     common.Address `json:"l1FeeRecipient"`
-	EIP1559Elasticity  uint64         `json:"eip1559Elasticity"`
-	EIP1559Denominator uint64         `json:"eip1559Denominator"`
+	EIP1559Elasticity  uint64 `json:"eip1559Elasticity"`
+	EIP1559Denominator uint64 `json:"eip1559Denominator"`
 }
 
 // String implements the stringer interface, returning the optimism fee config details.

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -16,7 +16,18 @@
 
 package params
 
-import "math/big"
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+var (
+	// The base fee portion of the transaction fee accumulates at this predeploy
+	OptimismBaseFeeRecipient = common.HexToAddress("0x4200000000000000000000000000000000000019")
+	// The L1 portion of the transaction fee accumulates at this predeploy
+	OptimismL1FeeRecipient = common.HexToAddress("0x420000000000000000000000000000000000001A")
+)
 
 const (
 	GasLimitBoundDivisor uint64 = 1024               // The bound divisor of the gas limit, used in update calculations.


### PR DESCRIPTION
*Description*

Reduce the amount of consensus critical config by hardcoding the addresses that fees pay out to. The final recipient of the fees can now be controlled at the application layer, by the admin of the proxy sitting at the addresses that fees are paid out to.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

