### PR TITLE
optimism: user can set pending block gas limit

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1032,6 +1032,9 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 	}
 	if genParams.gasLimit != nil { // override gas limit if specified
 		header.GasLimit = *genParams.gasLimit
+	} else if w.chain.Config().Optimism != nil && w.config.GasCeil != 0 {
+		// configure the gas limit of pending blocks with the miner gas limit config when using optimism
+		header.GasLimit = w.config.GasCeil
 	}
 	// Run the consensus preparation with the default or customized consensus engine.
 	if err := w.engine.Prepare(w.chain, header); err != nil {


### PR DESCRIPTION
**Description**

When the pending block is computed, it would previously use the full gas limit. When the eip 1559 elasticity is high, this can be too much gas for some resource constrained devices. And every tx processed into the pending block is re-applied if it's not included. This can cause high block production lag as seen in opcraft. To mitigate this, we can allow the user to set the pending gas limit with the existing miner gas limit flag, which is non-functional in optimism otherwise, since the gas limit is set by the system configuration.

The `prepareWork` method has two call paths:
- the engine API: we always specify the exact gas limit we want here
- the pending-block background work: the generation parameters are largely all left unspecified, including the gaslimit. If it's unspecified it determines the values from context. And when it's optimism, it doesn't need to use anything related to the parent gas limit, and can instead use the configured miner gas ceiling to produce a pending block with just the right amount of gas that the user is willing to process for pending-block functionality.

~~This depends on #22~~ Done

**Tests**

e2e testing of pending gas limit: https://github.com/ethereum-optimism/optimism/pull/4047

**Metadata**

Fix ENG-2978

