### PR TITLE
optimism: minor goerli fixes - banner, clique config, networkid

### DIFF
--- a/core/rawdb/accessors_metadata.go
+++ b/core/rawdb/accessors_metadata.go
@@ -64,6 +64,9 @@ func ReadChainConfig(db ethdb.KeyValueReader, hash common.Hash) *params.ChainCon
 		log.Error("Invalid chain config JSON", "hash", hash, "err", err)
 		return nil
 	}
+	if config.Optimism != nil {
+		config.Clique = nil // get rid of legacy clique data in chain config (optimism goerli issue)
+	}
 	return &config
 }
 

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -170,7 +170,6 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	if bcVersion != nil {
 		dbVer = fmt.Sprintf("%d", *bcVersion)
 	}
-	log.Info("Initialising Ethereum protocol", "network", config.NetworkId, "dbversion", dbVer)
 
 	if !config.SkipBcVersionCheck {
 		if bcVersion != nil && *bcVersion > core.BlockChainVersion {
@@ -216,6 +215,12 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	if err != nil {
 		return nil, err
 	}
+	if chainConfig := eth.blockchain.Config(); chainConfig.Optimism != nil { // config.Genesis.Config.ChainID cannot be used because it's based on CLI flags only, thus default to mainnet L1
+		config.NetworkId = chainConfig.ChainID.Uint64() // optimism defaults eth network ID to chain ID
+		eth.networkID = config.NetworkId
+	}
+	log.Info("Initialising Ethereum protocol", "network", config.NetworkId, "dbversion", dbVer)
+
 	eth.bloomIndexer.Start(eth.blockchain)
 
 	if config.TxPool.Journal != "" {

--- a/params/config.go
+++ b/params/config.go
@@ -437,6 +437,8 @@ func (c *ChainConfig) Description() string {
 	}
 	banner += fmt.Sprintf("Chain ID:  %v (%s)\n", c.ChainID, network)
 	switch {
+	case c.Optimism != nil:
+		banner += "Consensus: Optimism\n"
 	case c.Ethash != nil:
 		if c.TerminalTotalDifficulty == nil {
 			banner += "Consensus: Ethash (proof-of-work)\n"
@@ -453,8 +455,6 @@ func (c *ChainConfig) Description() string {
 		} else {
 			banner += "Consensus: Beacon (proof-of-stake), merged from Clique (proof-of-authority)\n"
 		}
-	case c.Optimism != nil:
-		banner += "Consensus: Optimism\n"
 	default:
 		banner += "Consensus: unknown\n"
 	}


### PR DESCRIPTION
Fixes minor issues encountered in goerli bedrock upgrade:
- The banner didn't display because clique config was set. Prioritize printing optimism consensus mode, if specified.
- The clique config shouldn't be there in the first place: if optimism config is specified, we remove the clique data (clique config was a holdover from legacy pre-bedrock geth workarounds).
- The networkid flag was missed by many users. Let's just default it to the chain ID.

Example of clique network in banner, during debugging before fixes:
![image](https://user-images.githubusercontent.com/19571989/212208870-01fcf7e2-e1f1-4f6e-b759-5efc484546f8.png)

Tested against goerli optimism bedrock network.

```
curl http://127.0.0.1:8545   -X POST   -H "Content-Type: application/json"   --data '{"method":"net_version","params":[],"id":1,"jsonrpc":"2.0"}'
{"jsonrpc":"2.0","id":1,"result":"420"}
```