### PR TITLE
optimism: set chain-ID of pre-bedrock relayed txs

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1473,6 +1473,10 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 			result.Nonce = hexutil.Uint64(*receipt.DepositNonce)
 		}
 	case types.LegacyTxType:
+		if v.Sign() == 0 && r.Sign() == 0 && s.Sign() == 0 { // pre-bedrock relayed tx does not have a signature
+			result.ChainID = (*hexutil.Big)(new(big.Int).Set(config.ChainID))
+			break
+		}
 		// if a legacy transaction has an EIP-155 chain id, include it explicitly
 		if id := tx.ChainId(); id.Sign() != 0 {
 			result.ChainID = (*hexutil.Big)(id)


### PR DESCRIPTION
**Description**

Pre-bedrock relayed txs do not have a signature. When served in the RPC the chain ID should not be computed from the signature values, but rather be set from the chain config, to ensure it's stated correctly in the RPC result. The legacy l2geth didn't include the chain ID in the response at all, but we do want it to be compatible with the latest API spec that includes it.

**Tests**

Fixes an API result of legacy data, may need a new testing strategy for l2geth data, but this change is simple enough that we can test-run it with:
```
cast rpc --rpc-url=http://127.0.0.1:8745 eth_getTransactionByHash 0xe1fb9e9031d966b707e154e228ad135956df7d3971bc40a6906848a81a8a98dd
```
Which previously recorded `"chainId":"0x7fffffffffffffee"` but should now be `"chainId":"0xa"`

**Metadata**

CLI-4072

**TODOs**

- [ ] Author or reviewer has added an entry to the [current release notes draft][RND], if appropriate.

[RND]: https://www.notion.so/oplabs/ded30107ceec41c88817e60322aa8d0a?v=b4a22cedb85a46a38c9be14e7c984953&pvs=4 "Release Notes"
