### PR TITLE
Fix sender of deposit transactions

### DIFF
--- a/core/types/transaction_marshalling_test.go
+++ b/core/types/transaction_marshalling_test.go
@@ -77,4 +77,27 @@ func TestTransactionUnmarshalJSON(t *testing.T) {
 			}
 		})
 	}
+
+	tests = []struct {
+		name          string
+		json          string
+		expectedError string
+	}{
+		{
+			name: "Valid deposit sender",
+			json: `{"type":"0x7e","nonce":"0x1","gas": "0x1234", "gasPrice":null,"maxPriorityFeePerGas":null,"maxFeePerGas":null,"value":"0x1","input":"0x616263646566","v":null,"r":null,"s":null,"to":null,"sourceHash":"0x0000000000000000000000000000000000000000000000000000000000000000","from":"0x0000000000000000000000000000000000000001","hash":"0xa4341f3db4363b7ca269a8538bd027b2f8784f84454ca917668642d5f6dffdf9"}`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var parsedTx = &Transaction{}
+			err := json.Unmarshal([]byte(test.json), &parsedTx)
+			require.NoError(t, err)
+
+			signer := NewLondonSigner(big.NewInt(123))
+			sender, err := signer.Sender(parsedTx)
+			require.NoError(t, err)
+			require.Equal(t, common.HexToAddress("0x1"), sender)
+		})
+	}
 }

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -183,7 +183,12 @@ func NewLondonSigner(chainId *big.Int) Signer {
 
 func (s londonSigner) Sender(tx *Transaction) (common.Address, error) {
 	if tx.Type() == DepositTxType {
-		return tx.inner.(*DepositTx).From, nil
+		switch tx.inner.(type) {
+		case *DepositTx:
+			return tx.inner.(*DepositTx).From, nil
+		case *depositTxWithNonce:
+			return tx.inner.(*depositTxWithNonce).From, nil
+		}
 	}
 	if tx.Type() != DynamicFeeTxType {
 		return s.eip2930Signer.Sender(tx)


### PR DESCRIPTION
**Description**

When the nonce of a deposit transaction is non-nil, the inner transaction is decoded as type `depositTxWithNonce`. Hence when getting the sender of such transactions, the type of the inner transaction should be checked.

**Tests**

Added test in core/types/transaction_marshalling_test.go

**TODOs**

- [ ] Author or reviewer has added an entry to the [current release notes draft][RND], if appropriate.

[RND]: https://www.notion.so/oplabs/ded30107ceec41c88817e60322aa8d0a?v=b4a22cedb85a46a38c9be14e7c984953&pvs=4 "Release Notes"
