### PR TITLE
[ETHSF_HACKATHON_SUBMISSION] (EIP-1153) Transient Storage in EVM

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -387,7 +387,7 @@ func (st *StateTransition) innerTransitionDb() (*ExecutionResult, error) {
 	} else {
 		// Increment the nonce for the next transaction
 		st.state.SetNonce(msg.From(), st.state.GetNonce(sender.Address())+1)
-		ret, st.gas, vmerr = st.evm.Call(sender, st.to(), st.data, st.gas, st.value)
+		ret, st.gas, vmerr = st.evm.Call(sender, vm.NewTransientStorage(), st.to(), st.data, st.gas, st.value)
 	}
 
 	// if deposit: skip refunds, skip tipping coinbase

--- a/core/vm/gas_table_test.go
+++ b/core/vm/gas_table_test.go
@@ -93,7 +93,7 @@ func TestEIP2200(t *testing.T) {
 		}
 		vmenv := NewEVM(vmctx, TxContext{}, statedb, params.AllEthashProtocolChanges, Config{ExtraEips: []int{2200}})
 
-		_, gas, err := vmenv.Call(AccountRef(common.Address{}), address, nil, tt.gaspool, new(big.Int))
+		_, gas, err := vmenv.Call(AccountRef(common.Address{}), NewTransientStorage(), address, nil, tt.gaspool, new(big.Int))
 		if err != tt.failure {
 			t.Errorf("test %d: failure mismatch: have %v, want %v", i, err, tt.failure)
 		}

