### PR TITLE
Remove unused variable to fix linter

### DIFF
--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -69,8 +69,6 @@ const (
 	maximumPendingTraceStates = 128
 )
 
-var errTxNotFound = errors.New("transaction not found")
-
 // StateReleaseFunc is used to deallocate resources held by constructing a
 // historical state for tracing purposes.
 type StateReleaseFunc func()


### PR DESCRIPTION
**Description**

Fix linter by removing the unused `errTxNotFound` variable.