### PR TITLE
Fix panics in debug_TraceTransaction

### DIFF
--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -208,10 +208,10 @@ func (eth *Ethereum) stateAtTransaction(block *types.Block, txIndex int, reexec 
 		msg, _ := tx.AsMessage(signer, block.BaseFee())
 		txContext := core.NewEVMTxContext(msg)
 		context := core.NewEVMBlockContext(block.Header(), eth.blockchain, nil)
+		context.L1CostFunc = types.NewL1CostFunc(eth.blockchain.Config(), statedb)
 		if idx == txIndex {
 			return msg, context, statedb, release, nil
 		}
-		context.L1CostFunc = types.NewL1CostFunc(eth.blockchain.Config(), statedb)
 		// Not yet the searched for transaction, execute on top of the current state
 		vmenv := vm.NewEVM(context, txContext, statedb, eth.blockchain.Config(), vm.Config{})
 		statedb.Prepare(tx.Hash(), idx)

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -827,10 +827,7 @@ func (api *API) TraceTransaction(ctx context.Context, hash common.Hash, config *
 	if err != nil {
 		return nil, err
 	}
-	if tx == nil {
-		if api.backend.HistoricalRPCService() == nil {
-			return nil, nil
-		}
+	if tx == nil && api.backend.HistoricalRPCService() != nil {
 		var histResult []*txTraceResult
 		err = api.backend.HistoricalRPCService().CallContext(ctx, &histResult, "debug_traceTransaction", hash, config)
 		if err != nil && err.Error() == "not found" {

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -828,6 +828,9 @@ func (api *API) TraceTransaction(ctx context.Context, hash common.Hash, config *
 		return nil, err
 	}
 	if tx == nil {
+		if api.backend.HistoricalRPCService() == nil {
+			return nil, fmt.Errorf("transaction %s %w", hash, ethereum.NotFound)
+		}
 		var histResult []*txTraceResult
 		err = api.backend.HistoricalRPCService().CallContext(ctx, &histResult, "debug_traceTransaction", hash, config)
 		if err != nil && err.Error() == "not found" {

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -829,7 +829,7 @@ func (api *API) TraceTransaction(ctx context.Context, hash common.Hash, config *
 	}
 	if tx == nil {
 		if api.backend.HistoricalRPCService() == nil {
-			return nil, fmt.Errorf("transaction %s %w", hash, ethereum.NotFound)
+			return nil, nil
 		}
 		var histResult []*txTraceResult
 		err = api.backend.HistoricalRPCService().CallContext(ctx, &histResult, "debug_traceTransaction", hash, config)


### PR DESCRIPTION
**Description**

Currently `debug_TraceTransaction` panic's in two separate scenarios: if the transaction doesn't exist (or hasn't yet been included in a block), or if the `--rollup.historicalrpc` argument is not provided. This PR fixes both those scenarios.

**Tests**

I've tested both scenarios using the Optimism bedrock devnet.

**Additional context**

Transaction doesn't exist panic:
```
ERROR[11-18|01:13:55.892] RPC method debug_traceTransaction crashed: runtime error: invalid memory address or nil pointer dereference
goroutine 2271 [running]:
github.com/ethereum/go-ethereum/rpc.(*callback).call.func1()
	github.com/ethereum/go-ethereum/rpc/service.go:199 +0x89
panic({0x133a420, 0x20e90d0})
	runtime/panic.go:838 +0x207
github.com/ethereum/go-ethereum/core.(*StateTransition).innerTransitionDb(0xc007653a80)
	github.com/ethereum/go-ethereum/core/state_transition.go:433 +0xbc4
github.com/ethereum/go-ethereum/core.(*StateTransition).TransitionDb(0xc007653a80)
	github.com/ethereum/go-ethereum/core/state_transition.go:311 +0xce
github.com/ethereum/go-ethereum/core.ApplyMessage(0x1699108?, {0x1846fd0?, 0xc00760cb40?}, 0x0?)
	github.com/ethereum/go-ethereum/core/state_transition.go:193 +0x2a
github.com/ethereum/go-ethereum/eth/tracers.(*API).traceTx(0xc0006259e0, {0x183e870, 0xc00766f600}, {0x1846fd0, 0xc00760cb40}, 0xc007826230, {0x1699108, 0x1699110, 0xc007836ae0, 0x0, ...}, ...)
	github.com/ethereum/go-ethereum/eth/tracers/api.go:987 +0x509
github.com/ethereum/go-ethereum/eth/tracers.(*API).TraceTransaction(0xc0006259e0, {0x183e870, 0xc00766f600}, {0x20, 0xe1, 0x86, 0x2f, 0x4e, 0xb, 0xff, ...}, ...)
	github.com/ethereum/go-ethereum/eth/tracers/api.go:861 +0x398
reflect.Value.call({0xc0003c3680?, 0xc003974b58?, 0x7fe9925e8a68?}, {0x15178b8, 0x4}, {0xc007838180, 0x4, 0x912bf2?})
	reflect/value.go:556 +0x845
reflect.Value.Call({0xc0003c3680?, 0xc003974b58?, 0x16?}, {0xc007838180, 0x4, 0x4})
	reflect/value.go:339 +0xbf
github.com/ethereum/go-ethereum/rpc.(*callback).call(0xc003a15aa0, {0x183e870?, 0xc00766f600}, {0xc007639428, 0x16}, {0xc007836360, 0x2, 0x4c64f7?})
	github.com/ethereum/go-ethereum/rpc/service.go:205 +0x3f0
github.com/ethereum/go-ethereum/rpc.(*handler).runMethod(0xc0078261e0?, {0x183e870?, 0xc00766f600?}, 0xc0076508c0, 0x2?, {0xc007836360?, 0x3cc704ede6351f2b?, 0x0?})
	github.com/ethereum/go-ethereum/rpc/handler.go:391 +0x45
github.com/ethereum/go-ethereum/rpc.(*handler).handleCall(0xc00782c750, 0xc007836300, 0xc0076508c0)
	github.com/ethereum/go-ethereum/rpc/handler.go:336 +0x239
github.com/ethereum/go-ethereum/rpc.(*handler).handleCallMsg(0xc00782c750, 0xc00039c800?, 0xc0076508c0)
	github.com/ethereum/go-ethereum/rpc/handler.go:297 +0x237
github.com/ethereum/go-ethereum/rpc.(*handler).handleMsg.func1(0xc007836300)
	github.com/ethereum/go-ethereum/rpc/handler.go:138 +0x35
github.com/ethereum/go-ethereum/rpc.(*handler).startCallProc.func1()
	github.com/ethereum/go-ethereum/rpc/handler.go:225 +0xc5
created by github.com/ethereum/go-ethereum/rpc.(*handler).startCallProc
	github.com/ethereum/go-ethereum/rpc/handler.go:221 +0x8d
```

No historical RPC panic:
```
ERROR[11-18|01:32:08.397] RPC method debug_traceTransaction crashed: runtime error: invalid memory address or nil pointer dereference
goroutine 288 [running]:
github.com/ethereum/go-ethereum/rpc.(*callback).call.func1()
	github.com/ethereum/go-ethereum/rpc/service.go:199 +0x89
panic({0x133a420, 0x20e90d0})
	runtime/panic.go:838 +0x207
github.com/ethereum/go-ethereum/rpc.(*Client).nextID(...)
	github.com/ethereum/go-ethereum/rpc/client.go:266
github.com/ethereum/go-ethereum/rpc.(*Client).newMessage(0x0?, {0x152f771?, 0x16?}, {0xc00428c6a0?, 0x2?, 0x2?})
	github.com/ethereum/go-ethereum/rpc/client.go:496 +0x41
github.com/ethereum/go-ethereum/rpc.(*Client).CallContext(0x0, {0x183e870, 0xc0041f0dc0}, {0x127a3c0, 0xc004286ba0}, {0x152f771, 0x16}, {0xc00428c6a0, 0x2, 0x2})
	github.com/ethereum/go-ethereum/rpc/client.go:324 +0x11d
github.com/ethereum/go-ethereum/eth/tracers.(*API).TraceTransaction(0xc0004439d0, {0x183e870, 0xc0041f0dc0}, {0x20, 0xe1, 0x86, 0x2f, 0x4e, 0xb, 0xff, ...}, ...)
	github.com/ethereum/go-ethereum/eth/tracers/api.go:832 +0x5ed
reflect.Value.call({0xc002a63580?, 0xc002a7c620?, 0x7ffba0bdb5b8?}, {0x15178b8, 0x4}, {0xc0041d2fc0, 0x4, 0x912bf2?})
	reflect/value.go:556 +0x845
reflect.Value.Call({0xc002a63580?, 0xc002a7c620?, 0x16?}, {0xc0041d2fc0, 0x4, 0x4})
	reflect/value.go:339 +0xbf
github.com/ethereum/go-ethereum/rpc.(*callback).call(0xc003a0fda0, {0x183e870?, 0xc0041f0dc0}, {0xc003945f50, 0x16}, {0xc004285110, 0x2, 0x4c64f7?})
	github.com/ethereum/go-ethereum/rpc/service.go:205 +0x3f0
github.com/ethereum/go-ethereum/rpc.(*handler).runMethod(0xc0041f48c0?, {0x183e870?, 0xc0041f0dc0?}, 0xc0003d3dc0, 0x2?, {0xc004285110?, 0x43a216?, 0x0?})
	github.com/ethereum/go-ethereum/rpc/handler.go:391 +0x45
github.com/ethereum/go-ethereum/rpc.(*handler).handleCall(0xc0041e7560, 0xc0042850b0, 0xc0003d3dc0)
	github.com/ethereum/go-ethereum/rpc/handler.go:336 +0x239
github.com/ethereum/go-ethereum/rpc.(*handler).handleCallMsg(0xc0041e7560, 0xc00006b400?, 0xc0003d3dc0)
	github.com/ethereum/go-ethereum/rpc/handler.go:297 +0x237
github.com/ethereum/go-ethereum/rpc.(*handler).handleMsg.func1(0xc0042850b0)
	github.com/ethereum/go-ethereum/rpc/handler.go:138 +0x35
github.com/ethereum/go-ethereum/rpc.(*handler).startCallProc.func1()
	github.com/ethereum/go-ethereum/rpc/handler.go:225 +0xc5
created by github.com/ethereum/go-ethereum/rpc.(*handler).startCallProc
	github.com/ethereum/go-ethereum/rpc/handler.go:221 +0x8d
```