### PR TITLE
optimism: fork.yaml update upstream base commit with 1.11.5 changes

### DIFF
--- a/fork.yaml
+++ b/fork.yaml
@@ -5,7 +5,7 @@ footer: |
 base:
   name: go-ethereum
   url: https://github.com/ethereum/go-ethereum
-  hash: 7e3b149be054053fd1177deaba3caf60d5f5d30b
+  hash: a38f4108571d1a144dc3cf3faf8990430d109bc4
 fork:
   name: op-geth
   url: https://github.com/ethereum-optimism/op-geth


### PR DESCRIPTION
**Description**

Updates fork-diff with the latest upstream commit as base (the 1.11.5 tag).


**TODOs**

- [x] Author or reviewer has added an entry to the [current release notes draft][RND], if appropriate.

[RND]: https://www.notion.so/oplabs/ded30107ceec41c88817e60322aa8d0a?v=b4a22cedb85a46a38c9be14e7c984953&pvs=4 "Release Notes"
