### PR TITLE
miner: adjust test to handle updated min-recommit interval

### DIFF
--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -476,7 +476,8 @@ func testAdjustInterval(t *testing.T, chainConfig *params.ChainConfig, engine co
 			estimate = estimate*(1-intervalAdjustRatio) + intervalAdjustRatio*(min-intervalAdjustBias)
 			wantMinInterval, wantRecommitInterval = 3*time.Second, time.Duration(estimate)*time.Nanosecond
 		case 3:
-			wantMinInterval, wantRecommitInterval = time.Second, time.Second
+			// lower than upstream test, since enforced min recommit interval is lower
+			wantMinInterval, wantRecommitInterval = 500*time.Millisecond, 500*time.Millisecond
 		}
 
 		// Check interval


### PR DESCRIPTION
**Description**

Fixes simple test cases that were broken in #102

The min recommit interval is now lower than the test case expects as lower bound, meaning that the 500ms doesn't get clipped to 1s anymore.
