### PR TITLE
miner,eth: latest block as pending block on rollup

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -156,6 +156,7 @@ var (
 		utils.RollupHistoricalRPCFlag,
 		utils.RollupHistoricalRPCTimeoutFlag,
 		utils.RollupDisableTxPoolGossipFlag,
+		utils.RollupComputePendingBlock,
 		configFileFlag,
 	}, utils.NetworkFlags, utils.DatabasePathFlags)
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -941,6 +941,11 @@ var (
 		Usage:    "Disable transaction pool gossip.",
 		Category: flags.RollupCategory,
 	}
+	RollupComputePendingBlock = &cli.BoolFlag{
+		Name:     "rollup.computependingblock",
+		Usage:    "By default the pending block equals the latest block to save resources and not leak txs from the tx-pool, this flag enables computing of the pending block from the tx-pool instead.",
+		Category: flags.RollupCategory,
+	}
 
 	// Metrics flags
 	MetricsEnabledFlag = &cli.BoolFlag{
@@ -1695,6 +1700,9 @@ func setMiner(ctx *cli.Context, cfg *miner.Config) {
 	}
 	if ctx.IsSet(MinerNewPayloadTimeout.Name) {
 		cfg.NewPayloadTimeout = ctx.Duration(MinerNewPayloadTimeout.Name)
+	}
+	if ctx.IsSet(RollupComputePendingBlock.Name) {
+		cfg.RollupComputePendingBlock = ctx.Bool(RollupComputePendingBlock.Name)
 	}
 }
 

--- a/eth/api.go
+++ b/eth/api.go
@@ -265,6 +265,9 @@ func (api *DebugAPI) DumpBlock(blockNr rpc.BlockNumber) (state.Dump, error) {
 		// both the pending block as well as the pending state from
 		// the miner and operate on those
 		_, stateDb := api.eth.miner.Pending()
+		if stateDb == nil {
+			return state.Dump{}, errors.New("no pending state")
+		}
 		return stateDb.RawDump(opts), nil
 	}
 	var header *types.Header
@@ -350,6 +353,9 @@ func (api *DebugAPI) AccountRange(blockNrOrHash rpc.BlockNumberOrHash, start hex
 			// both the pending block as well as the pending state from
 			// the miner and operate on those
 			_, stateDb = api.eth.miner.Pending()
+			if stateDb == nil {
+				return state.IteratorDump{}, errors.New("no pending state")
+			}
 		} else {
 			var header *types.Header
 			if number == rpc.LatestBlockNumber {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -199,7 +199,11 @@ func (b *EthAPIBackend) StateAndHeaderByNumber(ctx context.Context, number rpc.B
 	// Pending state is only known by the miner
 	if number == rpc.PendingBlockNumber {
 		block, state := b.eth.miner.Pending()
-		return state, block.Header(), nil
+		if block != nil {
+			return state, block.Header(), nil
+		} else {
+			number = rpc.LatestBlockNumber
+		}
 	}
 	// Otherwise resolve the block number and return its state
 	header, err := b.HeaderByNumber(ctx, number)

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -774,7 +774,7 @@ func (s *BlockChainAPI) GetHeaderByNumber(ctx context.Context, number rpc.BlockN
 	header, err := s.b.HeaderByNumber(ctx, number)
 	if header != nil && err == nil {
 		response := s.rpcMarshalHeader(ctx, header)
-		if number == rpc.PendingBlockNumber {
+		if number == rpc.PendingBlockNumber && s.b.ChainConfig().Optimism == nil { // don't remove info if optimism
 			// Pending header need to nil out a few fields
 			for _, field := range []string{"hash", "nonce", "miner"} {
 				response[field] = nil
@@ -803,7 +803,7 @@ func (s *BlockChainAPI) GetBlockByNumber(ctx context.Context, number rpc.BlockNu
 	block, err := s.b.BlockByNumber(ctx, number)
 	if block != nil && err == nil {
 		response, err := s.rpcMarshalBlock(ctx, block, true, fullTx)
-		if err == nil && number == rpc.PendingBlockNumber {
+		if err == nil && number == rpc.PendingBlockNumber && s.b.ChainConfig().Optimism == nil { // don't remove info if optimism
 			// Pending blocks need to nil out a few fields
 			for _, field := range []string{"hash", "nonce", "miner"} {
 				response[field] = nil

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -62,6 +62,8 @@ type Config struct {
 	Noverify   bool           // Disable remote mining solution verification(only useful in ethash).
 
 	NewPayloadTimeout time.Duration // The maximum time allowance for creating a new payload
+
+	RollupComputePendingBlock bool // Compute the pending block from tx-pool, instead of copying the latest-block
 }
 
 // DefaultConfig contains default settings for miner.


### PR DESCRIPTION
**Description**

This fixes the pending-block behavior to be more compatible with pre-bedrock assumptions: requests for the "pending" block/header get served the "latest" block. This prevents transactions from the tx-pool from being revealed before they are committed to by the sequencer

Additionally this updates other lesser used API endpoints that utilize the "pending" mining state as well:
- debug-namespace methods do not serve state or receipts for the pending block, if not available like in the rollup case.
- the pending-state in graph-QL queries (as hit by `StateAndHeaderByNumberOrHash`) continues processing as "latest" state when the pending state is not available, like in the rollup case.

And to prevent unnecessary pending-block computations, the worker in the `miner` package is changed to:
- Do not update the pending-block snapshot when processing txs
- Not triggering recommits: the Engine API does its own revising of payload builds with `buildPayload`, and thus we can disable the pending-block work-triggering parts by draining the events that create those, rather than processing them (in `newWorkLoop`). Draining is important, as unsubscribing would leave the producing subscription channels filling up, causing the engine API to hang after producing blocks.

The engine API will still be initiating tasks for block-building, but does so by merely using the block-building functionality of the worker, not the whole recommit and snapshot thing that still remains from L1 PoW days / pending-block support.

I also suspect that this improves sequencing performance, or at least reduces block-building lag spikes: rebuilding the pending block continuously on the head block which changes every 2 seconds, and re-applying transactions, is expensive. Previously this was worked-around on the sequencer node by setting the pending-block gas limit to be very low (5000 gas to effectively force the pending-blocks to be empty), but now it doesn't try to build it at all anymore, which means there is less contention around the state of the chain and the tx-pool.

**Tests**

https://github.com/ethereum-optimism/optimism/pull/5736

Replaces #81

Fix CLI-3793

