### PR TITLE
feat: Add support for Regolith in chain configuration

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -166,6 +166,10 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 	if ctx.IsSet(utils.OverrideOptimismBedrock.Name) {
 		cfg.Eth.OverrideOptimismBedrock = flags.GlobalBig(ctx, utils.OverrideOptimismBedrock.Name)
 	}
+	if ctx.IsSet(utils.OverrideOptimismRegolith.Name) {
+		v := ctx.Uint64(utils.OverrideOptimismRegolith.Name)
+		cfg.Eth.OverrideOptimismRegolith = &v
+	}
 	if ctx.IsSet(utils.OverrideOptimism.Name) {
 		override := ctx.Bool(utils.OverrideOptimism.Name)
 		cfg.Eth.OverrideOptimism = &override

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -67,6 +67,7 @@ var (
 		utils.OverrideShanghai,
 		utils.EnablePersonal,
 		utils.OverrideOptimismBedrock,
+		utils.OverrideOptimismRegolith,
 		utils.OverrideOptimism,
 		utils.EthashCacheDirFlag,
 		utils.EthashCachesInMemoryFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -279,6 +279,11 @@ var (
 		Usage:    "Manually specify OptimsimBedrock, overriding the bundled setting",
 		Category: flags.EthCategory,
 	}
+	OverrideOptimismRegolith = &flags.BigFlag{
+		Name:     "override.regolith",
+		Usage:    "Manually specify the OptimsimRegolith fork timestamp, overriding the bundled setting",
+		Category: flags.EthCategory,
+	}
 	OverrideOptimism = &cli.BoolFlag{
 		Name:     "override.optimism",
 		Usage:    "Manually specify optimism",

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -269,8 +269,9 @@ func (e *GenesisMismatchError) Error() string {
 type ChainOverrides struct {
 	OverrideShanghai *uint64
 	// optimism
-	OverrideOptimismBedrock *big.Int
-	OverrideOptimism        *bool
+	OverrideOptimismBedrock  *big.Int
+	OverrideOptimismRegolith *uint64
+	OverrideOptimism         *bool
 }
 
 // SetupGenesisBlock writes or updates the genesis block in db.
@@ -301,6 +302,9 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *trie.Database, gen
 			}
 			if overrides != nil && overrides.OverrideOptimismBedrock != nil {
 				config.BedrockBlock = overrides.OverrideOptimismBedrock
+			}
+			if overrides != nil && overrides.OverrideOptimismRegolith != nil {
+				config.RegolithTime = overrides.OverrideOptimismRegolith
 			}
 			if overrides != nil && overrides.OverrideOptimism != nil {
 				if *overrides.OverrideOptimism {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -205,6 +205,9 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	if config.OverrideOptimismBedrock != nil {
 		overrides.OverrideOptimismBedrock = config.OverrideOptimismBedrock
 	}
+	if config.OverrideOptimismRegolith != nil {
+		overrides.OverrideOptimismRegolith = config.OverrideOptimismRegolith
+	}
 	if config.OverrideOptimism != nil {
 		overrides.OverrideOptimism = config.OverrideOptimism
 	}

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -209,8 +209,9 @@ type Config struct {
 	// OverrideShanghai (TODO: remove after the fork)
 	OverrideShanghai *uint64 `toml:",omitempty"`
 
-	OverrideOptimismBedrock *big.Int
-	OverrideOptimism        *bool
+	OverrideOptimismBedrock  *big.Int
+	OverrideOptimismRegolith *uint64 `toml:",omitempty"`
+	OverrideOptimism         *bool
 
 	RollupSequencerHTTP        string
 	RollupHistoricalRPC        string

--- a/params/config.go
+++ b/params/config.go
@@ -447,6 +447,7 @@ type ChainConfig struct {
 	PragueTime   *uint64 `json:"pragueTime,omitempty"`   // Prague switch time (nil = no fork, 0 = already on prague)
 
 	BedrockBlock *big.Int `json:"bedrockBlock,omitempty"` // Bedrock switch block (nil = no fork, 0 = already on optimism bedrock)
+	RegolithTime *uint64  `json:"regolithTime,omitempty"` // Regolith switch time (nil = no fork, 0 = already on optimism regolith)
 
 	// TerminalTotalDifficulty is the amount of total difficulty reached by
 	// the network that triggers the consensus upgrade.
@@ -583,6 +584,9 @@ func (c *ChainConfig) Description() string {
 	if c.PragueTime != nil {
 		banner += fmt.Sprintf(" - Prague:                      @%-10v\n", *c.PragueTime)
 	}
+	if c.RegolithTime != nil {
+		banner += fmt.Sprintf(" - Regolith:                    @%-10v\n", *c.RegolithTime)
+	}
 	return banner
 }
 
@@ -686,6 +690,10 @@ func (c *ChainConfig) IsBedrock(num *big.Int) bool {
 	return isBlockForked(c.BedrockBlock, num)
 }
 
+func (c *ChainConfig) IsRegolith(time uint64) bool {
+	return isTimestampForked(c.RegolithTime, time)
+}
+
 // IsOptimism returns whether the node is an optimism node or not.
 func (c *ChainConfig) IsOptimism() bool {
 	return c.Optimism != nil
@@ -694,6 +702,10 @@ func (c *ChainConfig) IsOptimism() bool {
 // IsOptimismBedrock returns true iff this is an optimism node & bedrock is active
 func (c *ChainConfig) IsOptimismBedrock(num *big.Int) bool {
 	return c.IsOptimism() && c.IsBedrock(num)
+}
+
+func (c *ChainConfig) IsOptimismRegolith(time uint64) bool {
+	return c.IsOptimism() && c.IsRegolith(time)
 }
 
 // IsOptimismPreBedrock returns true iff this is an optimism node & bedrock is not yet active
@@ -1009,7 +1021,7 @@ type Rules struct {
 	IsByzantium, IsConstantinople, IsPetersburg, IsIstanbul bool
 	IsBerlin, IsLondon                                      bool
 	IsMerge, IsShanghai, isCancun, isPrague                 bool
-	IsOptimismBedrock                                       bool
+	IsOptimismBedrock, IsOptimismRegolith                   bool
 }
 
 // Rules ensures c's ChainID is not nil.
@@ -1035,6 +1047,7 @@ func (c *ChainConfig) Rules(num *big.Int, isMerge bool, timestamp uint64) Rules 
 		isCancun:         c.IsCancun(timestamp),
 		isPrague:         c.IsPrague(timestamp),
 		// Optimism
-		IsOptimismBedrock: c.IsOptimismBedrock(num),
+		IsOptimismBedrock:  c.IsOptimismBedrock(num),
+		IsOptimismRegolith: c.IsOptimismRegolith(timestamp),
 	}
 }

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -136,3 +136,22 @@ func TestConfigRules(t *testing.T) {
 		t.Errorf("expected %v to be shanghai", stamp)
 	}
 }
+
+func TestConfigRulesReglith(t *testing.T) {
+	c := &ChainConfig{
+		RegolithTime: newUint64(500),
+		Optimism:     &OptimismConfig{},
+	}
+	var stamp uint64
+	if r := c.Rules(big.NewInt(0), true, stamp); r.IsOptimismRegolith {
+		t.Errorf("expected %v to not be regolith", stamp)
+	}
+	stamp = 500
+	if r := c.Rules(big.NewInt(0), true, stamp); !r.IsOptimismRegolith {
+		t.Errorf("expected %v to be regolith", stamp)
+	}
+	stamp = math.MaxInt64
+	if r := c.Rules(big.NewInt(0), true, stamp); !r.IsOptimismRegolith {
+		t.Errorf("expected %v to be regolith", stamp)
+	}
+}


### PR DESCRIPTION
**Description**

Adds the regolith hard fork to `ChainConfig` and a CLI option to override the fork timestamp. There is currently no changes implemented with Regolith, just the config. This config will then act as the feature toggle that allows merging the actual regolith changes in small, incremental steps safely as they won't be enabled until the hard fork is actually scheduled.

**Tests**

Added tests for the rules logic around when regolith is enabled.

**Metadata**
- Fixes https://linear.app/optimism/issue/CLI-3395/update-chainconfig-to-include-regolith
