### PR TITLE
core/types: Include overhead in the L1GasUsed for receipts.

### DIFF
--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -536,7 +536,8 @@ func (rs Receipts) DeriveFields(config *params.ChainConfig, hash common.Hash, nu
 				if !txs[i].IsDepositTx() {
 					gas := txs[i].RollupDataGas().DataGas(time, config)
 					rs[i].L1GasPrice = l1Basefee
-					rs[i].L1GasUsed = new(big.Int).SetUint64(gas)
+					// GasUsed reported in receipt should include the overhead
+					rs[i].L1GasUsed = new(big.Int).Add(new(big.Int).SetUint64(gas), overhead)
 					rs[i].L1Fee = L1Cost(gas, l1Basefee, overhead, scalar)
 					rs[i].FeeScalar = feeScalar
 				}


### PR DESCRIPTION
**Description**

Adds the L1 overhead to the `l1GasUsed` reported for L2 transactions.  This restores the invariant that `l1Fee = l1GasPrice * l1FeeScalar * l1GasUsed` as it did pre-bedrock.

**Tests**

Added tests to check derivation of L1 gas related fields.

**Invariants**

`l1Fee = l1GasPrice * l1FeeScalar * l1GasUsed`


**TODOs**

- [ ] Author or reviewer has added an entry to the [current release notes draft][RND], if appropriate.

[RND]: https://www.notion.so/oplabs/ded30107ceec41c88817e60322aa8d0a?v=b4a22cedb85a46a38c9be14e7c984953&pvs=4 "Release Notes"