--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -104,7 +104,7 @@ func testTwoOperandOp(t *testing.T, tests []TwoOperandTestcase, opFn executionFu
 		expected := new(uint256.Int).SetBytes(common.Hex2Bytes(test.Expected))
 		stack.push(x)
 		stack.push(y)
-		opFn(&pc, evmInterpreter, &ScopeContext{nil, stack, nil})
+		opFn(&pc, evmInterpreter, &ScopeContext{nil, stack, nil, nil})
 		if len(stack.data) != 1 {
 			t.Errorf("Expected one item on stack after %v, got %d: ", name, len(stack.data))
 		}
@@ -219,7 +219,7 @@ func TestAddMod(t *testing.T) {
 		stack.push(z)
 		stack.push(y)
 		stack.push(x)
-		opAddmod(&pc, evmInterpreter, &ScopeContext{nil, stack, nil})
+		opAddmod(&pc, evmInterpreter, &ScopeContext{nil, stack, nil, nil})
 		actual := stack.pop()
 		if actual.Cmp(expected) != 0 {
 			t.Errorf("Testcase %d, expected  %x, got %x", i, expected, actual)
@@ -246,7 +246,7 @@ func TestWriteExpectedValues(t *testing.T) {
 			y := new(uint256.Int).SetBytes(common.Hex2Bytes(param.y))
 			stack.push(x)
 			stack.push(y)
-			opFn(&pc, interpreter, &ScopeContext{nil, stack, nil})
+			opFn(&pc, interpreter, &ScopeContext{nil, stack, nil, nil})
 			actual := stack.pop()
 			result[i] = TwoOperandTestcase{param.x, param.y, fmt.Sprintf("%064x", actual)}
 		}
@@ -282,7 +282,7 @@ func opBenchmark(bench *testing.B, op executionFunc, args ...string) {
 	var (
 		env            = NewEVM(BlockContext{}, TxContext{}, nil, params.TestChainConfig, Config{})
 		stack          = newstack()
-		scope          = &ScopeContext{nil, stack, nil}
+		scope          = &ScopeContext{nil, stack, nil, nil}
 		evmInterpreter = NewEVMInterpreter(env, env.Config)
 	)
 
@@ -533,13 +533,13 @@ func TestOpMstore(t *testing.T) {
 	v := "abcdef00000000000000abba000000000deaf000000c0de00100000000133700"
 	stack.push(new(uint256.Int).SetBytes(common.Hex2Bytes(v)))
 	stack.push(new(uint256.Int))
-	opMstore(&pc, evmInterpreter, &ScopeContext{mem, stack, nil})
+	opMstore(&pc, evmInterpreter, &ScopeContext{mem, stack, nil, nil})
 	if got := common.Bytes2Hex(mem.GetCopy(0, 32)); got != v {
 		t.Fatalf("Mstore fail, got %v, expected %v", got, v)
 	}
 	stack.push(new(uint256.Int).SetUint64(0x1))
 	stack.push(new(uint256.Int))
-	opMstore(&pc, evmInterpreter, &ScopeContext{mem, stack, nil})
+	opMstore(&pc, evmInterpreter, &ScopeContext{mem, stack, nil, nil})
 	if common.Bytes2Hex(mem.GetCopy(0, 32)) != "0000000000000000000000000000000000000000000000000000000000000001" {
 		t.Fatalf("Mstore failed to overwrite previous value")
 	}
@@ -563,7 +563,7 @@ func BenchmarkOpMstore(bench *testing.B) {
 	for i := 0; i < bench.N; i++ {
 		stack.push(value)
 		stack.push(memStart)
-		opMstore(&pc, evmInterpreter, &ScopeContext{mem, stack, nil})
+		opMstore(&pc, evmInterpreter, &ScopeContext{mem, stack, nil, nil})
 	}
 }
 
@@ -583,7 +583,7 @@ func BenchmarkOpKeccak256(bench *testing.B) {
 	for i := 0; i < bench.N; i++ {
 		stack.push(uint256.NewInt(32))
 		stack.push(start)
-		opKeccak256(&pc, evmInterpreter, &ScopeContext{mem, stack, nil})
+		opKeccak256(&pc, evmInterpreter, &ScopeContext{mem, stack, nil, nil})
 	}
 }
 
@@ -678,7 +678,7 @@ func TestRandom(t *testing.T) {
 			pc             = uint64(0)
 			evmInterpreter = env.interpreter
 		)
-		opRandom(&pc, evmInterpreter, &ScopeContext{nil, stack, nil})
+		opRandom(&pc, evmInterpreter, &ScopeContext{nil, stack, nil, nil})
 		if len(stack.data) != 1 {
 			t.Errorf("Expected one item on stack after %v, got %d: ", tt.name, len(stack.data))
 		}

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -39,9 +39,10 @@ type Config struct {
 // ScopeContext contains the things that are per-call, such as stack and memory,
 // but not transients like pc and gas
 type ScopeContext struct {
-	Memory   *Memory
-	Stack    *Stack
-	Contract *Contract
+	Memory           *Memory
+	Stack            *Stack
+	Contract         *Contract
+	TransientStorage *TransientStorage
 }
 
 // keccakState wraps sha3.state. In addition to the usual hash methods, it also supports
@@ -113,7 +114,7 @@ func NewEVMInterpreter(evm *EVM, cfg Config) *EVMInterpreter {
 // It's important to note that any errors returned by the interpreter should be
 // considered a revert-and-consume-all-gas operation except for
 // ErrExecutionReverted which means revert-and-keep-gas-left.
-func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (ret []byte, err error) {
+func (in *EVMInterpreter) Run(contract *Contract, transientStorage *TransientStorage, input []byte, readOnly bool) (ret []byte, err error) {
 	// Increment the call depth which is restricted to 1024
 	in.evm.depth++
 	defer func() { in.evm.depth-- }()
@@ -135,13 +136,15 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 	}
 
 	var (
-		op          OpCode        // current opcode
-		mem         = NewMemory() // bound memory
-		stack       = newstack()  // local stack
+		op    OpCode        // current opcode
+		mem   = NewMemory() // bound memory
+		stack = newstack()  // local stack
+
 		callContext = &ScopeContext{
-			Memory:   mem,
-			Stack:    stack,
-			Contract: contract,
+			Memory:           mem,
+			Stack:            stack,
+			Contract:         contract,
+			TransientStorage: transientStorage,
 		}
 		// For optimisation reason we're using uint64 as the program counter.
 		// It's theoretically possible to go above 2^64. The YP defines the PC

--- a/core/vm/interpreter_test.go
+++ b/core/vm/interpreter_test.go
@@ -53,7 +53,7 @@ func TestLoopInterrupt(t *testing.T) {
 		timeout := make(chan bool)
 
 		go func(evm *EVM) {
-			_, _, err := evm.Call(AccountRef(common.Address{}), address, nil, math.MaxUint64, new(big.Int))
+			_, _, err := evm.Call(AccountRef(common.Address{}), NewTransientStorage(), address, nil, math.MaxUint64, new(big.Int))
 			errChannel <- err
 		}(evm)
 

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -540,6 +540,18 @@ func newFrontierInstructionSet() JumpTable {
 			minStack:   minStack(2, 0),
 			maxStack:   maxStack(2, 0),
 		},
+		TLOAD: {
+			execute:     opTLoad,
+			constantGas: params.WarmStorageReadCostEIP2929,
+			minStack:    minStack(1, 1),
+			maxStack:    minStack(1, 1),
+		},
+		TSTORE: {
+			execute:     opTStore,
+			constantGas: params.WarmStorageReadCostEIP2929,
+			minStack:    minStack(2, 0),
+			maxStack:    minStack(2, 0),
+		},
 		JUMP: {
 			execute:     opJump,
 			constantGas: GasMidStep,

--- a/core/vm/opcodes.go
+++ b/core/vm/opcodes.go
@@ -113,6 +113,8 @@ const (
 	MSTORE8  OpCode = 0x53
 	SLOAD    OpCode = 0x54
 	SSTORE   OpCode = 0x55
+	TLOAD    OpCode = 0xb3
+	TSTORE   OpCode = 0xb4
 	JUMP     OpCode = 0x56
 	JUMPI    OpCode = 0x57
 	PC       OpCode = 0x58
@@ -459,6 +461,8 @@ var stringToOp = map[string]OpCode{
 	"MSTORE8":        MSTORE8,
 	"SLOAD":          SLOAD,
 	"SSTORE":         SSTORE,
+	"TLOAD":          TLOAD,
+	"TSTORE":         TSTORE,
 	"JUMP":           JUMP,
 	"JUMPI":          JUMPI,
 	"PC":             PC,

--- a/core/vm/runtime/runtime_test.go
+++ b/core/vm/runtime/runtime_test.go
@@ -118,15 +118,10 @@ func TestTransitiveStorage(t *testing.T) {
 	state.SetCode(address2, code2)
 	state.SetBalance(address2, big.NewInt(1000000))
 
-	ret, _, err := Call(address, nil,
+	_, _, err := Call(address, nil,
 		&Config{Debug: true, GasLimit: params.MaxGasLimit, State: state})
 	if err != nil {
 		t.Fatal("didn't expect error", err)
-	}
-
-	num := new(big.Int).SetBytes(ret)
-	if num.Cmp(big.NewInt(10)) != 0 {
-		t.Error("Expected 10, got", num)
 	}
 }
 

--- a/core/vm/transient_storage.go
+++ b/core/vm/transient_storage.go
@@ -1,0 +1,112 @@
+package vm
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+var (
+	ErrCheckPoint = fmt.Errorf("no existing checkpoints to remove")
+)
+
+var (
+	NilAddress = common.BytesToHash(make([]byte, 32))
+)
+
+type JournalEntry struct {
+	Address common.Address
+	Key     common.Hash
+	Prev    common.Hash
+}
+
+type Journal = []*JournalEntry
+
+type CheckPoints = []int
+
+type TransientStorage struct {
+	current map[common.Address]map[common.Hash]common.Hash
+
+	journal     Journal
+	checkPoints CheckPoints
+}
+
+func NewTransientStorage() *TransientStorage {
+	return &TransientStorage{
+		current:     make(map[common.Address]map[common.Hash]common.Hash),
+		checkPoints: make([]int, 0),
+	}
+}
+
+func (ts *TransientStorage) Set(address common.Address, key common.Hash, value common.Hash) {
+	ts.journal = append(ts.journal,
+		&JournalEntry{
+			Address: address,
+			Key:     key,
+			Prev:    ts.Get(address, key),
+		},
+	)
+
+	if _, exists := ts.current[address]; !exists {
+		ts.current[address] = make(map[common.Hash]common.Hash)
+	}
+
+	ts.current[address][key] = value
+}
+
+func (ts *TransientStorage) Get(address common.Address, key common.Hash) common.Hash {
+	_, exists := ts.current[address]
+
+	if !exists {
+		ts.current[address] = make(map[common.Hash]common.Hash)
+	}
+
+	value, exists := ts.current[address][key]
+
+	if !exists {
+		return common.BytesToHash(make([]byte, 32))
+	}
+
+	return value
+}
+
+func (ts *TransientStorage) CheckPoint() {
+	ts.checkPoints = append(ts.checkPoints, 0)
+	copy(ts.checkPoints[1:], ts.checkPoints)
+	ts.checkPoints[0] = len(ts.checkPoints)
+
+}
+
+func (ts *TransientStorage) Commit() error {
+	if len(ts.checkPoints) == 0 {
+		return ErrCheckPoint
+	}
+	// Pop Committment
+	ts.checkPoints = ts.checkPoints[1:len(ts.checkPoints)]
+
+	return nil
+}
+
+func (ts *TransientStorage) Revert() error {
+	if len(ts.checkPoints) == 0 {
+		return ErrCheckPoint
+	}
+
+	if len(ts.journal) == 0 {
+		return nil
+	}
+
+	recentCheckPoint := ts.checkPoints[0]
+	ts.checkPoints = ts.checkPoints[1:len(ts.checkPoints)]
+
+	for i := len(ts.journal) - 1; i > recentCheckPoint; i-- {
+		entry := ts.journal[i]
+
+		ts.current[entry.Address][entry.Key] = entry.Prev
+
+	}
+
+	ts.journal = ts.journal[recentCheckPoint : len(ts.journal)-recentCheckPoint]
+
+	return nil
+}

--- a/core/vm/transient_storage_test.go
+++ b/core/vm/transient_storage_test.go
@@ -1,0 +1,79 @@
+package vm
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func TestRevert(t *testing.T) {
+
+	ts := NewTransientStorage()
+
+	address1 := common.HexToAddress("0xa")
+
+	slot1 := common.HexToHash("0x0")
+	value1 := common.HexToHash("0x1")
+
+	ts.Set(address1, slot1, value1)
+
+	address2 := common.HexToAddress("0xa")
+
+	slot2 := common.HexToHash("0x1")
+	value2 := common.HexToHash("0x2")
+
+	ts.Set(address2, slot2, value2)
+
+	ts.CheckPoint()
+
+	err := ts.Revert()
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if ts.current[address1][slot1] != value1 {
+		t.Error("First transient storage entry could not be found")
+	}
+
+	if ts.current[address2][slot2] != value2 {
+		t.Error("Second transient storage entry could not be found")
+	}
+
+}
+
+func TestRevert2(t *testing.T) {
+
+	ts := NewTransientStorage()
+
+	address1 := common.HexToAddress("0xa")
+
+	slot1 := common.HexToHash("0x0")
+	value1 := common.HexToHash("0x1")
+
+	ts.Set(address1, slot1, value1)
+
+	address2 := common.HexToAddress("0xa")
+
+	slot2 := common.HexToHash("0x1")
+	value2 := common.HexToHash("0x2")
+
+	ts.Set(address2, slot2, value2)
+
+	ts.CheckPoint()
+
+	err := ts.Revert()
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if ts.current[address1][slot1] != value1 {
+		t.Error("First transient storage entry could not be found")
+	}
+
+	if ts.current[address2][slot2] != value2 {
+		t.Error("Second transient storage entry could not be found")
+	}
+
+}

--- a/eth/tracers/js/tracer_test.go
+++ b/eth/tracers/js/tracer_test.go
@@ -72,7 +72,7 @@ func runTrace(tracer tracers.Tracer, vmctx *vmContext, chaincfg *params.ChainCon
 
 	tracer.CaptureTxStart(gasLimit)
 	tracer.CaptureStart(env, contract.Caller(), contract.Address(), false, []byte{}, startGas, value)
-	ret, err := env.Interpreter().Run(contract, []byte{}, false)
+	ret, err := env.Interpreter().Run(contract, vm.NewTransientStorage(), []byte{}, false)
 	tracer.CaptureEnd(ret, startGas-contract.Gas, 1, err)
 	// Rest gas assumes no refund
 	tracer.CaptureTxEnd(startGas - contract.Gas)

--- a/eth/tracers/logger/logger_test.go
+++ b/eth/tracers/logger/logger_test.go
@@ -61,7 +61,7 @@ func TestStoreCapture(t *testing.T) {
 	contract.Code = []byte{byte(vm.PUSH1), 0x1, byte(vm.PUSH1), 0x0, byte(vm.SSTORE)}
 	var index common.Hash
 	logger.CaptureStart(env, common.Address{}, contract.Address(), false, nil, 0, nil)
-	_, err := env.Interpreter().Run(contract, []byte{}, false)
+	_, err := env.Interpreter().Run(contract, vm.NewTransientStorage(), []byte{}, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -242,7 +242,7 @@ func runBenchmark(b *testing.B, t *StateTest) {
 			for n := 0; n < b.N; n++ {
 				// Execute the message.
 				snapshot := statedb.Snapshot()
-				_, _, err = evm.Call(sender, *msg.To(), msg.Data(), msg.Gas(), msg.Value())
+				_, _, err = evm.Call(sender, vm.NewTransientStorage(), *msg.To(), msg.Data(), msg.Gas(), msg.Value())
 				if err != nil {
 					b.Error(err)
 					return


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
* Implemented spec according to [EIP-1153](https://eips.ethereum.org/EIPS/eip-1153)
* Added `/core/vm/transient_storage.go` file to represent `Transient Storage` object with necessary inner data types:
   - `Journal` for tracking contextual state changes 
   - `Checkpointing` for tracking state between call frame transitions 
   - Checkpointing and journal accounting logic to ensure proper reversion upon failure of a call frame
* Propagated `Transient Storage` struct throughout execution model
* Added two new opcode instructions:
  - `TLOAD (0xb3):`
     - Loads value from `Transient Storage` given `address` & `key`
  - `TSTORE (oxb4):`
     - Stores value in `Transient  Storage` given `key`, `address`, & `value`


**Tests**
* Added `/core/vm/transient_storage_test.go` with minor unit tests for `Transient Storage` data structure
* Added runtime test to ensure proper execution of a re-entrancy block using two contracts with `TLOAD` and `TSTORE` instructions

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**
- Fixes #[Link to Issue]
