### PR TITLE
miner: change min recommit interval to 100ms

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -61,7 +61,7 @@ const (
 
 	// minRecommitInterval is the minimal time interval to recreate the sealing block with
 	// any newly arrived transactions.
-	minRecommitInterval = 1 * time.Second
+	minRecommitInterval = 100 * time.Millisecond
 
 	// maxRecommitInterval is the maximum time interval to recreate the sealing block with
 	// any newly arrived transactions.


### PR DESCRIPTION
**Description**

Change min-recommit interval to 100ms to experiment with more block-building iterations and tx-inclusion of later txs.

This only affects the sequencing code.


**Tests**

Geth doesn't have a fake clock util here, and CI is laggy, so timing should be tested on devnet.

