### PR TITLE
Set op-geth version at build

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -251,6 +251,9 @@ func buildFlags(env build.Environment, staticLinking bool, buildTags []string) (
 		ld = append(ld, "-X", "github.com/ethereum/go-ethereum/internal/version.gitCommit="+env.Commit)
 		ld = append(ld, "-X", "github.com/ethereum/go-ethereum/internal/version.gitDate="+env.Date)
 	}
+	if env.Tag != "" {
+		ld = append(ld, "-X", "github.com/ethereum/go-ethereum/params.gitTag="+env.Tag)
+	}
 	// Strip DWARF on darwin. This used to be required for certain things,
 	// and there is no downside to this, so we just keep doing it.
 	if runtime.GOOS == "darwin" {

--- a/params/version.go
+++ b/params/version.go
@@ -18,6 +18,8 @@ package params
 
 import (
 	"fmt"
+	"regexp"
+	"strconv"
 )
 
 // Version is the version of upstream geth
@@ -29,12 +31,32 @@ const (
 )
 
 // OPVersion is the version of op-geth
-const (
+var (
 	OPVersionMajor = 0          // Major version component of the current release
 	OPVersionMinor = 1          // Minor version component of the current release
 	OPVersionPatch = 0          // Patch version component of the current release
 	OPVersionMeta  = "unstable" // Version metadata to append to the version string
 )
+
+// This is set at build-time by the linker when the build is done by build/ci.go.
+var gitTag string
+
+// Override the version variables if the gitTag was set at build time.
+var _ = func() (_ string) {
+	semver := regexp.MustCompile("^v([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?(?:\\+[0-9A-Za-z-]+)?$")
+	version := semver.FindStringSubmatch(gitTag)
+	if version == nil {
+		return
+	}
+	if version[4] == "" {
+		version[4] = "stable"
+	}
+	OPVersionMajor, _ = strconv.Atoi(version[1])
+	OPVersionMinor, _ = strconv.Atoi(version[2])
+	OPVersionPatch, _ = strconv.Atoi(version[3])
+	OPVersionMeta = version[4]
+	return
+}()
 
 // Version holds the textual version string.
 var Version = func() string {


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

As reported in https://github.com/base-org/node/issues/75, `op-geth` does not keep the version variables up-to-date with the released version tag.

This PR threads the env.Tag calculated in the `build/ci.go` script to an internal variable in the `params` package, and sets the `OPVersion*` variables to the relevant values.

**Tests**

Tested locally by building and running `geth --version`:
```
> go run build/ci.go install -static ./cmd/geth
```

For a tagged released commit:
```
> build/bin/geth --version
geth version 1.101106.0-stable-b5fecf58
```

For latest on `optimism` branch:
```
> build/bin/geth --version
geth version 0.1.0-unstable-b3c4be01-20230726
```
