### PR TITLE
Regolith hard-fork

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -166,6 +166,10 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 	if ctx.IsSet(utils.OverrideOptimismBedrock.Name) {
 		cfg.Eth.OverrideOptimismBedrock = flags.GlobalBig(ctx, utils.OverrideOptimismBedrock.Name)
 	}
+	if ctx.IsSet(utils.OverrideOptimismRegolith.Name) {
+		v := ctx.Uint64(utils.OverrideOptimismRegolith.Name)
+		cfg.Eth.OverrideOptimismRegolith = &v
+	}
 	if ctx.IsSet(utils.OverrideOptimism.Name) {
 		override := ctx.Bool(utils.OverrideOptimism.Name)
 		cfg.Eth.OverrideOptimism = &override

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -67,6 +67,7 @@ var (
 		utils.OverrideShanghai,
 		utils.EnablePersonal,
 		utils.OverrideOptimismBedrock,
+		utils.OverrideOptimismRegolith,
 		utils.OverrideOptimism,
 		utils.EthashCacheDirFlag,
 		utils.EthashCachesInMemoryFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -279,6 +279,11 @@ var (
 		Usage:    "Manually specify OptimsimBedrock, overriding the bundled setting",
 		Category: flags.EthCategory,
 	}
+	OverrideOptimismRegolith = &flags.BigFlag{
+		Name:     "override.regolith",
+		Usage:    "Manually specify the OptimsimRegolith fork timestamp, overriding the bundled setting",
+		Category: flags.EthCategory,
+	}
 	OverrideOptimism = &cli.BoolFlag{
 		Name:     "override.optimism",
 		Usage:    "Manually specify optimism",

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -255,6 +255,10 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 	log.Info(strings.Repeat("-", 153))
 	log.Info("")
 
+	if chainConfig.IsOptimism() && chainConfig.RegolithTime == nil {
+		log.Warn("Optimism RegolithTime has not been set")
+	}
+
 	bc := &BlockChain{
 		chainConfig:   chainConfig,
 		cacheConfig:   cacheConfig,

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -269,8 +269,9 @@ func (e *GenesisMismatchError) Error() string {
 type ChainOverrides struct {
 	OverrideShanghai *uint64
 	// optimism
-	OverrideOptimismBedrock *big.Int
-	OverrideOptimism        *bool
+	OverrideOptimismBedrock  *big.Int
+	OverrideOptimismRegolith *uint64
+	OverrideOptimism         *bool
 }
 
 // SetupGenesisBlock writes or updates the genesis block in db.
@@ -301,6 +302,9 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *trie.Database, gen
 			}
 			if overrides != nil && overrides.OverrideOptimismBedrock != nil {
 				config.BedrockBlock = overrides.OverrideOptimismBedrock
+			}
+			if overrides != nil && overrides.OverrideOptimismRegolith != nil {
+				config.RegolithTime = overrides.OverrideOptimismRegolith
 			}
 			if overrides != nil && overrides.OverrideOptimism != nil {
 				if *overrides.OverrideOptimism {

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -131,7 +131,8 @@ func applyTransaction(msg types.Message, config *params.ChainConfig, gp *GasPool
 
 	nonce := tx.Nonce()
 	if msg.IsDepositTx() && config.IsOptimismRegolith(evm.Context.Time) {
-		nonce = statedb.GetNonce(msg.From())
+		// Subtract 1 as the nonce in state has already been incremented from what was used
+		nonce = statedb.GetNonce(msg.From()) - 1
 		receipt.DepositNonce = &nonce
 	}
 

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -129,9 +129,15 @@ func applyTransaction(msg types.Message, config *params.ChainConfig, gp *GasPool
 	receipt.TxHash = tx.Hash()
 	receipt.GasUsed = result.UsedGas
 
+	nonce := tx.Nonce()
+	if msg.IsDepositTx() && config.IsOptimismRegolith(evm.Context.Time) {
+		nonce = statedb.GetNonce(msg.From())
+		receipt.DepositNonce = &nonce
+	}
+
 	// If the transaction created a contract, store the creation address in the receipt.
 	if msg.To() == nil {
-		receipt.ContractAddress = crypto.CreateAddress(evm.TxContext.Origin, tx.Nonce())
+		receipt.ContractAddress = crypto.CreateAddress(evm.TxContext.Origin, nonce)
 	}
 
 	// Set the receipt logs and create the bloom filter.

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -433,7 +433,7 @@ func (st *StateTransition) innerTransitionDb() (*ExecutionResult, error) {
 		}
 
 		// Return remaining gas to the block gas counter so it is available for the next transaction.
-		// However no refund is given to the user
+		// No refund is given to the user
 		st.gp.AddGas(st.gas)
 		return &ExecutionResult{
 			UsedGas:    st.gasUsed(),

--- a/core/types/gen_receipt_json.go
+++ b/core/types/gen_receipt_json.go
@@ -72,6 +72,7 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 		L1GasUsed         *hexutil.Big    `json:"l1GasUsed,omitempty"`
 		L1Fee             *hexutil.Big    `json:"l1Fee,omitempty"`
 		FeeScalar         *big.Float      `json:"l1FeeScalar,omitempty"`
+		DepositNonce      *hexutil.Uint64 `json:"DepositNonce,omitempty"`
 	}
 	var dec Receipt
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -129,6 +130,9 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 	}
 	if dec.FeeScalar != nil {
 		r.FeeScalar = dec.FeeScalar
+	}
+	if dec.DepositNonce != nil {
+		r.DepositNonce = (*uint64)(dec.DepositNonce)
 	}
 	return nil
 }

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -63,6 +63,7 @@ type Receipt struct {
 	TxHash          common.Hash    `json:"transactionHash" gencodec:"required"`
 	ContractAddress common.Address `json:"contractAddress"`
 	GasUsed         uint64         `json:"gasUsed" gencodec:"required"`
+	DepositNonce    *uint64        `json:"depositNonce,omitempty"`
 
 	// Inclusion information: These fields provide information about the inclusion of the
 	// transaction corresponding to this receipt.
@@ -101,11 +102,20 @@ type receiptRLP struct {
 	Logs              []*Log
 }
 
+type depositReceiptRlp struct {
+	PostStateOrStatus []byte
+	CumulativeGasUsed uint64
+	Bloom             Bloom
+	Logs              []*Log
+	DepositNonce      *uint64 `rlp:"optional"`
+}
+
 // storedReceiptRLP is the storage encoding of a receipt.
 type storedReceiptRLP struct {
 	PostStateOrStatus []byte
 	CumulativeGasUsed uint64
 	Logs              []*Log
+	DepositNonce      *uint64 `rlp:"optional"`
 }
 
 // LegacyOptimismStoredReceiptRLP is the pre bedrock storage encoding of a
@@ -209,7 +219,13 @@ func (r *Receipt) EncodeRLP(w io.Writer) error {
 // encodeTyped writes the canonical encoding of a typed receipt to w.
 func (r *Receipt) encodeTyped(data *receiptRLP, w *bytes.Buffer) error {
 	w.WriteByte(r.Type)
-	return rlp.Encode(w, data)
+	switch r.Type {
+	case DepositTxType:
+		withNonce := depositReceiptRlp{data.PostStateOrStatus, data.CumulativeGasUsed, data.Bloom, data.Logs, r.DepositNonce}
+		return rlp.Encode(w, withNonce)
+	default:
+		return rlp.Encode(w, data)
+	}
 }
 
 // MarshalBinary returns the consensus encoding of the receipt.
@@ -271,14 +287,23 @@ func (r *Receipt) decodeTyped(b []byte) error {
 		return errShortTypedReceipt
 	}
 	switch b[0] {
-	case DynamicFeeTxType, AccessListTxType, DepositTxType:
-		var data receiptRLP
+	case DynamicFeeTxType, AccessListTxType:
+		data := receiptRLP{}
 		err := rlp.DecodeBytes(b[1:], &data)
 		if err != nil {
 			return err
 		}
 		r.Type = b[0]
 		return r.setFromRLP(data)
+	case DepositTxType:
+		data := depositReceiptRlp{}
+		err := rlp.DecodeBytes(b[1:], &data)
+		if err != nil {
+			return err
+		}
+		r.Type = b[0]
+		r.DepositNonce = data.DepositNonce
+		return r.setFromRLP(receiptRLP{data.PostStateOrStatus, data.CumulativeGasUsed, data.Bloom, data.Logs})
 	default:
 		return ErrTxTypeNotSupported
 	}
@@ -342,6 +367,9 @@ func (r *ReceiptForStorage) EncodeRLP(_w io.Writer) error {
 		}
 	}
 	w.ListEnd(logList)
+	if r.DepositNonce != nil {
+		w.WriteUint64(*r.DepositNonce)
+	}
 	w.ListEnd(outerList)
 	return w.Flush()
 }
@@ -402,7 +430,9 @@ func decodeStoredReceiptRLP(r *ReceiptForStorage, blob []byte) error {
 	r.CumulativeGasUsed = stored.CumulativeGasUsed
 	r.Logs = stored.Logs
 	r.Bloom = CreateBloom(Receipts{(*Receipt)(r)})
-
+	if stored.DepositNonce != nil {
+		r.DepositNonce = stored.DepositNonce
+	}
 	return nil
 }
 
@@ -458,7 +488,11 @@ func (rs Receipts) DeriveFields(config *params.ChainConfig, hash common.Hash, nu
 		if txs[i].To() == nil {
 			// Deriving the signer is expensive, only do if it's actually needed
 			from, _ := Sender(signer, txs[i])
-			rs[i].ContractAddress = crypto.CreateAddress(from, txs[i].Nonce())
+			nonce := txs[i].Nonce()
+			if rs[i].DepositNonce != nil {
+				nonce = *rs[i].DepositNonce
+			}
+			rs[i].ContractAddress = crypto.CreateAddress(from, nonce)
 		}
 		// The used gas can be calculated based on previous r
 		if i == 0 {

--- a/core/types/receipt_test.go
+++ b/core/types/receipt_test.go
@@ -18,6 +18,7 @@ package types
 
 import (
 	"bytes"
+	"fmt"
 	"math"
 	"math/big"
 	"reflect"
@@ -27,6 +28,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -80,6 +82,42 @@ var (
 		},
 		Type: DynamicFeeTxType,
 	}
+	depositReceiptNoNonce = &Receipt{
+		Status:            ReceiptStatusFailed,
+		CumulativeGasUsed: 1,
+		Logs: []*Log{
+			{
+				Address: common.BytesToAddress([]byte{0x11}),
+				Topics:  []common.Hash{common.HexToHash("dead"), common.HexToHash("beef")},
+				Data:    []byte{0x01, 0x00, 0xff},
+			},
+			{
+				Address: common.BytesToAddress([]byte{0x01, 0x11}),
+				Topics:  []common.Hash{common.HexToHash("dead"), common.HexToHash("beef")},
+				Data:    []byte{0x01, 0x00, 0xff},
+			},
+		},
+		Type: DepositTxType,
+	}
+	nonce                   = uint64(1234)
+	depositReceiptWithNonce = &Receipt{
+		Status:            ReceiptStatusFailed,
+		CumulativeGasUsed: 1,
+		DepositNonce:      &nonce,
+		Logs: []*Log{
+			{
+				Address: common.BytesToAddress([]byte{0x11}),
+				Topics:  []common.Hash{common.HexToHash("dead"), common.HexToHash("beef")},
+				Data:    []byte{0x01, 0x00, 0xff},
+			},
+			{
+				Address: common.BytesToAddress([]byte{0x01, 0x11}),
+				Topics:  []common.Hash{common.HexToHash("dead"), common.HexToHash("beef")},
+				Data:    []byte{0x01, 0x00, 0xff},
+			},
+		},
+		Type: DepositTxType,
+	}
 )
 
 func TestDecodeEmptyTypedReceipt(t *testing.T) {
@@ -117,7 +155,12 @@ func TestDeriveFields(t *testing.T) {
 			Gas:      3,
 			GasPrice: big.NewInt(3),
 		}),
+		NewTx(&DepositTx{
+			Value: big.NewInt(3),
+			Gas:   4,
+		}),
 	}
+	depNonce := uint64(7)
 	// Create the corresponding receipts
 	receipts := Receipts{
 		&Receipt{
@@ -154,6 +197,26 @@ func TestDeriveFields(t *testing.T) {
 			ContractAddress: common.BytesToAddress([]byte{0x03, 0x33, 0x33}),
 			GasUsed:         3,
 		},
+		&Receipt{
+			Type:              DepositTxType,
+			PostState:         common.Hash{3}.Bytes(),
+			CumulativeGasUsed: 10,
+			Logs: []*Log{
+				{Address: common.BytesToAddress([]byte{0x33})},
+				{Address: common.BytesToAddress([]byte{0x03, 0x33})},
+			},
+			TxHash:          txs[3].Hash(),
+			ContractAddress: common.BytesToAddress([]byte{0x03, 0x33, 0x33}),
+			GasUsed:         4,
+			DepositNonce:    &depNonce,
+		},
+	}
+
+	nonces := []uint64{
+		txs[0].Nonce(),
+		txs[1].Nonce(),
+		txs[2].Nonce(),
+		*receipts[3].DepositNonce, // Deposit tx should use deposit nonce
 	}
 	// Clear all the computed fields and re-derive them
 	number := big.NewInt(1)
@@ -190,7 +253,7 @@ func TestDeriveFields(t *testing.T) {
 			t.Errorf("receipts[%d].ContractAddress = %s, want %s", i, receipts[i].ContractAddress.String(), (common.Address{}).String())
 		}
 		from, _ := Sender(signer, txs[i])
-		contractAddress := crypto.CreateAddress(from, txs[i].Nonce())
+		contractAddress := crypto.CreateAddress(from, nonces[i])
 		if txs[i].To() == nil && receipts[i].ContractAddress != contractAddress {
 			t.Errorf("receipts[%d].ContractAddress = %s, want %s", i, receipts[i].ContractAddress.String(), contractAddress.String())
 		}
@@ -379,4 +442,65 @@ func clearComputedFieldsOnLog(t *testing.T, log *Log) {
 	log.TxHash = common.Hash{}
 	log.TxIndex = math.MaxUint32
 	log.Index = math.MaxUint32
+}
+
+func TestRoundTripReceipt(t *testing.T) {
+	tests := []struct {
+		name string
+		rcpt *Receipt
+	}{
+		{name: "Legacy", rcpt: legacyReceipt},
+		{name: "AccessList", rcpt: accessListReceipt},
+		{name: "EIP1559", rcpt: eip1559Receipt},
+		{name: "DepositNoNonce", rcpt: depositReceiptNoNonce},
+		{name: "DepositWithNonce", rcpt: depositReceiptWithNonce},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			data, err := test.rcpt.MarshalBinary()
+			require.NoError(t, err)
+
+			d := &Receipt{}
+			err = d.UnmarshalBinary(data)
+			require.NoError(t, err)
+			require.Equal(t, test.rcpt, d)
+		})
+
+		t.Run(fmt.Sprintf("%sRejectExtraData", test.name), func(t *testing.T) {
+			data, err := test.rcpt.MarshalBinary()
+			require.NoError(t, err)
+			data = append(data, 1, 2, 3, 4)
+			d := &Receipt{}
+			err = d.UnmarshalBinary(data)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestRoundTripReceiptForStorage(t *testing.T) {
+	tests := []struct {
+		name string
+		rcpt *Receipt
+	}{
+		{name: "Legacy", rcpt: legacyReceipt},
+		{name: "AccessList", rcpt: accessListReceipt},
+		{name: "EIP1559", rcpt: eip1559Receipt},
+		{name: "DepositNoNonce", rcpt: depositReceiptNoNonce},
+		{name: "DepositWithNonce", rcpt: depositReceiptWithNonce},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			data, err := rlp.EncodeToBytes((*ReceiptForStorage)(test.rcpt))
+			require.NoError(t, err)
+
+			d := &ReceiptForStorage{}
+			err = rlp.DecodeBytes(data, d)
+			require.NoError(t, err)
+			// Only check the stored fields - the others are derived later
+			require.Equal(t, test.rcpt.Status, d.Status)
+			require.Equal(t, test.rcpt.CumulativeGasUsed, d.CumulativeGasUsed)
+			require.Equal(t, test.rcpt.Logs, d.Logs)
+			require.Equal(t, test.rcpt.DepositNonce, d.DepositNonce)
+		})
+	}
 }

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -205,6 +205,9 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	if config.OverrideOptimismBedrock != nil {
 		overrides.OverrideOptimismBedrock = config.OverrideOptimismBedrock
 	}
+	if config.OverrideOptimismRegolith != nil {
+		overrides.OverrideOptimismRegolith = config.OverrideOptimismRegolith
+	}
 	if config.OverrideOptimism != nil {
 		overrides.OverrideOptimism = config.OverrideOptimism
 	}

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -209,8 +209,9 @@ type Config struct {
 	// OverrideShanghai (TODO: remove after the fork)
 	OverrideShanghai *uint64 `toml:",omitempty"`
 
-	OverrideOptimismBedrock *big.Int
-	OverrideOptimism        *bool
+	OverrideOptimismBedrock  *big.Int
+	OverrideOptimismRegolith *uint64 `toml:",omitempty"`
+	OverrideOptimism         *bool
 
 	RollupSequencerHTTP        string
 	RollupHistoricalRPC        string

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1841,6 +1841,9 @@ func (s *TransactionAPI) GetTransactionReceipt(ctx context.Context, hash common.
 		fields["l1Fee"] = (*hexutil.Big)(receipt.L1Fee)
 		fields["l1FeeScalar"] = receipt.FeeScalar.String()
 	}
+	if s.b.ChainConfig().Optimism != nil && tx.IsDepositTx() && receipt.DepositNonce != nil {
+		fields["depositNonce"] = hexutil.Uint64(*receipt.DepositNonce)
+	}
 	// Assign the effective gas price paid
 	if !s.b.ChainConfig().IsLondon(bigblock) {
 		fields["effectiveGasPrice"] = hexutil.Uint64(tx.GasPrice().Uint64())

--- a/params/config.go
+++ b/params/config.go
@@ -447,6 +447,7 @@ type ChainConfig struct {
 	PragueTime   *uint64 `json:"pragueTime,omitempty"`   // Prague switch time (nil = no fork, 0 = already on prague)
 
 	BedrockBlock *big.Int `json:"bedrockBlock,omitempty"` // Bedrock switch block (nil = no fork, 0 = already on optimism bedrock)
+	RegolithTime *uint64  `json:"regolithTime,omitempty"` // Regolith switch time (nil = no fork, 0 = already on optimism regolith)
 
 	// TerminalTotalDifficulty is the amount of total difficulty reached by
 	// the network that triggers the consensus upgrade.
@@ -583,6 +584,9 @@ func (c *ChainConfig) Description() string {
 	if c.PragueTime != nil {
 		banner += fmt.Sprintf(" - Prague:                      @%-10v\n", *c.PragueTime)
 	}
+	if c.RegolithTime != nil {
+		banner += fmt.Sprintf(" - Regolith:                    @%-10v\n", *c.RegolithTime)
+	}
 	return banner
 }
 
@@ -686,6 +690,10 @@ func (c *ChainConfig) IsBedrock(num *big.Int) bool {
 	return isBlockForked(c.BedrockBlock, num)
 }
 
+func (c *ChainConfig) IsRegolith(time uint64) bool {
+	return isTimestampForked(c.RegolithTime, time)
+}
+
 // IsOptimism returns whether the node is an optimism node or not.
 func (c *ChainConfig) IsOptimism() bool {
 	return c.Optimism != nil
@@ -694,6 +702,10 @@ func (c *ChainConfig) IsOptimism() bool {
 // IsOptimismBedrock returns true iff this is an optimism node & bedrock is active
 func (c *ChainConfig) IsOptimismBedrock(num *big.Int) bool {
 	return c.IsOptimism() && c.IsBedrock(num)
+}
+
+func (c *ChainConfig) IsOptimismRegolith(time uint64) bool {
+	return c.IsOptimism() && c.IsRegolith(time)
 }
 
 // IsOptimismPreBedrock returns true iff this is an optimism node & bedrock is not yet active
@@ -1009,7 +1021,7 @@ type Rules struct {
 	IsByzantium, IsConstantinople, IsPetersburg, IsIstanbul bool
 	IsBerlin, IsLondon                                      bool
 	IsMerge, IsShanghai, isCancun, isPrague                 bool
-	IsOptimismBedrock                                       bool
+	IsOptimismBedrock, IsOptimismRegolith                   bool
 }
 
 // Rules ensures c's ChainID is not nil.
@@ -1035,6 +1047,7 @@ func (c *ChainConfig) Rules(num *big.Int, isMerge bool, timestamp uint64) Rules 
 		isCancun:         c.IsCancun(timestamp),
 		isPrague:         c.IsPrague(timestamp),
 		// Optimism
-		IsOptimismBedrock: c.IsOptimismBedrock(num),
+		IsOptimismBedrock:  c.IsOptimismBedrock(num),
+		IsOptimismRegolith: c.IsOptimismRegolith(timestamp),
 	}
 }

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -136,3 +136,22 @@ func TestConfigRules(t *testing.T) {
 		t.Errorf("expected %v to be shanghai", stamp)
 	}
 }
+
+func TestConfigRulesReglith(t *testing.T) {
+	c := &ChainConfig{
+		RegolithTime: newUint64(500),
+		Optimism:     &OptimismConfig{},
+	}
+	var stamp uint64
+	if r := c.Rules(big.NewInt(0), true, stamp); r.IsOptimismRegolith {
+		t.Errorf("expected %v to not be regolith", stamp)
+	}
+	stamp = 500
+	if r := c.Rules(big.NewInt(0), true, stamp); !r.IsOptimismRegolith {
+		t.Errorf("expected %v to be regolith", stamp)
+	}
+	stamp = math.MaxInt64
+	if r := c.Rules(big.NewInt(0), true, stamp); !r.IsOptimismRegolith {
+		t.Errorf("expected %v to be regolith", stamp)
+	}
+}


### PR DESCRIPTION
**Description**

Implements the Regolith hard fork update.  The update is not scheduled by default for any network currently.

 - Deposit transactions now report the actual gasUsed instead of reporting the tx gas limit (or 0 for system transactions)
 - ContractAddress is now reported correctly in receipts for deposit transactions that create contracts. The consensus receipt format now includes the actual nonce used for deposit transactions to enable this.

**Tests**

Serialisation of receipts for both consensus and storage is now tested.
Test for calculating the ContractAddress from deposit tx storage receipts

State transition/processing changes for regolith are not yet tested. Ideally need to add block reference tests to cover this.

**Metadata**
- Part of https://linear.app/optimism/issue/CLI-3384/implement-op-geth-changes
