### PR TITLE
Regolith: Store nonce in deposit transaction receipts

### DIFF
--- a/core/types/gen_receipt_json.go
+++ b/core/types/gen_receipt_json.go
@@ -72,6 +72,7 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 		L1GasUsed         *hexutil.Big    `json:"l1GasUsed,omitempty"`
 		L1Fee             *hexutil.Big    `json:"l1Fee,omitempty"`
 		FeeScalar         *big.Float      `json:"l1FeeScalar,omitempty"`
+		DepositNonce      *hexutil.Uint64 `json:"depositNonce,omitempty"`
 	}
 	var dec Receipt
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -129,6 +130,9 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 	}
 	if dec.FeeScalar != nil {
 		r.FeeScalar = dec.FeeScalar
+	}
+	if dec.DepositNonce != nil {
+		r.DepositNonce = (*uint64)(dec.DepositNonce)
 	}
 	return nil
 }

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -63,6 +63,9 @@ type Receipt struct {
 	TxHash          common.Hash    `json:"transactionHash" gencodec:"required"`
 	ContractAddress common.Address `json:"contractAddress"`
 	GasUsed         uint64         `json:"gasUsed" gencodec:"required"`
+	// DepositNonce was introduced in Regolith to store the actual nonce used by deposit transactions
+	// The state transition process ensures this is only set for Regolith deposit transactions.
+	DepositNonce *uint64 `json:"depositNonce,omitempty"`
 
 	// Inclusion information: These fields provide information about the inclusion of the
 	// transaction corresponding to this receipt.
@@ -101,11 +104,24 @@ type receiptRLP struct {
 	Logs              []*Log
 }
 
+type depositReceiptRlp struct {
+	PostStateOrStatus []byte
+	CumulativeGasUsed uint64
+	Bloom             Bloom
+	Logs              []*Log
+	// DepositNonce was introduced in Regolith to store the actual nonce used by deposit transactions.
+	// Must be nil for any transactions prior to Regolith or that aren't deposit transactions.
+	DepositNonce *uint64 `rlp:"optional"`
+}
+
 // storedReceiptRLP is the storage encoding of a receipt.
 type storedReceiptRLP struct {
 	PostStateOrStatus []byte
 	CumulativeGasUsed uint64
 	Logs              []*Log
+	// DepositNonce was introduced in Regolith to store the actual nonce used by deposit transactions.
+	// Must be nil for any transactions prior to Regolith or that aren't deposit transactions.
+	DepositNonce *uint64 `rlp:"optional"`
 }
 
 // LegacyOptimismStoredReceiptRLP is the pre bedrock storage encoding of a
@@ -209,7 +225,13 @@ func (r *Receipt) EncodeRLP(w io.Writer) error {
 // encodeTyped writes the canonical encoding of a typed receipt to w.
 func (r *Receipt) encodeTyped(data *receiptRLP, w *bytes.Buffer) error {
 	w.WriteByte(r.Type)
-	return rlp.Encode(w, data)
+	switch r.Type {
+	case DepositTxType:
+		withNonce := depositReceiptRlp{data.PostStateOrStatus, data.CumulativeGasUsed, data.Bloom, data.Logs, r.DepositNonce}
+		return rlp.Encode(w, withNonce)
+	default:
+		return rlp.Encode(w, data)
+	}
 }
 
 // MarshalBinary returns the consensus encoding of the receipt.
@@ -271,7 +293,7 @@ func (r *Receipt) decodeTyped(b []byte) error {
 		return errShortTypedReceipt
 	}
 	switch b[0] {
-	case DynamicFeeTxType, AccessListTxType, DepositTxType:
+	case DynamicFeeTxType, AccessListTxType:
 		var data receiptRLP
 		err := rlp.DecodeBytes(b[1:], &data)
 		if err != nil {
@@ -279,6 +301,15 @@ func (r *Receipt) decodeTyped(b []byte) error {
 		}
 		r.Type = b[0]
 		return r.setFromRLP(data)
+	case DepositTxType:
+		var data depositReceiptRlp
+		err := rlp.DecodeBytes(b[1:], &data)
+		if err != nil {
+			return err
+		}
+		r.Type = b[0]
+		r.DepositNonce = data.DepositNonce
+		return r.setFromRLP(receiptRLP{data.PostStateOrStatus, data.CumulativeGasUsed, data.Bloom, data.Logs})
 	default:
 		return ErrTxTypeNotSupported
 	}
@@ -342,6 +373,9 @@ func (r *ReceiptForStorage) EncodeRLP(_w io.Writer) error {
 		}
 	}
 	w.ListEnd(logList)
+	if r.DepositNonce != nil {
+		w.WriteUint64(*r.DepositNonce)
+	}
 	w.ListEnd(outerList)
 	return w.Flush()
 }
@@ -402,7 +436,9 @@ func decodeStoredReceiptRLP(r *ReceiptForStorage, blob []byte) error {
 	r.CumulativeGasUsed = stored.CumulativeGasUsed
 	r.Logs = stored.Logs
 	r.Bloom = CreateBloom(Receipts{(*Receipt)(r)})
-
+	if stored.DepositNonce != nil {
+		r.DepositNonce = stored.DepositNonce
+	}
 	return nil
 }
 
@@ -458,7 +494,11 @@ func (rs Receipts) DeriveFields(config *params.ChainConfig, hash common.Hash, nu
 		if txs[i].To() == nil {
 			// Deriving the signer is expensive, only do if it's actually needed
 			from, _ := Sender(signer, txs[i])
-			rs[i].ContractAddress = crypto.CreateAddress(from, txs[i].Nonce())
+			nonce := txs[i].Nonce()
+			if rs[i].DepositNonce != nil {
+				nonce = *rs[i].DepositNonce
+			}
+			rs[i].ContractAddress = crypto.CreateAddress(from, nonce)
 		}
 		// The used gas can be calculated based on previous r
 		if i == 0 {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1826,6 +1826,9 @@ func (s *TransactionAPI) GetTransactionReceipt(ctx context.Context, hash common.
 		fields["l1Fee"] = (*hexutil.Big)(receipt.L1Fee)
 		fields["l1FeeScalar"] = receipt.FeeScalar.String()
 	}
+	if s.b.ChainConfig().Optimism != nil && tx.IsDepositTx() && receipt.DepositNonce != nil {
+		fields["depositNonce"] = hexutil.Uint64(*receipt.DepositNonce)
+	}
 	// Assign the effective gas price paid
 	if !s.b.ChainConfig().IsLondon(bigblock) {
 		fields["effectiveGasPrice"] = hexutil.Uint64(tx.GasPrice().Uint64())


### PR DESCRIPTION
**Description**

Store the actual nonce used for deposit transactions in the receipt. It is then used when returning the receipt via the JSON-RPC API as a `DepositNonce` field and when calculating the `ContractAddress` for contract creation transactions.

The existing deposit transaction type is used, but after regolith its receipt has an additional rlp field that reports the Nonce.  Implementation-wise this is marked as an optional field so deposits from both before and after the fork can be parsed. The state transition guarantees that the nonce is only present post-regolith.

**Tests**

* Check that deposit tx rlp from pre-bedrock (without nonce) is unchanged and can be parsed by the new code
* Check that receipts can be roundtrip for storage and consensus
* Check that deposit tx receipt derived fields are correctly calculating (including using the nonce when present to calculate the correct ContractAddress)

**Additional context**

Builds on #50 which should be merged first

**Metadata**
- Fixes https://linear.app/optimism/issue/CLI-3398/op-geth-regolith-deposit-nonce-changes
