### PR TITLE
Add upstream release check

### DIFF
--- a/.circleci/check-releases.sh
+++ b/.circleci/check-releases.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+LATEST_RELEASE=$(curl -s --fail -L \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  https://api.github.com/repos/ethereum/go-ethereum/releases \
+  | jq -r '(.[] | select(.draft==false) | select(.prerelease==false)).tag_name' | head -n 1)
+
+echo "Detected latest go-ethereum release as ${LATEST_RELEASE}"
+
+git remote add upstream https://github.com/ethereum/go-ethereum
+git fetch upstream > /dev/null
+
+if git branch --contains "${LATEST_RELEASE}" 2>&1 | grep -e '^[ *]*optimism$' > /dev/null
+then
+  echo "Up to date with latest release.  Great job! 🎉"
+else
+  echo "Release has not been merged"
+  exit 1
+fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   gcp-cli: circleci/gcp-cli@3.0.1
+  slack: circleci/slack@4.10.1
 
 commands:
   gcp-oidc-authenticate:
@@ -120,6 +121,19 @@ jobs:
       - checkout
       - run:
           command: go run build/ci.go lint
+  check-releases:
+    docker:
+      - image: cimg/go:1.19
+    steps:
+      - checkout
+      - run:
+          command: .circleci/check-releases.sh
+      - slack/notify:
+          channel: C03N11M0BBN
+          branch_pattern: optimism
+          event: fail
+          template: basic_fail_1
+
 
 workflows:
   main:
@@ -156,3 +170,15 @@ workflows:
             - oplabs-gcr-release
           requires:
             - hold
+  scheduled:
+    triggers:
+      - schedule:
+          # run daily
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only: [ "optimism" ]
+    jobs:
+      - check-releases:
+          name: Check for new upstream releases
+          context: slack


### PR DESCRIPTION
**Description**

Adds a daily check for new upstream Geth releases that haven't yet been merged into op-geth. Will post to slack when such a release is found.

**Metadata**
- Fixes https://linear.app/optimism/issue/CLI-3688/monitor-upstream-geth-releases
