### PR TITLE
Schedule Regolith on Base Goerli at 1682614800

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -300,6 +300,10 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *trie.Database, gen
 			if config.IsOptimism() && config.ChainID != nil && config.ChainID.Cmp(params.OptimismGoerliChainId) == 0 {
 				// Apply Optimism Goerli regolith time
 				config.RegolithTime = &params.OptimismGoerliRegolithTime
+			} 
+			if config.IsOptimism() && config.ChainID != nil && config.ChainID.Cmp(params.BaseGoerliChainId) == 0 {
+				// Apply Base Goerli regolith time
+				config.RegolithTime = &params.BaseGoerliRegolithTime
 			}
 			if overrides != nil && overrides.OverrideShanghai != nil {
 				config.ShanghaiTime = overrides.OverrideShanghai

--- a/params/config.go
+++ b/params/config.go
@@ -34,11 +34,14 @@ var (
 	GoerliGenesisHash  = common.HexToHash("0xbf7e331f7f7c1dd2e05159666b3bf8bc7a8a3a9eb1d518969eab529dd9b88c1a")
 )
 
-// Optimism chain config
+// OP Stack chain config
 var (
 	OptimismGoerliChainId = big.NewInt(420)
 	// March 17, 2023 @ 7:00:00 pm UTC
 	OptimismGoerliRegolithTime = uint64(1679079600)
+	BaseGoerliChainId = big.NewInt(84531)
+	// April 27, 2023 @ 5:00:00 pm UTC
+	BaseGoerliRegolithTime = uint64(1682614800)
 )
 
 // TrustedCheckpoints associates each known checkpoint with the genesis hash of


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
Sets Base Goerli Regolith upgrade to occur on Thursday April 27, 2023 @ 5:00:00 pm UTC, 1:00:00 pm EST, 10:00:00 am PST

**Tests**
<img width="705" alt="Screenshot 2023-04-13 at 7 02 17 PM" src="https://user-images.githubusercontent.com/107630902/231901241-ef1611fa-d1e9-41c9-bbd1-800d0036d8ff.png">


Ran local devnet with Base Goerli chain identifier (`84531`) and verified that op-geth set the correct timestamp. 

**TODOs**

- [ ] Author or reviewer has added an entry to the [current release notes draft][RND], if appropriate.

[RND]: https://www.notion.so/oplabs/ded30107ceec41c88817e60322aa8d0a?v=b4a22cedb85a46a38c9be14e7c984953&pvs=4 "Release Notes"
