### PR TITLE
Include 0 values for v,r,s and gasPrice on deposit transactions

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1429,28 +1429,6 @@ type RPCTransaction struct {
 func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber uint64, index uint64, baseFee *big.Int, config *params.ChainConfig) *RPCTransaction {
 	signer := types.MakeSigner(config, new(big.Int).SetUint64(blockNumber))
 	from, _ := types.Sender(signer, tx)
-	if tx.Type() == types.DepositTxType {
-		srcHash := tx.SourceHash()
-		isSystemTx := tx.IsSystemTx()
-		result := &RPCTransaction{
-			Type:       hexutil.Uint64(tx.Type()),
-			From:       from,
-			Gas:        hexutil.Uint64(tx.Gas()),
-			Hash:       tx.Hash(),
-			Input:      hexutil.Bytes(tx.Data()),
-			To:         tx.To(),
-			Value:      (*hexutil.Big)(tx.Value()),
-			Mint:       (*hexutil.Big)(tx.Mint()),
-			SourceHash: &srcHash,
-			IsSystemTx: &isSystemTx,
-		}
-		if blockHash != (common.Hash{}) {
-			result.BlockHash = &blockHash
-			result.BlockNumber = (*hexutil.Big)(new(big.Int).SetUint64(blockNumber))
-			result.TransactionIndex = (*hexutil.Uint64)(&index)
-		}
-		return result
-	}
 	v, r, s := tx.RawSignatureValues()
 	result := &RPCTransaction{
 		Type:     hexutil.Uint64(tx.Type()),
@@ -1471,7 +1449,14 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 		result.BlockNumber = (*hexutil.Big)(new(big.Int).SetUint64(blockNumber))
 		result.TransactionIndex = (*hexutil.Uint64)(&index)
 	}
+
 	switch tx.Type() {
+	case types.DepositTxType:
+		srcHash := tx.SourceHash()
+		isSystemTx := tx.IsSystemTx()
+		result.SourceHash = &srcHash
+		result.IsSystemTx = &isSystemTx
+		result.Mint = (*hexutil.Big)(tx.Mint())
 	case types.LegacyTxType:
 		// if a legacy transaction has an EIP-155 chain id, include it explicitly
 		if id := tx.ChainId(); id.Sign() != 0 {

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -3,7 +3,6 @@ package ethapi
 import (
 	"encoding/json"
 	"math/big"
-	"reflect"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -21,29 +20,15 @@ func TestNewRPCTransactionDepositTx(t *testing.T) {
 	})
 	got := newRPCTransaction(tx, common.Hash{}, uint64(12), uint64(1), big.NewInt(0), &params.ChainConfig{})
 	// Should provide zero values for unused fields that are required in other transactions
-	if !reflect.DeepEqual(got.GasPrice, (*hexutil.Big)(big.NewInt(0))) {
-		t.Errorf("newRPCTransaction().GasPrice = %v, want 0x0", got.GasPrice)
-	}
-	if !reflect.DeepEqual(got.V, (*hexutil.Big)(big.NewInt(0))) {
-		t.Errorf("newRPCTransaction().V = %v, want 0x0", got.V)
-	}
-	if !reflect.DeepEqual(got.R, (*hexutil.Big)(big.NewInt(0))) {
-		t.Errorf("newRPCTransaction().R = %v, want 0x0", got.R)
-	}
-	if !reflect.DeepEqual(got.S, (*hexutil.Big)(big.NewInt(0))) {
-		t.Errorf("newRPCTransaction().S = %v, want 0x0", got.S)
-	}
+	require.Equal(t, got.GasPrice, (*hexutil.Big)(big.NewInt(0)), "newRPCTransaction().GasPrice = %v, want 0x0", got.GasPrice)
+	require.Equal(t, got.V, (*hexutil.Big)(big.NewInt(0)), "newRPCTransaction().V = %v, want 0x0", got.V)
+	require.Equal(t, got.R, (*hexutil.Big)(big.NewInt(0)), "newRPCTransaction().R = %v, want 0x0", got.R)
+	require.Equal(t, got.S, (*hexutil.Big)(big.NewInt(0)), "newRPCTransaction().S = %v, want 0x0", got.S)
 
 	// Should include deposit tx specific fields
-	if *got.SourceHash != tx.SourceHash() {
-		t.Errorf("newRPCTransaction().SourceHash = %v, want %v", got.SourceHash, tx.SourceHash())
-	}
-	if *got.IsSystemTx != tx.IsSystemTx() {
-		t.Errorf("newRPCTransaction().IsSystemTx = %v, want %v", got.IsSystemTx, tx.IsSystemTx())
-	}
-	if !reflect.DeepEqual(got.Mint, (*hexutil.Big)(tx.Mint())) {
-		t.Errorf("newRPCTransaction().Mint = %v, want %v", got.Mint, tx.Mint())
-	}
+	require.Equal(t, *got.SourceHash, tx.SourceHash(), "newRPCTransaction().SourceHash = %v, want %v", got.SourceHash, tx.SourceHash())
+	require.Equal(t, *got.IsSystemTx, tx.IsSystemTx(), "newRPCTransaction().IsSystemTx = %v, want %v", got.IsSystemTx, tx.IsSystemTx())
+	require.Equal(t, got.Mint, (*hexutil.Big)(tx.Mint()), "newRPCTransaction().Mint = %v, want %v", got.Mint, tx.Mint())
 }
 
 func TestUnmarshalRpcDepositTx(t *testing.T) {


### PR DESCRIPTION
**Description**

When serializing deposit transactions for RPC responses, provide 0 values for v, r, s and gasPrice instead of null to improve compatibility with existing parsing code.

**Tests**

Added a unit test for these default fields and the deposit specific ones to cover the behaviour changed from geth.


**Metadata**
- Fixes https://linear.app/optimism/issue/CLI-3281/spike-work-out-differences-between-gettransactionbyhash-response-on


With these changes deposit transactions are now reported as:
```json
{
  "jsonrpc": "2.0",
  "id": 2,
  "result": {
    "blockHash": "0x6b2d65121124c6742664cfc6f11a48f551ecebaec2a42a1da48fae75dfe54851",
    "blockNumber": "0x4165bc",
    "from": "0x6197d1eef304eb5284a0f6720f79403b4e9bf3a5",
    "gas": "0x208620",
    "gasPrice": "0x0",
    "hash": "0xb0d03f274bc79b2dc4f138de29d616ab6dcd34d7bb83cf87ff81f9a6429b987a",
    "input": "0xd764ad0b0001000000000000000000000000000000000000000000000000000000000305000000000000000000000000bc1b58a9eea87b8677fff0b2cd4c47804bb01065000000000000000000000000c466c5e2d59edf7fca93311ff7aef5fb018463cf000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001cfde000000000000000000000000000000000000000000000000000000000000000c00000000000000000000000000000000000000000000000000000000000000044ed8378f500000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000063c735c000000000000000000000000000000000000000000000000000000000",
    "nonce": "0x0",
    "to": "0x4200000000000000000000000000000000000007",
    "transactionIndex": "0x1",
    "value": "0x0",
    "type": "0x7e",
    "v": "0x0",
    "r": "0x0",
    "s": "0x0",
    "sourceHash": "0x8cab2861a5a3d9031709bc95bdcbf87d52ce82d64b72eae3411ae896c72a8e20",
    "mint": "0x0",
    "isSystemTx": false
  }
}
```