### PR TITLE
[Bug] Fix concurrent map write panic

### DIFF
--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -639,9 +639,9 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 		go func() {
 			blockCtx := core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil)
 			defer pend.Done()
-			blockCtx.L1CostFunc = types.NewL1CostFunc(api.backend.ChainConfig(), statedb)
 			// Fetch and execute the next transaction trace tasks
 			for task := range jobs {
+				blockCtx.L1CostFunc = types.NewL1CostFunc(api.backend.ChainConfig(), task.statedb)
 				msg, _ := txs[task.index].AsMessage(signer, block.BaseFee())
 				txctx := &Context{
 					BlockHash: blockHash,


### PR DESCRIPTION
**Description**

We noticed `op-geth` panic'ing when trying to use the debug tracing API with high concurrency. This is due to a `fatal error: concurrent map read and map write` in the state DB from the `L1CostFunc`.

This PR uses the copy of the state DB that's passed into the jobs channel as part of the task struct.

**Tests**

This is hard to reproduce... would love some pointers on regression testing.