### PR TITLE
Fix Regolith test name typo

### DIFF
--- a/params/config_test.go
+++ b/params/config_test.go
@@ -137,7 +137,7 @@ func TestConfigRules(t *testing.T) {
 	}
 }
 
-func TestConfigRulesReglith(t *testing.T) {
+func TestConfigRulesRegolith(t *testing.T) {
 	c := &ChainConfig{
 		RegolithTime: newUint64(500),
 		Optimism:     &OptimismConfig{},


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Fix the typo in config test name

**Tests**

N/A

**Invariants**

N/A

**Additional context**

<img width="936" alt="Screenshot 2023-02-26 at 14 01 04" src="https://user-images.githubusercontent.com/25429261/221409173-70acf2f1-5f22-4f3a-b287-684b087dc462.png">

