### PR TITLE
Optimism Bedrock fork block + override

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -161,6 +161,13 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 	if ctx.IsSet(utils.OverrideTerminalTotalDifficulty.Name) {
 		cfg.Eth.OverrideTerminalTotalDifficulty = flags.GlobalBig(ctx, utils.OverrideTerminalTotalDifficulty.Name)
 	}
+	if ctx.IsSet(utils.OverrideOptimismBedrock.Name) {
+		cfg.Eth.OverrideOptimismBedrock = flags.GlobalBig(ctx, utils.OverrideOptimismBedrock.Name)
+	}
+	if ctx.IsSet(utils.OverrideOptimism.Name) {
+		override := ctx.Bool(utils.OverrideOptimism.Name)
+		cfg.Eth.OverrideOptimism = &override
+	}
 	if ctx.IsSet(utils.OverrideTerminalTotalDifficultyPassed.Name) {
 		override := ctx.Bool(utils.OverrideTerminalTotalDifficultyPassed.Name)
 		cfg.Eth.OverrideTerminalTotalDifficultyPassed = &override

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -66,6 +66,8 @@ var (
 		utils.SmartCardDaemonPathFlag,
 		utils.OverrideTerminalTotalDifficulty,
 		utils.OverrideTerminalTotalDifficultyPassed,
+		utils.OverrideOptimismBedrock,
+		utils.OverrideOptimism,
 		utils.EthashCacheDirFlag,
 		utils.EthashCachesInMemoryFlag,
 		utils.EthashCachesOnDiskFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -282,6 +282,16 @@ var (
 		Usage:    "Manually specify TerminalTotalDifficultyPassed, overriding the bundled setting",
 		Category: flags.EthCategory,
 	}
+	OverrideOptimismBedrock = &flags.BigFlag{
+		Name:     "override.bedrock",
+		Usage:    "Manually specify OptimsimBedrock, overriding the bundled setting",
+		Category: flags.EthCategory,
+	}
+	OverrideOptimism = &cli.BoolFlag{
+		Name:     "override.optimism",
+		Usage:    "Manually specify optimism",
+		Category: flags.EthCategory,
+	}
 	// Light server and client settings
 	LightServeFlag = &cli.IntFlag{
 		Name:     "light.serve",

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -269,6 +269,8 @@ func (e *GenesisMismatchError) Error() string {
 type ChainOverrides struct {
 	OverrideTerminalTotalDifficulty       *big.Int
 	OverrideTerminalTotalDifficultyPassed *bool
+	OverrideOptimismBedrock               *big.Int
+	OverrideOptimism                      *bool
 }
 
 // SetupGenesisBlock writes or updates the genesis block in db.
@@ -300,6 +302,17 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, genesis *Genesis, override
 			}
 			if overrides != nil && overrides.OverrideTerminalTotalDifficultyPassed != nil {
 				config.TerminalTotalDifficultyPassed = *overrides.OverrideTerminalTotalDifficultyPassed
+			}
+			if overrides != nil && overrides.OverrideOptimismBedrock != nil {
+				config.BedrockBlock = overrides.OverrideOptimismBedrock
+			}
+			if overrides != nil && overrides.OverrideOptimism != nil {
+				if *overrides.OverrideOptimism {
+					config.Optimism = &params.OptimismConfig{
+						EIP1559Elasticity:  10,
+						EIP1559Denominator: 50,
+					}
+				}
 			}
 		}
 	}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -203,6 +203,12 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	if config.OverrideTerminalTotalDifficulty != nil {
 		overrides.OverrideTerminalTotalDifficulty = config.OverrideTerminalTotalDifficulty
 	}
+	if config.OverrideOptimismBedrock != nil {
+		overrides.OverrideOptimismBedrock = config.OverrideOptimismBedrock
+	}
+	if config.OverrideOptimism != nil {
+		overrides.OverrideOptimism = config.OverrideOptimism
+	}
 	if config.OverrideTerminalTotalDifficultyPassed != nil {
 		overrides.OverrideTerminalTotalDifficultyPassed = config.OverrideTerminalTotalDifficultyPassed
 	}

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -213,6 +213,9 @@ type Config struct {
 	// OverrideTerminalTotalDifficultyPassed (TODO: remove after the fork)
 	OverrideTerminalTotalDifficultyPassed *bool `toml:",omitempty"`
 
+	OverrideOptimismBedrock *big.Int
+	OverrideOptimism        *bool
+
 	// SyncTarget defines the target block of sync. It's only used for
 	// development purposes.
 	SyncTarget *types.Block


### PR DESCRIPTION
**Description**

This enables two overrides: the bedrock fork block & the optimism config
being set. The optimism override uses the default EIP 1559 parameters.

These make it easy to setup a node in optimism mode & have a configurable
bedrock block.

All of the rules accessors are also helpful for checking which mode the
node is running in.