### PR TITLE
internal/ethapi: add chain-config debug RPC method

### DIFF
--- a/fork.yaml
+++ b/fork.yaml
@@ -163,7 +163,7 @@ def:
           globs:
             - "eth/state_accessor.go"
         - title: API frontend
-          description: Format deposit and L1-cost data in transaction responses.
+          description: Format deposit and L1-cost data in transaction responses. Add `debug_chainConfig` API.
           globs:
             - "internal/ethapi/api.go"
             - "rpc/errors.go"

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -2272,6 +2272,10 @@ func (api *DebugAPI) SetHead(number hexutil.Uint64) {
 	api.b.SetHead(uint64(number))
 }
 
+func (api *DebugAPI) ChainConfig() *params.ChainConfig {
+	return api.b.ChainConfig()
+}
+
 // NetAPI offers network related RPC methods
 type NetAPI struct {
 	net            *p2p.Server


### PR DESCRIPTION
**Description**

Export the chain-config for debug / dev-tooling purposes. Since the chain-config format is technically node-dependent, it's only exposed on the debug namespace.

Indexers depend on the fork block numbers to post-process the chain, so this makes it easy to access, and generic between all op-stack chains. This prevents having to lookup external sources or manual database inspection work.
