### PR TITLE
core: reinstate ContractCode function to support snap-sync from legacy DB nodes

### DIFF
--- a/cmd/devp2p/internal/ethtest/snap.go
+++ b/cmd/devp2p/internal/ethtest/snap.go
@@ -249,11 +249,11 @@ func (s *Suite) TestSnapGetByteCodes(t *utesting.T) {
 		// A few stateroots
 		{
 			nBytes: 10000, hashes: []common.Hash{s.chain.RootAt(0), s.chain.RootAt(999)},
-			expHashes: 0,
+			expHashes: 1, // 32-byte keys are detected as code, even if not code (like genesis hash), in legacy lookups.
 		},
 		{
 			nBytes: 10000, hashes: []common.Hash{s.chain.RootAt(0), s.chain.RootAt(0)},
-			expHashes: 0,
+			expHashes: 2, // 32-byte keys are detected as code, even if not code (like genesis hash), in legacy lookups.
 		},
 		// Empties
 		{

--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -311,6 +311,14 @@ func (bc *BlockChain) ContractCodeWithPrefix(hash common.Hash) ([]byte, error) {
 	return bc.stateCache.(codeReader).ContractCodeWithPrefix(common.Hash{}, hash)
 }
 
+// ContractCode retrieves a blob of data associated with a contract hash
+// either from ephemeral in-memory cache, or from persistent storage.
+// This is a legacy-method, replaced by ContractCodeWithPrefix,
+// but required for old databases to serve snap-sync.
+func (bc *BlockChain) ContractCode(hash common.Hash) ([]byte, error) {
+	return bc.stateCache.ContractCode(common.Hash{}, hash)
+}
+
 // State returns a new mutable state based on the current HEAD block.
 func (bc *BlockChain) State() (*state.StateDB, error) {
 	return bc.StateAt(bc.CurrentBlock().Root)


### PR DESCRIPTION
**Description**

Due to the way the v1.12.0 changes and snap-sync support changes landed, this build issue was caused.

```
# github.com/ethereum/go-ethereum/eth/protocols/snap
eth/protocols/snap/handler.go:472:32: chain.ContractCode undefined (type *core.BlockChain has no field or method ContractCode)
```

We need the legacy contract-code without prefix to support serving sync from older databases that do not have the prefix as part of the contract-code key.

This effectively undoes https://github.com/ethereum/go-ethereum/pull/27186
