### PR TITLE
Add missing L1CostFunc set

### DIFF
--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -657,6 +657,7 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 		signer    = types.MakeSigner(api.backend.ChainConfig(), block.Number())
 		results   = make([]*txTraceResult, len(txs))
 	)
+	blockCtx.L1CostFunc = types.NewL1CostFunc(api.backend.ChainConfig(), statedb)
 	for i, tx := range txs {
 		// Generate the next state snapshot fast without tracing
 		msg, _ := tx.AsMessage(signer, block.BaseFee())


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

We are experiencing a panic in `debug_traceBlockByHash` due to a missing `L1CostFunc`. This PR sets this.

An alternative direction might be to refactor `NewEVMBlockContext` to accept a `types.L1CostFunc`... but this seems fine for now.

**Tests**

No tests added. Very similar PR to #27.

**Additional context**

Panic:
```
goroutine 59443519 [running]:
github.com/ethereum/go-ethereum/rpc.(*callback).call.func1()
	github.com/ethereum/go-ethereum/rpc/service.go:199 +0x89
panic({0x17a3f20, 0x2841670})
	runtime/panic.go:884 +0x212
github.com/ethereum/go-ethereum/core.(*StateTransition).innerTransitionDb(0xc01ea81400)
	github.com/ethereum/go-ethereum/core/state_transition.go:477 +0x1026
github.com/ethereum/go-ethereum/core.(*StateTransition).TransitionDb(0xc01ea81400)
	github.com/ethereum/go-ethereum/core/state_transition.go:333 +0xce
github.com/ethereum/go-ethereum/core.ApplyMessage(0x1d7f5d8?, {0x1d8e530?, 0xc023411040?}, 0x0?)
	github.com/ethereum/go-ethereum/core/state_transition.go:211 +0x2a
github.com/ethereum/go-ethereum/eth/tracers.(*API).traceTx(0xc001afb3c0, {0x1d7f5d8, 0xc02fe8e480}, {0x1d8e530, 0xc023411040}, 0xc01f10e3c0, {0x1b822b0, 0x1b822b8, 0xc02b7d3530, 0x0, ...}, ...)
	github.com/ethereum/go-ethereum/eth/tracers/api.go:1038 +0x529
github.com/ethereum/go-ethereum/eth/tracers.(*API).traceBlock(0xc001afb3c0, {0x1d7f5d8?, 0xc02fe8e480?}, 0xc0234106e0, 0x0)
	github.com/ethereum/go-ethereum/eth/tracers/api.go:668 +0xd34
github.com/ethereum/go-ethereum/eth/tracers.(*API).TraceBlockByHash(0xc001afb3c0, {0x1d7f5d8, 0xc02fe8e480}, {0x3f, 0x79, 0x8a, 0xeb, 0x6f, 0x87, 0x85, ...}, ...)
	github.com/ethereum/go-ethereum/eth/tracers/api.go:501 +0x485
reflect.Value.call({0xc003c13d00?, 0xc000299fa8?, 0x7f5e5035ef18?}, {0x19ea6d2, 0x4}, {0xc03a095320, 0x4, 0xc30312?})
	reflect/value.go:584 +0x8c5
reflect.Value.Call({0xc003c13d00?, 0xc000299fa8?, 0x16?}, {0xc03a095320?, 0x1?, 0x2?})
	reflect/value.go:368 +0xbc
github.com/ethereum/go-ethereum/rpc.(*callback).call(0xc004934f60, {0x1d7f5d8?, 0xc02fe8e480}, {0xc02b5edcf8, 0x16}, {0xc02b7d3020, 0x2, 0x4ce997?})
	github.com/ethereum/go-ethereum/rpc/service.go:205 +0x3e5
github.com/ethereum/go-ethereum/rpc.(*handler).runMethod(0xc01ea77d10?, {0x1d7f5d8?, 0xc02fe8e480?}, 0xc014d51500, 0x2?, {0xc02b7d3020?, 0x5?, 0xc01eab4c80?})
	github.com/ethereum/go-ethereum/rpc/handler.go:513 +0x45
github.com/ethereum/go-ethereum/rpc.(*handler).handleCall(0xc01ea05b00, 0xc02b7d2f60, 0xc014d51500)
	github.com/ethereum/go-ethereum/rpc/handler.go:459 +0x239
github.com/ethereum/go-ethereum/rpc.(*handler).handleCallMsg(0xc01ea05b00, 0xc02b7d2fc0?, 0xc014d51500)
	github.com/ethereum/go-ethereum/rpc/handler.go:420 +0x237
github.com/ethereum/go-ethereum/rpc.(*handler).handleMsg.func1(0xc02b7d2f60)
	github.com/ethereum/go-ethereum/rpc/handler.go:256 +0x1a5
github.com/ethereum/go-ethereum/rpc.(*handler).startCallProc.func1()
	github.com/ethereum/go-ethereum/rpc/handler.go:348 +0xc5
created by github.com/ethereum/go-ethereum/rpc.(*handler).startCallProc
	github.com/ethereum/go-ethereum/rpc/handler.go:344 +0x8d
```
