### PR TITLE
Spike of recording the actual used gas for deposit transactions

### DIFF
--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -211,7 +211,7 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig,
 				receipt.Status = types.ReceiptStatusSuccessful
 			}
 			receipt.TxHash = tx.Hash()
-			receipt.GasUsed = msgResult.UsedGas
+			receipt.GasUsed = msgResult.ActualUsedGas
 
 			// If the transaction created a contract, store the creation address in the receipt.
 			if msg.To() == nil {

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -122,7 +122,7 @@ func applyTransaction(msg types.Message, config *params.ChainConfig, author *com
 		receipt.Status = types.ReceiptStatusSuccessful
 	}
 	receipt.TxHash = tx.Hash()
-	receipt.GasUsed = result.UsedGas
+	receipt.GasUsed = result.ActualUsedGas
 
 	// If the transaction created a contract, store the creation address in the receipt.
 	if msg.To() == nil {

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -1080,7 +1080,7 @@ func (b *Block) Call(ctx context.Context, args struct {
 
 	return &CallResult{
 		data:    result.ReturnData,
-		gasUsed: Long(result.UsedGas),
+		gasUsed: Long(result.ActualUsedGas),
 		status:  status,
 	}, nil
 }
@@ -1150,7 +1150,7 @@ func (p *Pending) Call(ctx context.Context, args struct {
 
 	return &CallResult{
 		data:    result.ReturnData,
-		gasUsed: Long(result.UsedGas),
+		gasUsed: Long(result.ActualUsedGas),
 		status:  status,
 	}, nil
 }

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1641,7 +1641,7 @@ func AccessList(ctx context.Context, b Backend, blockNrOrHash rpc.BlockNumberOrH
 			return nil, 0, nil, fmt.Errorf("failed to apply transaction: %v err: %v", args.toTransaction().Hash(), err)
 		}
 		if tracer.Equal(prevTracer) {
-			return accessList, res.UsedGas, res.Err, nil
+			return accessList, res.ActualUsedGas, res.Err, nil
 		}
 		prevTracer = tracer
 	}


### PR DESCRIPTION
**Description**

Quick implementation of storing the actual gas used by deposit transactions when recording receipts to the database so it can be reported via JSON-RPC requests. The consensus value `CumulativeUsedGas` remains unchanged so this doesn't affect the resulting block hash or cause chain splits.

Things to note:
* Reporting correct values for existing nodes will require a resync as this information has to be captured when executing the transaction
* Comes at a cost of storing an extra uint64 per transaction
* Will not work with snap sync (when supported) because that only sends the consensus representation of receipt with `CumulativeGas` (which for deposit transactions is incremented by either 0 or the tx gas limit, not the actual used gas).
* These receipts will be stored in the database so we'll always have to support this additional format, even if we later hard fork to make it unnecessary (though for new receipts we can go back to omitting the GasUsed field again).

**Metadata**
- https://linear.app/optimism/issue/CLI-3280/fix-gasused-in-deposit-tx-receipts
