### PR TITLE
fork.yaml: update fork diff for v1.11.6

### DIFF
--- a/fork.yaml
+++ b/fork.yaml
@@ -5,7 +5,7 @@ footer: |
 base:
   name: go-ethereum
   url: https://github.com/ethereum/go-ethereum
-  hash: a38f4108571d1a144dc3cf3faf8990430d109bc4
+  hash: ea9e62ca3db5c33aa7438ebf39c189afd53c6bf8
 fork:
   name: op-geth
   url: https://github.com/ethereum-optimism/op-geth


### PR DESCRIPTION
**Description**

Cleans up the https://op-geth.optimism.io diff site by changing the upstream reference to match the v1.11.6 changes introduced in #88 
