### PR TITLE
miner: empty pending block by default on rollup

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -941,6 +941,11 @@ var (
 		Usage:    "Disable transaction pool gossip.",
 		Category: flags.RollupCategory,
 	}
+	RollupEnablePendingTxs = &cli.BoolFlag{
+		Name:     "rollup.enablependingtxs",
+		Usage:    "Enable the pending block building to include txs from the tx-pool",
+		Category: flags.RollupCategory,
+	}
 
 	// Metrics flags
 	MetricsEnabledFlag = &cli.BoolFlag{
@@ -1695,6 +1700,9 @@ func setMiner(ctx *cli.Context, cfg *miner.Config) {
 	}
 	if ctx.IsSet(MinerNewPayloadTimeout.Name) {
 		cfg.NewPayloadTimeout = ctx.Duration(MinerNewPayloadTimeout.Name)
+	}
+	if ctx.IsSet(RollupEnablePendingTxs.Name) {
+		cfg.RollupAllowPendingTxs = ctx.Bool(RollupEnablePendingTxs.Name)
 	}
 }
 

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -62,6 +62,8 @@ type Config struct {
 	Noverify   bool           // Disable remote mining solution verification(only useful in ethash).
 
 	NewPayloadTimeout time.Duration // The maximum time allowance for creating a new payload
+
+	RollupAllowPendingTxs bool // Allow tx inclusion in the pending block, only applicable with optimism rollup config
 }
 
 // DefaultConfig contains default settings for miner.


### PR DESCRIPTION
**Description**

This changes the default pending-block construction behavior on OP-stack chains to produce empty pending blocks.

The pending-block gas-limit was, and is still, configurable with `--miner.gaslimit=XYZ`

The old pending-block functionality can be re-enabled by `--rollup.enablependingtxs`.

The pending block is used for gas estimation, and so the gas-limit is important. At the same time, the pending block should be empty on shared-node RPC providers, to preserve tx-privacy.

**Tests**

Work in progress, op-e2e.

**Metadata**

Fix CLI-3793

**TODOs**

- [ ] Author or reviewer has added an entry to the [current release notes draft][RND], if appropriate.

[RND]: https://www.notion.so/oplabs/ded30107ceec41c88817e60322aa8d0a?v=b4a22cedb85a46a38c9be14e7c984953&pvs=4 "Release Notes"
