### PR TITLE
core: Don't require L1 cost to be paid when simulating transactions

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -223,7 +223,7 @@ func (st *StateTransition) buyGas() error {
 	mgval := new(big.Int).SetUint64(st.msg.Gas())
 	mgval = mgval.Mul(mgval, st.gasPrice)
 	var l1Cost *big.Int
-	if st.evm.Context.L1CostFunc != nil {
+	if st.evm.Context.L1CostFunc != nil && !st.msg.IsFake() {
 		l1Cost = st.evm.Context.L1CostFunc(st.evm.Context.BlockNumber.Uint64(), st.evm.Context.Time, st.msg)
 	}
 	if l1Cost != nil {


### PR DESCRIPTION
**Description**

Fixes and issue where `eth_call` would fail with errors like:
```
        	Error:      	Expected nil, but got: &fmt.wrapError{msg:"failed to get number: err: insufficient funds for gas * price + value: address 0x0000000000000000000000000000000000000000 have 1 want 22316 (supplied gas 9223372036854775807)", err:(*rpc.jsonError)(0x14008999950)}
```

Prior to https://github.com/ethereum-optimism/op-geth/commit/cde9c26c4888d3676d2162996b3c1e6768bd08c5 `l1CostGas` would always be set to 0 in both `NewMessage` and simulated.go's `callMsg`. Now both those places create a new `RollupGasData` struct and then the gas used calculation is performed by its `DataGas` method. As a result, the real L1 gas cost winds up being used instead of being hard coded to 0.

Now L1 costs are ignored entirely when the msg is fake, ensuring L1 gas cost isn't charged.

**Metadata**
- Fixes #[Link to Issue]
