### PR TITLE
fix: update insufficient funds error message

### DIFF
--- a/core/error.go
+++ b/core/error.go
@@ -65,7 +65,7 @@ var (
 
 	// ErrInsufficientFunds is returned if the total cost of executing a transaction
 	// is higher than the balance of the user's account.
-	ErrInsufficientFunds = errors.New("insufficient funds for gas * price + value")
+	ErrInsufficientFunds = errors.New("insufficient funds for gas * price + value + L1 data fee")
 
 	// ErrGasUintOverflow is returned when calculating gas usage.
 	ErrGasUintOverflow = errors.New("gas uint64 overflow")


### PR DESCRIPTION
Updates ErrInsufficientFunds to include a reference to the L1 data fee. We include the L1 data fee in the calculation to check if you have sufficient funds, so it's important that this be communicated in the error message. This was part of a report from a user that they were confused because the error message did not make this explicit.