### PR TITLE
Reject system deposit transactions in Regolith

### DIFF
--- a/core/error.go
+++ b/core/error.go
@@ -100,4 +100,7 @@ var (
 
 	// ErrSenderNoEOA is returned if the sender of a transaction is a contract.
 	ErrSenderNoEOA = errors.New("sender not an eoa")
+
+	// ErrSystemTxNotSupported is returned for any deposit tx with IsSystemTx=true after the Regolith fork
+	ErrSystemTxNotSupported = errors.New("system tx not supported")
 )

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -259,6 +259,10 @@ func (st *StateTransition) preCheck() error {
 		st.gas += st.msg.Gas() // Add gas here in order to be able to execute calls.
 		// Don't touch the gas pool for system transactions
 		if st.msg.IsSystemTx() {
+			if st.evm.ChainConfig().IsOptimismRegolith(st.evm.Context.Time) {
+				return fmt.Errorf("%w: address %v", ErrSystemTxNotSupported,
+					st.msg.From().Hex())
+			}
 			return nil
 		}
 		return st.gp.SubGas(st.msg.Gas()) // gas used by deposits may not be used by other txs


### PR DESCRIPTION
**Description**

Once the Regolith hard fork activates, reject any deposit tx with `IsSystemTx: true`.

**Tests**

Not covered in op-geth repo but will be checked via e2e tests with https://github.com/ethereum-optimism/optimism/pull/4931

**Additional context**

Builds on https://github.com/ethereum-optimism/op-geth/pull/52

**Metadata**
- Fixes https://linear.app/optimism/issue/CLI-3414/opgeth-regolith-reject-system-transactions
