### PR TITLE
Make deposit tx parsing more flexible

### DIFF
--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -281,9 +281,17 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 			}
 		}
 	case DepositTxType:
-		if dec.AccessList != nil || dec.V != nil || dec.R != nil || dec.S != nil || dec.MaxFeePerGas != nil ||
-			dec.MaxPriorityFeePerGas != nil || dec.GasPrice != nil || (dec.Nonce != nil && *dec.Nonce != 0) {
+		if dec.AccessList != nil || dec.MaxFeePerGas != nil ||
+			dec.MaxPriorityFeePerGas != nil || (dec.Nonce != nil && *dec.Nonce != 0) {
 			return errors.New("unexpected field(s) in deposit transaction")
+		}
+		if dec.GasPrice != nil && dec.GasPrice.ToInt() != big.NewInt(0) {
+			return errors.New("deposit transaction GasPrice must be 0")
+		}
+		if (dec.V != nil && dec.V.ToInt() != big.NewInt(0)) ||
+			(dec.R != nil && dec.R.ToInt() != big.NewInt(0)) ||
+			(dec.S != nil && dec.S.ToInt() != big.NewInt(0)) {
+			return errors.New("deposit transaction signature must be 0 or unset")
 		}
 		var itx DepositTx
 		inner = &itx

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -285,12 +285,12 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 			dec.MaxPriorityFeePerGas != nil || (dec.Nonce != nil && *dec.Nonce != 0) {
 			return errors.New("unexpected field(s) in deposit transaction")
 		}
-		if dec.GasPrice != nil && dec.GasPrice.ToInt() != big.NewInt(0) {
+		if dec.GasPrice != nil && dec.GasPrice.ToInt().Cmp(common.Big0) != 0 {
 			return errors.New("deposit transaction GasPrice must be 0")
 		}
-		if (dec.V != nil && dec.V.ToInt() != big.NewInt(0)) ||
-			(dec.R != nil && dec.R.ToInt() != big.NewInt(0)) ||
-			(dec.S != nil && dec.S.ToInt() != big.NewInt(0)) {
+		if (dec.V != nil && dec.V.ToInt().Cmp(common.Big0) != 0) ||
+			(dec.R != nil && dec.R.ToInt().Cmp(common.Big0) != 0) ||
+			(dec.S != nil && dec.S.ToInt().Cmp(common.Big0) != 0) {
 			return errors.New("deposit transaction signature must be 0 or unset")
 		}
 		var itx DepositTx

--- a/core/types/transaction_marshalling_test.go
+++ b/core/types/transaction_marshalling_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_Transaction_UnmarshalJson_Deposit(t *testing.T) {
+func TestTransactionUnmarshalJsonDeposit(t *testing.T) {
 	tx := NewTx(&DepositTx{
 		SourceHash:          common.HexToHash("0x1234"),
 		IsSystemTransaction: true,
@@ -24,7 +24,7 @@ func Test_Transaction_UnmarshalJson_Deposit(t *testing.T) {
 	require.Equal(t, tx.Hash(), got.Hash())
 }
 
-func TestTransaction_UnmarshalJSON(t *testing.T) {
+func TestTransactionUnmarshalJSON(t *testing.T) {
 	tests := []struct {
 		name          string
 		json          string

--- a/core/types/transaction_marshalling_test.go
+++ b/core/types/transaction_marshalling_test.go
@@ -2,10 +2,27 @@ package types
 
 import (
 	"encoding/json"
+	"math/big"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
+
+func Test_Transaction_UnmarshalJson_Deposit(t *testing.T) {
+	tx := NewTx(&DepositTx{
+		SourceHash:          common.HexToHash("0x1234"),
+		IsSystemTransaction: true,
+		Mint:                big.NewInt(34),
+	})
+	json, err := tx.MarshalJSON()
+	require.NoError(t, err, "Failed to marshal tx JSON")
+
+	got := &Transaction{}
+	err = got.UnmarshalJSON(json)
+	require.NoError(t, err, "Failed to unmarshal tx JSON")
+	require.Equal(t, tx.Hash(), got.Hash())
+}
 
 func TestTransaction_UnmarshalJSON(t *testing.T) {
 	tests := []struct {

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_UnmarshalRpcDepositTx(t *testing.T) {
+func TestUnmarshalRpcDepositTx(t *testing.T) {
 	tests := []struct {
 		name     string
 		modifier func(tx *RPCTransaction)

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -12,52 +12,85 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_newRPCTransaction_UnmarshalDepositTx_RoundTrip(t *testing.T) {
-	tx := types.NewTx(&types.DepositTx{
-		SourceHash:          common.HexToHash("0x1234"),
-		IsSystemTransaction: true,
-		Mint:                big.NewInt(34),
-	})
-	rpcTx := newRPCTransaction(tx, common.Hash{}, uint64(12), uint64(1), big.NewInt(0), &params.ChainConfig{})
-	json, err := json.Marshal(rpcTx)
-	require.NoError(t, err, "marshalling failed")
-	parsed := &types.Transaction{}
-	err = parsed.UnmarshalJSON(json)
-	require.NoError(t, err, "unmarshal failed")
-}
-
-func Test_newRPCTransaction_UnmarshalDepositTx_NilValues(t *testing.T) {
-	tx := types.NewTx(&types.DepositTx{
-		SourceHash:          common.HexToHash("0x1234"),
-		IsSystemTransaction: true,
-		Mint:                big.NewInt(34),
-	})
-	rpcTx := newRPCTransaction(tx, common.Hash{}, uint64(12), uint64(1), big.NewInt(0), &params.ChainConfig{})
-	rpcTx.V = nil
-	rpcTx.R = nil
-	rpcTx.S = nil
-	rpcTx.GasPrice = nil
-	json, err := json.Marshal(rpcTx)
-	require.NoError(t, err, "marshalling failed")
-	parsed := &types.Transaction{}
-	err = parsed.UnmarshalJSON(json)
-	require.NoError(t, err, "unmarshal failed")
-}
-
-func Test_newRPCTransaction_UnmarshalDepositTx_ZeroValues(t *testing.T) {
-	tx := types.NewTx(&types.DepositTx{
-		SourceHash:          common.HexToHash("0x1234"),
-		IsSystemTransaction: true,
-		Mint:                big.NewInt(34),
-	})
-	rpcTx := newRPCTransaction(tx, common.Hash{}, uint64(12), uint64(1), big.NewInt(0), &params.ChainConfig{})
-	rpcTx.V = (*hexutil.Big)(common.Big0)
-	rpcTx.R = (*hexutil.Big)(common.Big0)
-	rpcTx.S = (*hexutil.Big)(common.Big0)
-	rpcTx.GasPrice = (*hexutil.Big)(common.Big0)
-	json, err := json.Marshal(rpcTx)
-	require.NoError(t, err, "marshalling failed")
-	parsed := &types.Transaction{}
-	err = parsed.UnmarshalJSON(json)
-	require.NoError(t, err, "unmarshal failed")
+func Test_UnmarshalRpcDepositTx(t *testing.T) {
+	tests := []struct {
+		name     string
+		modifier func(tx *RPCTransaction)
+		valid    bool
+	}{
+		{
+			name:     "Unmodified",
+			modifier: func(tx *RPCTransaction) {},
+			valid:    true,
+		},
+		{
+			name: "Zero Values",
+			modifier: func(tx *RPCTransaction) {
+				tx.V = (*hexutil.Big)(common.Big0)
+				tx.R = (*hexutil.Big)(common.Big0)
+				tx.S = (*hexutil.Big)(common.Big0)
+				tx.GasPrice = (*hexutil.Big)(common.Big0)
+			},
+			valid: true,
+		},
+		{
+			name: "Nil Values",
+			modifier: func(tx *RPCTransaction) {
+				tx.V = nil
+				tx.R = nil
+				tx.S = nil
+				tx.GasPrice = nil
+			},
+			valid: true,
+		},
+		{
+			name: "Non-Zero GasPrice",
+			modifier: func(tx *RPCTransaction) {
+				tx.GasPrice = (*hexutil.Big)(big.NewInt(43))
+			},
+			valid: false,
+		},
+		{
+			name: "Non-Zero V",
+			modifier: func(tx *RPCTransaction) {
+				tx.V = (*hexutil.Big)(big.NewInt(43))
+			},
+			valid: false,
+		},
+		{
+			name: "Non-Zero R",
+			modifier: func(tx *RPCTransaction) {
+				tx.R = (*hexutil.Big)(big.NewInt(43))
+			},
+			valid: false,
+		},
+		{
+			name: "Non-Zero S",
+			modifier: func(tx *RPCTransaction) {
+				tx.S = (*hexutil.Big)(big.NewInt(43))
+			},
+			valid: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tx := types.NewTx(&types.DepositTx{
+				SourceHash:          common.HexToHash("0x1234"),
+				IsSystemTransaction: true,
+				Mint:                big.NewInt(34),
+			})
+			rpcTx := newRPCTransaction(tx, common.Hash{}, uint64(12), uint64(1), big.NewInt(0), &params.ChainConfig{})
+			test.modifier(rpcTx)
+			json, err := json.Marshal(rpcTx)
+			require.NoError(t, err, "marshalling failed: %w", err)
+			println(string(json))
+			parsed := &types.Transaction{}
+			err = parsed.UnmarshalJSON(json)
+			if test.valid {
+				require.NoError(t, err, "unmarshal failed: %w", err)
+			} else {
+				require.Error(t, err, "unmarshal should have failed but did not")
+			}
+		})
+	}
 }

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -1,0 +1,63 @@
+package ethapi
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_newRPCTransaction_UnmarshalDepositTx_RoundTrip(t *testing.T) {
+	tx := types.NewTx(&types.DepositTx{
+		SourceHash:          common.HexToHash("0x1234"),
+		IsSystemTransaction: true,
+		Mint:                big.NewInt(34),
+	})
+	rpcTx := newRPCTransaction(tx, common.Hash{}, uint64(12), uint64(1), big.NewInt(0), &params.ChainConfig{})
+	json, err := json.Marshal(rpcTx)
+	require.NoError(t, err, "marshalling failed")
+	parsed := &types.Transaction{}
+	err = parsed.UnmarshalJSON(json)
+	require.NoError(t, err, "unmarshal failed")
+}
+
+func Test_newRPCTransaction_UnmarshalDepositTx_NilValues(t *testing.T) {
+	tx := types.NewTx(&types.DepositTx{
+		SourceHash:          common.HexToHash("0x1234"),
+		IsSystemTransaction: true,
+		Mint:                big.NewInt(34),
+	})
+	rpcTx := newRPCTransaction(tx, common.Hash{}, uint64(12), uint64(1), big.NewInt(0), &params.ChainConfig{})
+	rpcTx.V = nil
+	rpcTx.R = nil
+	rpcTx.S = nil
+	rpcTx.GasPrice = nil
+	json, err := json.Marshal(rpcTx)
+	require.NoError(t, err, "marshalling failed")
+	parsed := &types.Transaction{}
+	err = parsed.UnmarshalJSON(json)
+	require.NoError(t, err, "unmarshal failed")
+}
+
+func Test_newRPCTransaction_UnmarshalDepositTx_ZeroValues(t *testing.T) {
+	tx := types.NewTx(&types.DepositTx{
+		SourceHash:          common.HexToHash("0x1234"),
+		IsSystemTransaction: true,
+		Mint:                big.NewInt(34),
+	})
+	rpcTx := newRPCTransaction(tx, common.Hash{}, uint64(12), uint64(1), big.NewInt(0), &params.ChainConfig{})
+	rpcTx.V = (*hexutil.Big)(common.Big0)
+	rpcTx.R = (*hexutil.Big)(common.Big0)
+	rpcTx.S = (*hexutil.Big)(common.Big0)
+	rpcTx.GasPrice = (*hexutil.Big)(common.Big0)
+	json, err := json.Marshal(rpcTx)
+	require.NoError(t, err, "marshalling failed")
+	parsed := &types.Transaction{}
+	err = parsed.UnmarshalJSON(json)
+	require.NoError(t, err, "unmarshal failed")
+}


### PR DESCRIPTION
**Description**
Allow either nil or 0 values for v, r, s and GasPrice. Add a test to ensure deposit tx json can be round-tripped.

This is required for #40 which starts to set these values to 0 instead of nil.

**Tests**

Added a test to confirm that deposit tx can be parsed from the JSON it serializes so at least the serialise and unserialise code is compatible.

**Metadata**
First step required for https://linear.app/optimism/issue/CLI-3281/spike-work-out-differences-between-gettransactionbyhash-response-on
