### PR TITLE
Support snap sync for OP chains

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -163,9 +163,9 @@ func newHandler(config *handlerConfig) (*handler, error) {
 		}
 	} else {
 		blockNumber := h.chain.CurrentBlock().Number
-		// [Optimism] Allow snap sync from bedrock genesis block
-		if blockNumber.Uint64() > 0 && blockNumber.Cmp(config.Chain.Config().BedrockBlock) != 0 {
+		if blockNumber.Uint64() > 0 && (!config.Chain.Config().IsOptimism() || blockNumber.Cmp(config.Chain.Config().BedrockBlock) != 0) {
 			// Print warning log if database is not empty to run snap sync.
+			// For OP chains, snap sync from bedrock block is allowed.
 			log.Warn("Switch sync mode from snap sync to full sync")
 		} else {
 			// If snap sync was requested and our database is empty, grant it

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -162,7 +162,9 @@ func newHandler(config *handlerConfig) (*handler, error) {
 			log.Warn("Switch sync mode from full sync to snap sync")
 		}
 	} else {
-		if h.chain.CurrentBlock().Number.Uint64() > 0 {
+		blockNumber := h.chain.CurrentBlock().Number
+		// [Optimism] Allow snap sync from bedrock genesis block
+		if blockNumber.Uint64() > 0 && blockNumber.Cmp(config.Chain.Config().BedrockBlock) != 0 {
 			// Print warning log if database is not empty to run snap sync.
 			log.Warn("Switch sync mode from snap sync to full sync")
 		} else {

--- a/eth/protocols/snap/handler.go
+++ b/eth/protocols/snap/handler.go
@@ -469,7 +469,7 @@ func ServiceGetByteCodesQuery(chain *core.BlockChain, req *GetByteCodesPacket) [
 			// Peers should not request the empty code, but if they do, at
 			// least sent them back a correct response without db lookups
 			codes = append(codes, []byte{})
-		} else if blob, err := chain.ContractCodeWithPrefix(hash); err == nil {
+		} else if blob, err := chain.ContractCode(hash); err == nil {
 			codes = append(codes, blob)
 			bytes += uint64(len(blob))
 		}


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Hi! This is Tei from Test in Prod.

This PR is a small fix for Geth’s snap sync for op chains.

- Geth reads account bytecodes with prefixed keys during the snap-sync. However, the bedrock genesis DB saves bytecodes with the legacy key without prefixes. **This PR adds a fallback logic for the legacy keys** to serve bytecodes for snap sync.
    - FYI, this fallback had been removed by the Geth team (https://github.com/ethereum/go-ethereum/pull/24276/files#diff-048b7cda1c653b08f9eea9ee81ac5937ea8326556bceffd1ca1a3059bc24dbfdR470) for optimization.
    - New nodes that are synced using snap-sync will have prefixed keys in their DB, so eventually we can follow the deprecation process.
- Geth starts snap sync only if the current chain head is at the genesis block. **This PR allows snap sync from the bedrock genesis** block.

**Tests**

This fix was tested manually. I think it can be tested automatically in Hive.

**Additional context**

A [new feature](https://github.com/ethereum-optimism/optimism/pull/6243) to trigger snap sync of op-geth has been implemented in op-node.
