### PR TITLE
core/rawdb: Add DepositNonce and legacy fields to copy of storedReceiptRLP in accessors_chain

### DIFF
--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -679,6 +679,15 @@ type storedReceiptRLP struct {
 	PostStateOrStatus []byte
 	CumulativeGasUsed uint64
 	Logs              []*types.Log
+
+	// Remaining fields are declared to allow the receipt RLP to be parsed without errors.
+	// However, they must not be used as they may not be populated correctly due to multiple receipt formats
+	// being combined into a single list of optional fields which can be mistaken for each other.
+	// DepositNonce (*uint64) from Regolith deposit tx receipts will be parsed into L1GasUsed
+	L1GasUsed  *big.Int `rlp:"optional"` // OVM legacy
+	L1GasPrice *big.Int `rlp:"optional"` // OVM legacy
+	L1Fee      *big.Int `rlp:"optional"` // OVM legacy
+	FeeScalar  string   `rlp:"optional"` // OVM legacy
 }
 
 // ReceiptLogs is a barebone version of ReceiptForStorage which only keeps


### PR DESCRIPTION
**Description**

eth_getLogs RPC parses the receipts using its own copy of storedReceiptsRLP. For RLP decoding to work it needs to include optional fields for each of the additional values in deposit tx receipts and legacy OVM receipts. These fields are never actually used - only the `Log` field is accessed.

**Tests**

Added a `DepositNonce` value to one of the receipts in the existing test for `ReadLogs`.

Currently unable to write automated tests for parsing of legacy receipts as we don't have a way to insert them into the database except by doing a migration. Tested that manually against Goerli migrated database.

**Metadata**
- https://linear.app/optimism/issue/CLI-3555/error-from-eth-getlogs-when-regolith-enabled
