### PR TITLE
core: Schedule Regolith on Optimism Goerli at 1679079600

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -297,6 +297,10 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *trie.Database, gen
 	}
 	applyOverrides := func(config *params.ChainConfig) {
 		if config != nil {
+			if config.IsOptimism() && config.ChainID != nil && config.ChainID.Cmp(params.OptimismGoerliChainId) == 0 {
+				// Apply Optimism Goerli regolith time
+				config.RegolithTime = &params.OptimismGoerliRegolithTime
+			}
 			if overrides != nil && overrides.OverrideShanghai != nil {
 				config.ShanghaiTime = overrides.OverrideShanghai
 			}

--- a/params/config.go
+++ b/params/config.go
@@ -34,6 +34,13 @@ var (
 	GoerliGenesisHash  = common.HexToHash("0xbf7e331f7f7c1dd2e05159666b3bf8bc7a8a3a9eb1d518969eab529dd9b88c1a")
 )
 
+// Optimism chain config
+var (
+	OptimismGoerliChainId = big.NewInt(420)
+	// March 17, 2023 @ 7:00:00 pm UTC
+	OptimismGoerliRegolithTime = uint64(1679079600)
+)
+
 // TrustedCheckpoints associates each known checkpoint with the genesis hash of
 // the chain it belongs to.
 var TrustedCheckpoints = map[common.Hash]*TrustedCheckpoint{


### PR DESCRIPTION
**Description**

Schedules Regolith on Optimism Goerli at 1679079600 which is March 17, 2023 @ 7:00:00 pm UTC / March 17, 2023 12:00 MST


**Metadata**
- Part of https://linear.app/optimism/issue/CLI-3396/add-regolith-fork-time-for-gorli-to-op-geth
