### PR TITLE
Log a warning when optimism enabled but regolith not scheduled

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -255,6 +255,10 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 	log.Info(strings.Repeat("-", 153))
 	log.Info("")
 
+	if chainConfig.IsOptimism() && chainConfig.RegolithTime == nil {
+		log.Warn("Optimism RegolithTime has not been set")
+	}
+
 	bc := &BlockChain{
 		chainConfig:   chainConfig,
 		cacheConfig:   cacheConfig,


### PR DESCRIPTION
**Description**

Log a warning when starting op-geth on an Optimism chain without a regolith timestamp set. 

Should hold off merging this until we're getting close to setting a timestamp for Regolith so users aren't warned about something they can't fix too much.
