### PR TITLE
op-geth: more daisychain routing

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ethereum/go-ethereum"
+
 	"github.com/davecgh/go-spew/spew"
 	"github.com/tyler-smith/go-bip39"
 
@@ -631,12 +633,12 @@ func (s *BlockChainAPI) BlockNumber() hexutil.Uint64 {
 // given block number. The rpc.LatestBlockNumber and rpc.PendingBlockNumber meta
 // block numbers are also allowed.
 func (s *BlockChainAPI) GetBalance(ctx context.Context, address common.Address, blockNrOrHash rpc.BlockNumberOrHash) (*hexutil.Big, error) {
-	state, header, err := s.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
-	if state == nil || err != nil {
+	header, err := headerByNumberOrHash(ctx, s.b, blockNrOrHash)
+	if err != nil {
 		return nil, err
 	}
 
-	if header != nil && s.b.ChainConfig().IsOptimismPreBedrock(header.Number) {
+	if s.b.ChainConfig().IsOptimismPreBedrock(header.Number) {
 		if s.b.HistoricalRPCService() != nil {
 			var res hexutil.Big
 			err := s.b.HistoricalRPCService().CallContext(ctx, &res, "eth_getBalance", address, blockNrOrHash)
@@ -647,6 +649,11 @@ func (s *BlockChainAPI) GetBalance(ctx context.Context, address common.Address, 
 		} else {
 			return nil, rpc.ErrNoHistoricalFallback
 		}
+	}
+
+	state, _, err := s.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
+	if state == nil || err != nil {
+		return nil, err
 	}
 
 	return (*hexutil.Big)(state.GetBalance(address)), state.Error()
@@ -671,12 +678,12 @@ type StorageResult struct {
 
 // GetProof returns the Merkle-proof for a given account and optionally some storage keys.
 func (s *BlockChainAPI) GetProof(ctx context.Context, address common.Address, storageKeys []string, blockNrOrHash rpc.BlockNumberOrHash) (*AccountResult, error) {
-	state, header, err := s.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
-	if state == nil || err != nil {
+	header, err := headerByNumberOrHash(ctx, s.b, blockNrOrHash)
+	if err != nil {
 		return nil, err
 	}
 
-	if header != nil && s.b.ChainConfig().IsOptimismPreBedrock(header.Number) {
+	if s.b.ChainConfig().IsOptimismPreBedrock(header.Number) {
 		if s.b.HistoricalRPCService() != nil {
 			var res AccountResult
 			err := s.b.HistoricalRPCService().CallContext(ctx, &res, "eth_getProof", address, storageKeys, blockNrOrHash)
@@ -687,6 +694,11 @@ func (s *BlockChainAPI) GetProof(ctx context.Context, address common.Address, st
 		} else {
 			return nil, rpc.ErrNoHistoricalFallback
 		}
+	}
+
+	state, _, err := s.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
+	if state == nil || err != nil {
+		return nil, err
 	}
 
 	storageTrie := state.StorageTrie(address)
@@ -862,12 +874,12 @@ func (s *BlockChainAPI) GetUncleCountByBlockHash(ctx context.Context, blockHash 
 
 // GetCode returns the code stored at the given address in the state for the given block number.
 func (s *BlockChainAPI) GetCode(ctx context.Context, address common.Address, blockNrOrHash rpc.BlockNumberOrHash) (hexutil.Bytes, error) {
-	state, header, err := s.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
-	if state == nil || err != nil {
+	header, err := headerByNumberOrHash(ctx, s.b, blockNrOrHash)
+	if err != nil {
 		return nil, err
 	}
 
-	if header != nil && s.b.ChainConfig().IsOptimismPreBedrock(header.Number) {
+	if s.b.ChainConfig().IsOptimismPreBedrock(header.Number) {
 		if s.b.HistoricalRPCService() != nil {
 			var res hexutil.Bytes
 			err := s.b.HistoricalRPCService().CallContext(ctx, &res, "eth_getCode", address, blockNrOrHash)
@@ -880,6 +892,11 @@ func (s *BlockChainAPI) GetCode(ctx context.Context, address common.Address, blo
 		}
 	}
 
+	state, _, err := s.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
+	if state == nil || err != nil {
+		return nil, err
+	}
+
 	code := state.GetCode(address)
 	return code, state.Error()
 }
@@ -888,12 +905,12 @@ func (s *BlockChainAPI) GetCode(ctx context.Context, address common.Address, blo
 // block number. The rpc.LatestBlockNumber and rpc.PendingBlockNumber meta block
 // numbers are also allowed.
 func (s *BlockChainAPI) GetStorageAt(ctx context.Context, address common.Address, hexKey string, blockNrOrHash rpc.BlockNumberOrHash) (hexutil.Bytes, error) {
-	state, header, err := s.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
-	if state == nil || err != nil {
+	header, err := headerByNumberOrHash(ctx, s.b, blockNrOrHash)
+	if err != nil {
 		return nil, err
 	}
 
-	if header != nil && s.b.ChainConfig().IsOptimismPreBedrock(header.Number) {
+	if s.b.ChainConfig().IsOptimismPreBedrock(header.Number) {
 		if s.b.HistoricalRPCService() != nil {
 			var res hexutil.Bytes
 			err := s.b.HistoricalRPCService().CallContext(ctx, &res, "eth_getStorageAt", address, hexKey, blockNrOrHash)
@@ -906,6 +923,11 @@ func (s *BlockChainAPI) GetStorageAt(ctx context.Context, address common.Address
 		}
 	}
 
+	state, _, err := s.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
+	if state == nil || err != nil {
+		return nil, err
+	}
+
 	key, err := decodeHash(hexKey)
 
 	if err != nil {
@@ -913,6 +935,18 @@ func (s *BlockChainAPI) GetStorageAt(ctx context.Context, address common.Address
 	}
 	res := state.GetState(address, key)
 	return res[:], state.Error()
+}
+
+// The HeaderByNumberOrHash method returns a nil error and nil header
+// if the header is not found, but only for nonexistent block numbers. This is
+// different from StateAndHeaderByNumberOrHash. To account for this discrepancy,
+// headerOrNumberByHash will properly convert the error into an ethereum.NotFound.
+func headerByNumberOrHash(ctx context.Context, b Backend, blockNrOrHash rpc.BlockNumberOrHash) (*types.Header, error) {
+	header, err := b.HeaderByNumberOrHash(ctx, blockNrOrHash)
+	if header == nil {
+		return nil, fmt.Errorf("header %w", ethereum.NotFound)
+	}
+	return header, err
 }
 
 // OverrideAccount indicates the overriding fields of account during the execution
@@ -1098,8 +1132,12 @@ func (e *revertError) ErrorData() interface{} {
 // Note, this function doesn't make and changes in the state/blockchain and is
 // useful to execute and retrieve values.
 func (s *BlockChainAPI) Call(ctx context.Context, args TransactionArgs, blockNrOrHash rpc.BlockNumberOrHash, overrides *StateOverride) (hexutil.Bytes, error) {
-	header, err := s.b.HeaderByNumberOrHash(ctx, blockNrOrHash)
-	if err == nil && header != nil && s.b.ChainConfig().IsOptimismPreBedrock(header.Number) {
+	header, err := headerByNumberOrHash(ctx, s.b, blockNrOrHash)
+	if err != nil {
+		return nil, err
+	}
+
+	if s.b.ChainConfig().IsOptimismPreBedrock(header.Number) {
 		if s.b.HistoricalRPCService() != nil {
 			var res hexutil.Bytes
 			err := s.b.HistoricalRPCService().CallContext(ctx, &res, "eth_call", args, blockNrOrHash, overrides)
@@ -1251,8 +1289,12 @@ func (s *BlockChainAPI) EstimateGas(ctx context.Context, args TransactionArgs, b
 		bNrOrHash = *blockNrOrHash
 	}
 
-	header, err := s.b.HeaderByNumberOrHash(ctx, bNrOrHash)
-	if err == nil && header != nil && s.b.ChainConfig().IsOptimismPreBedrock(header.Number) {
+	header, err := headerByNumberOrHash(ctx, s.b, bNrOrHash)
+	if err != nil {
+		return 0, err
+	}
+
+	if s.b.ChainConfig().IsOptimismPreBedrock(header.Number) {
 		if s.b.HistoricalRPCService() != nil {
 			var res hexutil.Uint64
 			err := s.b.HistoricalRPCService().CallContext(ctx, &res, "eth_estimateGas", args, blockNrOrHash)
@@ -1514,7 +1556,7 @@ func (s *BlockChainAPI) CreateAccessList(ctx context.Context, args TransactionAr
 		bNrOrHash = *blockNrOrHash
 	}
 
-	header, err := s.b.HeaderByNumberOrHash(ctx, bNrOrHash)
+	header, err := headerByNumberOrHash(ctx, s.b, bNrOrHash)
 	if err == nil && header != nil && s.b.ChainConfig().IsOptimismPreBedrock(header.Number) {
 		if s.b.HistoricalRPCService() != nil {
 			var res accessListResult
@@ -1681,12 +1723,12 @@ func (s *TransactionAPI) GetTransactionCount(ctx context.Context, address common
 		return (*hexutil.Uint64)(&nonce), nil
 	}
 	// Resolve block number and use its state to ask for the nonce
-	state, header, err := s.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
-	if state == nil || err != nil {
+	header, err := headerByNumberOrHash(ctx, s.b, blockNrOrHash)
+	if err != nil {
 		return nil, err
 	}
 
-	if header != nil && s.b.ChainConfig().IsOptimismPreBedrock(header.Number) {
+	if s.b.ChainConfig().IsOptimismPreBedrock(header.Number) {
 		if s.b.HistoricalRPCService() != nil {
 			var res hexutil.Uint64
 			err := s.b.HistoricalRPCService().CallContext(ctx, &res, "eth_getTransactionCount", address, blockNrOrHash)
@@ -1697,6 +1739,11 @@ func (s *TransactionAPI) GetTransactionCount(ctx context.Context, address common
 		} else {
 			return nil, rpc.ErrNoHistoricalFallback
 		}
+	}
+
+	state, _, err := s.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
+	if state == nil || err != nil {
+		return nil, err
 	}
 
 	nonce := state.GetNonce(address)

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -631,10 +631,24 @@ func (s *BlockChainAPI) BlockNumber() hexutil.Uint64 {
 // given block number. The rpc.LatestBlockNumber and rpc.PendingBlockNumber meta
 // block numbers are also allowed.
 func (s *BlockChainAPI) GetBalance(ctx context.Context, address common.Address, blockNrOrHash rpc.BlockNumberOrHash) (*hexutil.Big, error) {
-	state, _, err := s.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
+	state, header, err := s.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
 	if state == nil || err != nil {
 		return nil, err
 	}
+
+	if header != nil && s.b.ChainConfig().IsOptimismPreBedrock(header.Number) {
+		if s.b.HistoricalRPCService() != nil {
+			var res hexutil.Big
+			err := s.b.HistoricalRPCService().CallContext(ctx, &res, "eth_getBalance", address, blockNrOrHash)
+			if err != nil {
+				return nil, fmt.Errorf("historical backend error: %w", err)
+			}
+			return &res, nil
+		} else {
+			return nil, rpc.ErrNoHistoricalFallback
+		}
+	}
+
 	return (*hexutil.Big)(state.GetBalance(address)), state.Error()
 }
 
@@ -657,9 +671,22 @@ type StorageResult struct {
 
 // GetProof returns the Merkle-proof for a given account and optionally some storage keys.
 func (s *BlockChainAPI) GetProof(ctx context.Context, address common.Address, storageKeys []string, blockNrOrHash rpc.BlockNumberOrHash) (*AccountResult, error) {
-	state, _, err := s.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
+	state, header, err := s.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
 	if state == nil || err != nil {
 		return nil, err
+	}
+
+	if header != nil && s.b.ChainConfig().IsOptimismPreBedrock(header.Number) {
+		if s.b.HistoricalRPCService() != nil {
+			var res AccountResult
+			err := s.b.HistoricalRPCService().CallContext(ctx, &res, "eth_getProof", address, storageKeys, blockNrOrHash)
+			if err != nil {
+				return nil, fmt.Errorf("historical backend error: %w", err)
+			}
+			return &res, nil
+		} else {
+			return nil, rpc.ErrNoHistoricalFallback
+		}
 	}
 
 	storageTrie := state.StorageTrie(address)
@@ -835,10 +862,24 @@ func (s *BlockChainAPI) GetUncleCountByBlockHash(ctx context.Context, blockHash 
 
 // GetCode returns the code stored at the given address in the state for the given block number.
 func (s *BlockChainAPI) GetCode(ctx context.Context, address common.Address, blockNrOrHash rpc.BlockNumberOrHash) (hexutil.Bytes, error) {
-	state, _, err := s.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
+	state, header, err := s.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
 	if state == nil || err != nil {
 		return nil, err
 	}
+
+	if header != nil && s.b.ChainConfig().IsOptimismPreBedrock(header.Number) {
+		if s.b.HistoricalRPCService() != nil {
+			var res hexutil.Bytes
+			err := s.b.HistoricalRPCService().CallContext(ctx, &res, "eth_getCode", address, blockNrOrHash)
+			if err != nil {
+				return nil, fmt.Errorf("historical backend error: %w", err)
+			}
+			return res, nil
+		} else {
+			return nil, rpc.ErrNoHistoricalFallback
+		}
+	}
+
 	code := state.GetCode(address)
 	return code, state.Error()
 }
@@ -847,11 +888,26 @@ func (s *BlockChainAPI) GetCode(ctx context.Context, address common.Address, blo
 // block number. The rpc.LatestBlockNumber and rpc.PendingBlockNumber meta block
 // numbers are also allowed.
 func (s *BlockChainAPI) GetStorageAt(ctx context.Context, address common.Address, hexKey string, blockNrOrHash rpc.BlockNumberOrHash) (hexutil.Bytes, error) {
-	state, _, err := s.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
+	state, header, err := s.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
 	if state == nil || err != nil {
 		return nil, err
 	}
+
+	if header != nil && s.b.ChainConfig().IsOptimismPreBedrock(header.Number) {
+		if s.b.HistoricalRPCService() != nil {
+			var res hexutil.Bytes
+			err := s.b.HistoricalRPCService().CallContext(ctx, &res, "eth_getStorageAt", address, hexKey, blockNrOrHash)
+			if err != nil {
+				return nil, fmt.Errorf("historical backend error: %w", err)
+			}
+			return res, nil
+		} else {
+			return nil, rpc.ErrNoHistoricalFallback
+		}
+	}
+
 	key, err := decodeHash(hexKey)
+
 	if err != nil {
 		return nil, fmt.Errorf("unable to decode storage key: %s", err)
 	}
@@ -1045,12 +1101,12 @@ func (s *BlockChainAPI) Call(ctx context.Context, args TransactionArgs, blockNrO
 	header, err := s.b.HeaderByNumberOrHash(ctx, blockNrOrHash)
 	if err == nil && header != nil && s.b.ChainConfig().IsOptimismPreBedrock(header.Number) {
 		if s.b.HistoricalRPCService() != nil {
-			var histResult hexutil.Bytes
-			err := s.b.HistoricalRPCService().CallContext(ctx, &histResult, "eth_call", args, blockNrOrHash, overrides)
+			var res hexutil.Bytes
+			err := s.b.HistoricalRPCService().CallContext(ctx, &res, "eth_call", args, blockNrOrHash, overrides)
 			if err != nil {
 				return nil, fmt.Errorf("historical backend error: %w", err)
 			}
-			return histResult, nil
+			return res, nil
 		} else {
 			return nil, rpc.ErrNoHistoricalFallback
 		}
@@ -1198,12 +1254,12 @@ func (s *BlockChainAPI) EstimateGas(ctx context.Context, args TransactionArgs, b
 	header, err := s.b.HeaderByNumberOrHash(ctx, bNrOrHash)
 	if err == nil && header != nil && s.b.ChainConfig().IsOptimismPreBedrock(header.Number) {
 		if s.b.HistoricalRPCService() != nil {
-			var result hexutil.Uint64
-			err := s.b.HistoricalRPCService().CallContext(ctx, &result, "eth_estimateGas", args, blockNrOrHash)
+			var res hexutil.Uint64
+			err := s.b.HistoricalRPCService().CallContext(ctx, &res, "eth_estimateGas", args, blockNrOrHash)
 			if err != nil {
 				return 0, fmt.Errorf("historical backend error: %w", err)
 			}
-			return result, nil
+			return res, nil
 		} else {
 			return 0, rpc.ErrNoHistoricalFallback
 		}
@@ -1457,6 +1513,21 @@ func (s *BlockChainAPI) CreateAccessList(ctx context.Context, args TransactionAr
 	if blockNrOrHash != nil {
 		bNrOrHash = *blockNrOrHash
 	}
+
+	header, err := s.b.HeaderByNumberOrHash(ctx, bNrOrHash)
+	if err == nil && header != nil && s.b.ChainConfig().IsOptimismPreBedrock(header.Number) {
+		if s.b.HistoricalRPCService() != nil {
+			var res accessListResult
+			err := s.b.HistoricalRPCService().CallContext(ctx, &res, "eth_createAccessList", args, blockNrOrHash)
+			if err != nil {
+				return nil, fmt.Errorf("historical backend error: %w", err)
+			}
+			return &res, nil
+		} else {
+			return nil, rpc.ErrNoHistoricalFallback
+		}
+	}
+
 	acl, gasUsed, vmerr, err := AccessList(ctx, s.b, bNrOrHash, args)
 	if err != nil {
 		return nil, err
@@ -1610,10 +1681,24 @@ func (s *TransactionAPI) GetTransactionCount(ctx context.Context, address common
 		return (*hexutil.Uint64)(&nonce), nil
 	}
 	// Resolve block number and use its state to ask for the nonce
-	state, _, err := s.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
+	state, header, err := s.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
 	if state == nil || err != nil {
 		return nil, err
 	}
+
+	if header != nil && s.b.ChainConfig().IsOptimismPreBedrock(header.Number) {
+		if s.b.HistoricalRPCService() != nil {
+			var res hexutil.Uint64
+			err := s.b.HistoricalRPCService().CallContext(ctx, &res, "eth_getTransactionCount", address, blockNrOrHash)
+			if err != nil {
+				return nil, fmt.Errorf("historical backend error: %w", err)
+			}
+			return &res, nil
+		} else {
+			return nil, rpc.ErrNoHistoricalFallback
+		}
+	}
+
 	nonce := state.GetNonce(address)
 	return (*hexutil.Uint64)(&nonce), state.Error()
 }


### PR DESCRIPTION
**Description**

Adds the following RPC endpoints to the daisychain usage:

- `eth_getBalance`
- `eth_getProof`
- `eth_getCode`
- `eth_getStorageAt`
- `eth_getTransactionCount`

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

Closes ENG-3203
