### PR TITLE
fix: Validate gas field specified when unmarshalling deposit tx JSON

### DIFF
--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -290,6 +290,9 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 		if dec.To != nil {
 			itx.To = dec.To
 		}
+		if dec.Gas == nil {
+			return errors.New("missing required field 'gas' for txdata")
+		}
 		itx.Gas = uint64(*dec.Gas)
 		if dec.Value == nil {
 			return errors.New("missing required field 'value' in transaction")

--- a/core/types/transaction_marshalling_test.go
+++ b/core/types/transaction_marshalling_test.go
@@ -1,0 +1,63 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransaction_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name          string
+		json          string
+		expectedError string
+	}{
+		{
+			name:          "No gas",
+			json:          `{"type":"0x7e","nonce":null,"gasPrice":null,"maxPriorityFeePerGas":null,"maxFeePerGas":null,"value":"0x1","input":"0x616263646566","v":null,"r":null,"s":null,"to":null,"sourceHash":"0x0000000000000000000000000000000000000000000000000000000000000000","from":"0x0000000000000000000000000000000000000001","isSystemTx":false,"hash":"0xa4341f3db4363b7ca269a8538bd027b2f8784f84454ca917668642d5f6dffdf9"}`,
+			expectedError: "missing required field 'gas'",
+		},
+		{
+			name:          "No value",
+			json:          `{"type":"0x7e","nonce":null,"gas": "0x1234", "gasPrice":null,"maxPriorityFeePerGas":null,"maxFeePerGas":null,"input":"0x616263646566","v":null,"r":null,"s":null,"to":null,"sourceHash":"0x0000000000000000000000000000000000000000000000000000000000000000","from":"0x0000000000000000000000000000000000000001","isSystemTx":false,"hash":"0xa4341f3db4363b7ca269a8538bd027b2f8784f84454ca917668642d5f6dffdf9"}`,
+			expectedError: "missing required field 'value'",
+		},
+		{
+			name:          "No input",
+			json:          `{"type":"0x7e","nonce":null,"gas": "0x1234", "gasPrice":null,"maxPriorityFeePerGas":null,"maxFeePerGas":null,"value":"0x1","v":null,"r":null,"s":null,"to":null,"sourceHash":"0x0000000000000000000000000000000000000000000000000000000000000000","from":"0x0000000000000000000000000000000000000001","isSystemTx":false,"hash":"0xa4341f3db4363b7ca269a8538bd027b2f8784f84454ca917668642d5f6dffdf9"}`,
+			expectedError: "missing required field 'input'",
+		},
+		{
+			name:          "No from",
+			json:          `{"type":"0x7e","nonce":null,"gas": "0x1234", "gasPrice":null,"maxPriorityFeePerGas":null,"maxFeePerGas":null,"value":"0x1","input":"0x616263646566","v":null,"r":null,"s":null,"to":null,"sourceHash":"0x0000000000000000000000000000000000000000000000000000000000000000","isSystemTx":false,"hash":"0xa4341f3db4363b7ca269a8538bd027b2f8784f84454ca917668642d5f6dffdf9"}`,
+			expectedError: "missing required field 'from'",
+		},
+		{
+			name:          "No sourceHash",
+			json:          `{"type":"0x7e","nonce":null,"gas": "0x1234", "gasPrice":null,"maxPriorityFeePerGas":null,"maxFeePerGas":null,"value":"0x1","input":"0x616263646566","v":null,"r":null,"s":null,"to":null,"from":"0x0000000000000000000000000000000000000001","isSystemTx":false,"hash":"0xa4341f3db4363b7ca269a8538bd027b2f8784f84454ca917668642d5f6dffdf9"}`,
+			expectedError: "missing required field 'sourceHash'",
+		},
+		{
+			name: "No mint",
+			json: `{"type":"0x7e","nonce":null,"gas": "0x1234", "gasPrice":null,"maxPriorityFeePerGas":null,"maxFeePerGas":null,"value":"0x1","input":"0x616263646566","v":null,"r":null,"s":null,"to":null,"sourceHash":"0x0000000000000000000000000000000000000000000000000000000000000000","from":"0x0000000000000000000000000000000000000001","isSystemTx":false,"hash":"0xa4341f3db4363b7ca269a8538bd027b2f8784f84454ca917668642d5f6dffdf9"}`,
+			// Allowed
+		},
+		{
+			name: "No IsSystemTx",
+			json: `{"type":"0x7e","nonce":null,"gas": "0x1234", "gasPrice":null,"maxPriorityFeePerGas":null,"maxFeePerGas":null,"value":"0x1","input":"0x616263646566","v":null,"r":null,"s":null,"to":null,"sourceHash":"0x0000000000000000000000000000000000000000000000000000000000000000","from":"0x0000000000000000000000000000000000000001","hash":"0xa4341f3db4363b7ca269a8538bd027b2f8784f84454ca917668642d5f6dffdf9"}`,
+			// Allowed
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var parsedTx = &Transaction{}
+			err := json.Unmarshal([]byte(test.json), &parsedTx)
+			if test.expectedError == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, test.expectedError)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Description**
Fixes `Transaction.UnmarshalJSON` to return an error if the `gas` field is not specified or is `null` in the JSON.


**Tests**

Added tests to confirm JSON is rejected if any of the required deposit tx fields are missing.

**Invariants**

Unmarshalling tx JSON never panics.

**Metadata**
- Fixes https://linear.app/optimism/issue/CLI-3335/sherlock-276-panic-when-decoding-a-malformed-deposit-transaction-json
