### PR TITLE
ethapi: Omit isSystemTx: "false" from JSON-RPC responses

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1464,7 +1464,10 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 		srcHash := tx.SourceHash()
 		isSystemTx := tx.IsSystemTx()
 		result.SourceHash = &srcHash
-		result.IsSystemTx = &isSystemTx
+		if isSystemTx {
+			// Only include IsSystemTx when true
+			result.IsSystemTx = &isSystemTx
+		}
 		result.Mint = (*hexutil.Big)(tx.Mint())
 		if receipt != nil && receipt.DepositNonce != nil {
 			result.Nonce = hexutil.Uint64(*receipt.DepositNonce)

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -36,6 +36,15 @@ func TestNewRPCTransactionDepositTx(t *testing.T) {
 	require.Equal(t, got.Nonce, (hexutil.Uint64)(nonce), "newRPCTransaction().Mint = %v, want %v", got.Nonce, nonce)
 }
 
+func TestNewRPCTransactionOmitIsSystemTxFalse(t *testing.T) {
+	tx := types.NewTx(&types.DepositTx{
+		IsSystemTransaction: false,
+	})
+	got := newRPCTransaction(tx, common.Hash{}, uint64(12), uint64(1), big.NewInt(0), &params.ChainConfig{}, nil)
+
+	require.Nil(t, got.IsSystemTx, "should omit IsSystemTx when false")
+}
+
 func TestUnmarshalRpcDepositTx(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
**Description**

Omit the `isSystemTx` field from JSON-RPC unless the value is actually true.  `isSystemTx` was already optional, defaulting to false, when parsing so this is backwards compatible.  The `IsSystemTx` field is still always included RLP so this isn't a consensus affecting change.

**Tests**

Added test to confirm IsSystemTx is nil rather than false.

**Metadata**
- Fixes https://linear.app/optimism/issue/CLI-3545/omit-issystemtx-from-json-rpc-responses-when-false
