### PR TITLE
fix: startup receipt deser

### DIFF
--- a/core/types/legacy.go
+++ b/core/types/legacy.go
@@ -39,6 +39,10 @@ func IsLegacyStoredReceipts(raw []byte) (bool, error) {
 	if err := rlp.DecodeBytes(raw, &v5); err == nil {
 		return false, nil
 	}
+	var legacyOptimism []LegacyOptimismStoredReceiptRLP
+	if err := rlp.DecodeBytes(raw, &legacyOptimism); err == nil {
+		return false, nil
+	}
 	return false, errors.New("value is not a valid receipt encoding")
 }
 


### PR DESCRIPTION
**Description**

Part of the boot process looks at receipts in the database to determine which schema is used. When booting with legacy optimism style receipts in the database, an error message is shown on boot. This error message doesn't do anything, but this commit fixes the problem. If when checking for legacy receipts and `true` is returned, then geth will shutdown and tell the user to run a migration command to migrate to newer style receipts. We return `false` to prevent geth from shutting down. Further investigation is needed to ensure that having these receipts in the database won't cause any issues, we may need to migrate them similarly to the tool that the geth team wrote to upgrade the receipt serialization.

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->


