### PR TITLE
Multi-arch docker build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,9 +32,7 @@ jobs:
     steps:
       - when:
           condition:
-            or:
-              - equal: [ optimism, <<pipeline.git.branch>> ]
-              - equal: [ optimism-history, <<pipeline.git.branch>> ]
+            equal: [ optimism, <<pipeline.git.branch>> ]
           steps:
             - checkout
             - setup_remote_docker:
@@ -43,17 +41,14 @@ jobs:
                 name: Build and push
                 command: |
                   echo "$DOCKER_PASS" | docker login -u "$DOCKER_USERNAME" --password-stdin
-                  docker build -t "ethereumoptimism/op-geth:$CIRCLE_SHA1" -f Dockerfile .
-                  docker tag "ethereumoptimism/op-geth:$CIRCLE_SHA1" "ethereumoptimism/op-geth:$CIRCLE_BRANCH"
-                  docker push "ethereumoptimism/op-geth:$CIRCLE_SHA1"
-                  docker push "ethereumoptimism/op-geth:$CIRCLE_BRANCH"
-
-                  if [ $CIRCLE_BRANCH = "optimism" ]
-                  then
-                    docker tag "ethereumoptimism/op-geth:$CIRCLE_SHA1" "ethereumoptimism/op-geth:latest"
-                    docker push "ethereumoptimism/op-geth:latest"
-                  pwd
-                  fi
+                  docker context create buildx-build
+                  docker buildx create --use buildx-build
+                  docker buildx build --push \
+                    --tag "ethereumoptimism/op-geth:$CIRCLE_SHA1" \
+                    --tag "ethereumoptimism/op-geth:$CIRCLE_BRANCH" \
+                    --tag "ethereumoptimism/op-geth:latest \
+                    --platform=linux/arm64,linux/amd64 \
+                    -f Dockerfile .
       # Below step is required to prevent CircleCI from barfing on a
       # job with no steps
       - run: echo 0


### PR DESCRIPTION
**Description**

Build amd64 & arm64 docker images. The docker build step is now really slow because it is doing a full emulation. I attempted an approach like https://github.com/ethereum-optimism/optimism/pull/5018, but geth does not play well with being cross compiled inside docker. I believe it is an issue with cgo.

I tested this by bypassing the branch condition check.

**Metadata**
- Fixes CLI-3530
