### PR TITLE
Use 'message' instead of 'msg' for json logging

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -10,7 +10,7 @@ import (
 
 const timeKey = "t"
 const lvlKey = "lvl"
-const msgKey = "msg"
+const msgKey = "message"
 const ctxKey = "ctx"
 const errorKey = "LOG15_ERROR"
 const skipLevel = 2


### PR DESCRIPTION
**Description**

Use 'message' instead of 'msg' for json logging. This is what GCP expects.

**Tests**

Confirmed that GCP now parses logs.


**Metadata**
- Fixes ENG-3284
