### PR TITLE
Include the actual nonce used when returning deposit tx from the JSON RPC API

### DIFF
--- a/core/types/deposit_tx.go
+++ b/core/types/deposit_tx.go
@@ -78,6 +78,8 @@ func (tx *DepositTx) nonce() uint64          { return 0 }
 func (tx *DepositTx) to() *common.Address    { return tx.To }
 func (tx *DepositTx) isSystemTx() bool       { return tx.IsSystemTransaction }
 
+func (tx *DepositTx) effectiveNonce() *uint64 { return nil }
+
 func (tx *DepositTx) rawSignatureValues() (v, r, s *big.Int) {
 	return common.Big0, common.Big0, common.Big0
 }

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -289,6 +289,20 @@ func (tx *Transaction) Value() *big.Int { return new(big.Int).Set(tx.inner.value
 // Nonce returns the sender account nonce of the transaction.
 func (tx *Transaction) Nonce() uint64 { return tx.inner.nonce() }
 
+// EffectiveNonce returns the nonce that was actually used as part of transaction execution
+// Returns nil if the effective nonce is not known
+func (tx *Transaction) EffectiveNonce() *uint64 {
+	type txWithEffectiveNonce interface {
+		effectiveNonce() *uint64
+	}
+
+	if itx, ok := tx.inner.(txWithEffectiveNonce); ok {
+		return itx.effectiveNonce()
+	}
+	nonce := tx.inner.nonce()
+	return &nonce
+}
+
 // To returns the recipient address of the transaction.
 // For contract-creation transactions, To returns nil.
 func (tx *Transaction) To() *common.Address {

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -19,10 +19,12 @@ package types
 import (
 	"encoding/json"
 	"errors"
+	"io"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/rlp"
 )
 
 // txJSON is the JSON representation of transactions.
@@ -282,7 +284,7 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 		}
 	case DepositTxType:
 		if dec.AccessList != nil || dec.MaxFeePerGas != nil ||
-			dec.MaxPriorityFeePerGas != nil || (dec.Nonce != nil && *dec.Nonce != 0) {
+			dec.MaxPriorityFeePerGas != nil {
 			return errors.New("unexpected field(s) in deposit transaction")
 		}
 		if dec.GasPrice != nil && dec.GasPrice.ToInt().Cmp(common.Big0) != 0 {
@@ -324,6 +326,10 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 		if dec.IsSystemTx != nil {
 			itx.IsSystemTransaction = *dec.IsSystemTx
 		}
+
+		if dec.Nonce != nil {
+			inner = &depositTxWithNonce{DepositTx: itx, EffectiveNonce: uint64(*dec.Nonce)}
+		}
 	default:
 		return ErrTxTypeNotSupported
 	}
@@ -334,3 +340,15 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 	// TODO: check hash here?
 	return nil
 }
+
+type depositTxWithNonce struct {
+	DepositTx
+	EffectiveNonce uint64
+}
+
+// EncodeRLP ensures that RLP encoding this transaction excludes the nonce. Otherwise, the tx Hash would change
+func (tx *depositTxWithNonce) EncodeRLP(w io.Writer) error {
+	return rlp.Encode(w, tx.DepositTx)
+}
+
+func (tx *depositTxWithNonce) effectiveNonce() *uint64 { return &tx.EffectiveNonce }

--- a/eth/api.go
+++ b/eth/api.go
@@ -320,7 +320,7 @@ func (api *DebugAPI) GetBadBlocks(ctx context.Context) ([]*BadBlockArgs, error) 
 		} else {
 			blockRlp = fmt.Sprintf("%#x", rlpBytes)
 		}
-		if blockJSON, err = ethapi.RPCMarshalBlock(block, true, true, api.eth.APIBackend.ChainConfig()); err != nil {
+		if blockJSON, err = ethapi.RPCMarshalBlock(ctx, block, true, true, api.eth.APIBackend); err != nil {
 			blockJSON = map[string]interface{}{"error": err.Error()}
 		}
 		results = append(results, &BadBlockArgs{

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -18,7 +18,11 @@ func TestNewRPCTransactionDepositTx(t *testing.T) {
 		IsSystemTransaction: true,
 		Mint:                big.NewInt(34),
 	})
-	got := newRPCTransaction(tx, common.Hash{}, uint64(12), uint64(1), big.NewInt(0), &params.ChainConfig{})
+	nonce := uint64(7)
+	receipt := &types.Receipt{
+		DepositNonce: &nonce,
+	}
+	got := newRPCTransaction(tx, common.Hash{}, uint64(12), uint64(1), big.NewInt(0), &params.ChainConfig{}, receipt)
 	// Should provide zero values for unused fields that are required in other transactions
 	require.Equal(t, got.GasPrice, (*hexutil.Big)(big.NewInt(0)), "newRPCTransaction().GasPrice = %v, want 0x0", got.GasPrice)
 	require.Equal(t, got.V, (*hexutil.Big)(big.NewInt(0)), "newRPCTransaction().V = %v, want 0x0", got.V)
@@ -29,6 +33,7 @@ func TestNewRPCTransactionDepositTx(t *testing.T) {
 	require.Equal(t, *got.SourceHash, tx.SourceHash(), "newRPCTransaction().SourceHash = %v, want %v", got.SourceHash, tx.SourceHash())
 	require.Equal(t, *got.IsSystemTx, tx.IsSystemTx(), "newRPCTransaction().IsSystemTx = %v, want %v", got.IsSystemTx, tx.IsSystemTx())
 	require.Equal(t, got.Mint, (*hexutil.Big)(tx.Mint()), "newRPCTransaction().Mint = %v, want %v", got.Mint, tx.Mint())
+	require.Equal(t, got.Nonce, (hexutil.Uint64)(nonce), "newRPCTransaction().Mint = %v, want %v", got.Nonce, nonce)
 }
 
 func TestUnmarshalRpcDepositTx(t *testing.T) {
@@ -98,7 +103,7 @@ func TestUnmarshalRpcDepositTx(t *testing.T) {
 				IsSystemTransaction: true,
 				Mint:                big.NewInt(34),
 			})
-			rpcTx := newRPCTransaction(tx, common.Hash{}, uint64(12), uint64(1), big.NewInt(0), &params.ChainConfig{})
+			rpcTx := newRPCTransaction(tx, common.Hash{}, uint64(12), uint64(1), big.NewInt(0), &params.ChainConfig{}, nil)
 			test.modifier(rpcTx)
 			json, err := json.Marshal(rpcTx)
 			require.NoError(t, err, "marshalling failed: %w", err)


### PR DESCRIPTION
**Description**

When returning deposit transaction information from the JSON-RPC API, the actual nonce used is loaded from the receipt and included in the response.

**Tests**

Will be tested via e2e tests in https://github.com/ethereum-optimism/optimism/pull/4931

**Additional context**

There's a complication here because while tx serialisation is done via a custom `RPCTransaction` type that has a `Nonce` field, deserialisation is done back into the same `TxData` type (`DepositTx` in this case).  Since `DepositTx` doesn't have a `Nonce` field, there's nowhere to store the nonce from the API so it becomes unavailable to anyone using the client api client which happens to include our e2e tests.  To get around this, I've introduced a `depositTxWithNonce` wrapper which adds the `Nonce` field if one is specified. The state transaction `preCheck` has been updated to ensure all deposit tx being executed have a 0 nonce.  This solution works, but I'm not entirely convinced it's a good design to use...

**Metadata**
- Fixes https://linear.app/optimism/issue/CLI-3413/op-geth-regolith-include-actual-nonce-for-deposit-transactions-in-api
