### PR TITLE
allow gas tip estimate to drop when blocks are mostly empty

### DIFF
--- a/eth/gasprice/feehistory_test.go
+++ b/eth/gasprice/feehistory_test.go
@@ -58,7 +58,7 @@ func TestFeeHistory(t *testing.T) {
 			MaxHeaderHistory: c.maxHeader,
 			MaxBlockHistory:  c.maxBlock,
 		}
-		backend := newTestBackend(t, big.NewInt(16), c.pending)
+		backend := newTestBackend(t, big.NewInt(16), c.pending, false)
 		oracle := NewOracle(backend, config)
 
 		first, reward, baseFee, ratio, err := oracle.FeeHistory(context.Background(), c.count, c.last, c.percent)


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Tweak the gas tip estimation algorithm to allow the gas tip estimate to drop when there is plenty of block space by including low dummy prices in the price array that gets sampled when mostly empty blocks are encountered. A block is deemed "mostly empty" when the gas it consumes is less than half its target.

**Tests**

Updated unit test to exercise both the near-full and mostly-empty cases.  This change is also running on our Base goerli nodes in production here: https://goerli.base.org

**Additional context**

This fixes an issue we are encountering on Base goerli testnet, and I imagine affects other chains where blocks are not (yet) near full. Once a node sees a few transactions with a given priority fee, it effectively locks in that first-seen priority fee as its tip estimate even when there is plenty of blockspace. Without a bot or some other activity forcing txs with lower-than-estimated gas tip, it never drops.