### PR TITLE
optimism: Add --rollup.historicalrpctimeout flag

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -154,6 +154,7 @@ var (
 		utils.IgnoreLegacyReceiptsFlag,
 		utils.RollupSequencerHTTPFlag,
 		utils.RollupHistoricalRPCFlag,
+		utils.RollupHistoricalRPCTimeoutFlag,
 		utils.RollupDisableTxPoolGossipFlag,
 		configFileFlag,
 	}, utils.NetworkFlags, utils.DatabasePathFlags)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -933,6 +933,13 @@ var (
 		Category: flags.RollupCategory,
 	}
 
+	RollupHistoricalRPCTimeoutFlag = &cli.StringFlag{
+		Name:     "rollup.historicalrpctimeout",
+		Usage:    "Timeout for historical RPC requests.",
+		Value:    "5s",
+		Category: flags.RollupCategory,
+	}
+
 	RollupDisableTxPoolGossipFlag = &cli.BoolFlag{
 		Name:     "rollup.disabletxpoolgossip",
 		Usage:    "Disable transaction pool gossip.",
@@ -1940,6 +1947,9 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	}
 	if ctx.IsSet(RollupHistoricalRPCFlag.Name) {
 		cfg.RollupHistoricalRPC = ctx.String(RollupHistoricalRPCFlag.Name)
+	}
+	if ctx.IsSet(RollupHistoricalRPCTimeoutFlag.Name) {
+		cfg.RollupHistoricalRPCTimeout = ctx.Duration(RollupHistoricalRPCTimeoutFlag.Name)
 	}
 	cfg.RollupDisableTxPoolGossip = ctx.Bool(RollupDisableTxPoolGossipFlag.Name)
 	// Override any default configs for hard coded networks.

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -285,7 +285,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	}
 
 	if config.RollupHistoricalRPC != "" {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), config.RollupHistoricalRPCTimeout)
 		client, err := rpc.DialContext(ctx, config.RollupHistoricalRPC)
 		cancel()
 		if err != nil {

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -220,8 +220,9 @@ type Config struct {
 	// development purposes.
 	SyncTarget *types.Block
 
-	RollupSequencerHTTP string
-	RollupHistoricalRPC string
+	RollupSequencerHTTP        string
+	RollupHistoricalRPC        string
+	RollupHistoricalRPCTimeout time.Duration
 
 	RollupDisableTxPoolGossip bool
 }

--- a/ethclient/ethclient_test.go
+++ b/ethclient/ethclient_test.go
@@ -298,6 +298,7 @@ func newTestBackend(t *testing.T, enableHistoricalState bool) (*node.Node, []*ty
 	config.Ethash.PowMode = ethash.ModeFake
 	if enableHistoricalState {
 		config.RollupHistoricalRPC = histAddr
+		config.RollupHistoricalRPCTimeout = time.Second * 5
 	}
 	ethservice, err := eth.New(n, config)
 	if err != nil {

--- a/les/client.go
+++ b/les/client.go
@@ -210,7 +210,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*LightEthereum, error) {
 	}
 
 	if config.RollupHistoricalRPC != "" {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), config.RollupHistoricalRPCTimeout)
 		client, err := rpc.DialContext(ctx, config.RollupHistoricalRPC)
 		cancel()
 		if err != nil {


### PR DESCRIPTION
This flag lets one configure the initial timeout of RPC requests to the historical RPC service.

Fixes ENG-3294