### PR TITLE
params: source chainConfig and genesis from superchain-registry

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1079,7 +1079,6 @@ func setBootstrapNodes(ctx *cli.Context, cfg *p2p.Config) {
 		urls = params.RinkebyBootnodes
 	case ctx.Bool(GoerliFlag.Name):
 		urls = params.GoerliBootnodes
-		// TODO(): BetaOPNetworkFlag default bootnodes
 	}
 
 	// don't apply defaults if BootstrapNodes is already set
@@ -2205,13 +2204,14 @@ func MakeGenesis(ctx *cli.Context) *core.Genesis {
 	case ctx.Bool(GoerliFlag.Name):
 		genesis = core.DefaultGoerliGenesisBlock()
 	case ctx.IsSet(BetaOPNetworkFlag.Name):
-		ch, err := params.OPStackChainIDByName(ctx.String(BetaOPNetworkFlag.Name))
+		name := ctx.String(BetaOPNetworkFlag.Name)
+		ch, err := params.OPStackChainIDByName(name)
 		if err != nil {
-			Fatalf("failed to load OP-Stack chain: %v", err)
+			Fatalf("failed to load OP-Stack chain %q: %v", name, err)
 		}
 		genesis, err := core.LoadOPStackGenesis(ch)
 		if err != nil {
-			Fatalf("failed to load genesis for OP-Stack chain %d: %v", ch, err)
+			Fatalf("failed to load genesis for OP-Stack chain %q (%d): %v", name, ch, err)
 		}
 		return genesis
 	case ctx.Bool(DeveloperFlag.Name):

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2207,11 +2207,11 @@ func MakeGenesis(ctx *cli.Context) *core.Genesis {
 	case ctx.IsSet(BetaOPNetworkFlag.Name):
 		ch, err := params.OPStackChainIDByName(ctx.String(BetaOPNetworkFlag.Name))
 		if err != nil {
-			Fatalf("failed to load OP-Stack chain: %w", err)
+			Fatalf("failed to load OP-Stack chain: %v", err)
 		}
 		genesis, err := core.LoadOPStackGenesis(ch)
 		if err != nil {
-			Fatalf("failed to load genesis for OP-Stack chain %d: %w", ch, err)
+			Fatalf("failed to load genesis for OP-Stack chain %d: %v", ch, err)
 		}
 		return genesis
 	case ctx.Bool(DeveloperFlag.Name):

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -302,11 +302,11 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *trie.Database, gen
 	}
 	applyOverrides := func(config *params.ChainConfig) {
 		if config != nil {
-			if config.IsOptimism() && config.ChainID != nil && config.ChainID.Cmp(params.OptimismGoerliChainId) == 0 {
+			if config.IsOptimism() && config.ChainID != nil && config.ChainID.Cmp(big.NewInt(params.OPGoerliChainID)) == 0 {
 				// Apply Optimism Goerli regolith time
 				config.RegolithTime = &params.OptimismGoerliRegolithTime
 			}
-			if config.IsOptimism() && config.ChainID != nil && config.ChainID.Cmp(params.BaseGoerliChainId) == 0 {
+			if config.IsOptimism() && config.ChainID != nil && config.ChainID.Cmp(big.NewInt(params.BaseGoerliChainID)) == 0 {
 				// Apply Base Goerli regolith time
 				config.RegolithTime = &params.BaseGoerliRegolithTime
 			}
@@ -467,7 +467,7 @@ func (g *Genesis) ToBlock() *types.Block {
 	if g.StateHash != nil {
 		if len(g.Alloc) > 0 {
 			panic(fmt.Errorf("cannot both have genesis hash %s "+
-				"and state-allocation with %d entries", *g.StateHash, len(g.Alloc)))
+				"and non-empty state-allocation", *g.StateHash))
 		}
 		root = *g.StateHash
 	} else if root, err = g.Alloc.deriveHash(); err != nil {

--- a/core/superchain.go
+++ b/core/superchain.go
@@ -84,9 +84,9 @@ func LoadOPStackGenesis(chainID uint64) (*Genesis, error) {
 	// and check the genesis matches the chain genesis definition.
 	if chConfig.Genesis.L2.Number != genesisBlock.NumberU64() {
 		switch chainID {
-		case 10:
+		case params.OPMainnetChainID:
 			expectedHash = common.HexToHash("0x7ca38a1916c42007829c55e69d3e9a73265554b586a499015373241b8a3fa48b")
-		case 420:
+		case params.OPGoerliChainID:
 			expectedHash = common.HexToHash("0xc1fc15cd51159b1f1e5cbc4b82e85c1447ddfa33c52cf1d98d14fba0d6354be1")
 		default:
 			return nil, fmt.Errorf("unknown stateless genesis definition for chain %d", chainID)

--- a/core/superchain.go
+++ b/core/superchain.go
@@ -31,7 +31,7 @@ func LoadOPStackGenesis(chainID uint64) (*Genesis, error) {
 		Nonce:      gen.Nonce,
 		Timestamp:  gen.Timestamp,
 		ExtraData:  gen.ExtraData,
-		GasLimit:   uint64(gen.GasLimit),
+		GasLimit:   gen.GasLimit,
 		Difficulty: (*big.Int)(gen.Difficulty),
 		Mixhash:    common.Hash(gen.Mixhash),
 		Coinbase:   common.Address(gen.Coinbase),

--- a/core/superchain.go
+++ b/core/superchain.go
@@ -1,0 +1,68 @@
+package core
+
+import (
+	"fmt"
+
+	"github.com/ethereum-optimism/superchain-registry/superchain"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+func LoadOPStackGenesis(chainID uint64) (*Genesis, error) {
+	chConfig, ok := superchain.OPChains[chainID]
+	if !ok {
+		return nil, fmt.Errorf("unknown chain ID: %d", chainID)
+	}
+
+	cfg, err := params.LoadOPStackChainConfig(chainID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load params.ChainConfig for chain %d: %w", chainID, err)
+	}
+
+	genesis := &Genesis{
+		Config:     cfg,
+		Nonce:      0,
+		Timestamp:  chConfig.Genesis.L2Time,
+		ExtraData:  []byte("BEDROCK"),
+		GasLimit:   30_000_000,
+		Difficulty: nil,
+		Mixhash:    common.Hash{},
+		Coinbase:   common.Address{},
+		Alloc:      nil,
+		Number:     0,
+		GasUsed:    0,
+		ParentHash: common.Hash{},
+		BaseFee:    nil,
+	}
+
+	// TODO: load state allocations
+
+	// TODO: exceptions for OP-Mainnet and OP-Goerli to handle pre-Bedrock history
+
+	if chConfig.Genesis.ExtraData != nil {
+		genesis.ExtraData = *chConfig.Genesis.ExtraData
+		if len(genesis.ExtraData) > 32 {
+			return nil, fmt.Errorf("chain must have 32 bytes or less extra-data in genesis, got %d", len(genesis.ExtraData))
+		}
+	}
+	// TODO: apply all genesis block values
+
+	// Verify we correctly produced the genesis config by recomputing the genesis-block-hash
+	genesisBlock := genesis.ToBlock()
+	genesisBlockHash := genesisBlock.Hash()
+	if [32]byte(chConfig.Genesis.L2.Hash) != genesisBlockHash {
+		return nil, fmt.Errorf("produced genesis with hash %s but expected %s", genesisBlockHash, chConfig.Genesis.L2.Hash)
+	}
+	return genesis, nil
+}
+
+func SystemConfigAddr(chainID uint64) (common.Address, error) {
+	// TODO(proto): when we move to CREATE-2 proxy addresses
+	// for SystemConfig contracts we can deterministically compute the system config addr,
+	// and do not have to load it from the superchain configs.
+	chConfig, ok := superchain.OPChains[chainID]
+	if !ok {
+		return common.Address{}, fmt.Errorf("unknown chain ID: %d", chainID)
+	}
+	return common.Address(chConfig.SystemConfigAddr), nil
+}

--- a/core/superchain.go
+++ b/core/superchain.go
@@ -81,7 +81,7 @@ func LoadOPStackGenesis(chainID uint64) (*Genesis, error) {
 	expectedHash := common.Hash([32]byte(chConfig.Genesis.L2.Hash))
 
 	// Verify we correctly produced the genesis config by recomputing the genesis-block-hash,
-	// if the genesis matches the chain genesis definition.
+	// and check the genesis matches the chain genesis definition.
 	if chConfig.Genesis.L2.Number != genesisBlock.NumberU64() {
 		switch chainID {
 		case 10:

--- a/core/superchain_test.go
+++ b/core/superchain_test.go
@@ -1,0 +1,11 @@
+package core
+
+import "testing"
+
+func TestOPStackGenesis(t *testing.T) {
+	gen, err := LoadOPStackGenesis(7777777)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("genesis block hash: %s", gen.ToBlock().Hash())
+}

--- a/core/superchain_test.go
+++ b/core/superchain_test.go
@@ -1,11 +1,17 @@
 package core
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/superchain-registry/superchain"
+)
 
 func TestOPStackGenesis(t *testing.T) {
-	gen, err := LoadOPStackGenesis(7777777)
-	if err != nil {
-		t.Fatal(err)
+	for id := range superchain.OPChains {
+		gen, err := LoadOPStackGenesis(id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("chain: %d, genesis block hash: %s", id, gen.ToBlock().Hash())
 	}
-	t.Logf("genesis block hash: %s", gen.ToBlock().Hash())
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/ethereum/go-ethereum
 go 1.19
 
 require (
+	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v0.3.0
 	github.com/VictoriaMetrics/fastcache v1.6.0
 	github.com/aws/aws-sdk-go-v2 v1.2.0
@@ -130,3 +131,5 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
+
+replace github.com/ethereum-optimism/superchain-registry/superchain v0.0.0 => ../superchain-registry/superchain

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/deckarep/golang-set/v2 v2.1.0
 	github.com/docker/docker v1.6.2
 	github.com/dop251/goja v0.0.0-20230122112309-96b1610dd4f7
-	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0
+	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20230817174831-5d3ca1966435
 	github.com/ethereum/c-kzg-4844 v0.2.0
 	github.com/fatih/color v1.7.0
 	github.com/fjl/gencodec v0.0.0-20230517082657-f9840df7b83e
@@ -131,5 +131,3 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
-
-replace github.com/ethereum-optimism/superchain-registry/superchain v0.0.0 => ../superchain-registry/superchain

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/ethereum/go-ethereum
 go 1.19
 
 require (
-	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v0.3.0
 	github.com/VictoriaMetrics/fastcache v1.6.0
 	github.com/aws/aws-sdk-go-v2 v1.2.0
@@ -20,6 +19,7 @@ require (
 	github.com/deckarep/golang-set/v2 v2.1.0
 	github.com/docker/docker v1.6.2
 	github.com/dop251/goja v0.0.0-20230122112309-96b1610dd4f7
+	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0
 	github.com/ethereum/c-kzg-4844 v0.2.0
 	github.com/fatih/color v1.7.0
 	github.com/fjl/gencodec v0.0.0-20230517082657-f9840df7b83e

--- a/go.sum
+++ b/go.sum
@@ -122,6 +122,8 @@ github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/etcd-io/bbolt v1.3.3/go.mod h1:ZF2nL25h33cCyBtcyWeZ2/I3HQOfTP+0PIEvHjkjCrw=
+github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20230817174831-5d3ca1966435 h1:2CzkJkkTLuVyoVFkoW5w6vDB2Q7eJzxXw/ybA17xjqM=
+github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20230817174831-5d3ca1966435/go.mod h1:v2YpePbdGBF0Gr6VWq49MFFmcTW0kRYZ2ingBJYWEwg=
 github.com/ethereum/c-kzg-4844 v0.2.0 h1:+cUvymlnoDDQgMInp25Bo3OmLajmmY8mLJ/tLjqd77Q=
 github.com/ethereum/c-kzg-4844 v0.2.0/go.mod h1:WI2Nd82DMZAAZI1wV2neKGost9EKjvbpQR9OqE5Qqa8=
 github.com/fasthttp-contrib/websocket v0.0.0-20160511215533-1f3b11f56072/go.mod h1:duJ4Jxv5lDcvg4QuQr0oowTf7dz4/CR8NtyCooz9HL8=

--- a/params/config.go
+++ b/params/config.go
@@ -31,12 +31,16 @@ var (
 	GoerliGenesisHash  = common.HexToHash("0xbf7e331f7f7c1dd2e05159666b3bf8bc7a8a3a9eb1d518969eab529dd9b88c1a")
 )
 
+const (
+	OPMainnetChainID  = 10
+	OPGoerliChainID   = 420
+	BaseGoerliChainID = 84531
+)
+
 // OP Stack chain config
 var (
-	OptimismGoerliChainId = big.NewInt(420)
 	// March 17, 2023 @ 7:00:00 pm UTC
 	OptimismGoerliRegolithTime = uint64(1679079600)
-	BaseGoerliChainId          = big.NewInt(84531)
 	// May 4, 2023 @ 5:00:00 pm UTC
 	BaseGoerliRegolithTime = uint64(1683219600)
 )

--- a/params/superchain.go
+++ b/params/superchain.go
@@ -8,6 +8,12 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
+func init() {
+	for id, ch := range superchain.OPChains {
+		NetworkNames[fmt.Sprintf("%d", id)] = ch.Name
+	}
+}
+
 func OPStackChainIDByName(name string) (uint64, error) {
 	for id, ch := range superchain.OPChains {
 		if ch.Chain+"-"+ch.Superchain == name {

--- a/params/superchain.go
+++ b/params/superchain.go
@@ -73,7 +73,7 @@ func LoadOPStackChainConfig(chainID uint64) (*ChainConfig, error) {
 
 	// special overrides for OP-Stack chains with pre-Regolith upgrade history
 	switch chainID {
-	case 420:
+	case OPGoerliChainID:
 		out.LondonBlock = big.NewInt(4061224)
 		out.ArrowGlacierBlock = big.NewInt(4061224)
 		out.GrayGlacierBlock = big.NewInt(4061224)
@@ -81,14 +81,14 @@ func LoadOPStackChainConfig(chainID uint64) (*ChainConfig, error) {
 		out.BedrockBlock = big.NewInt(4061224)
 		out.RegolithTime = &OptimismGoerliRegolithTime
 		out.Optimism.EIP1559Elasticity = 10
-	case 10:
+	case OPMainnetChainID:
 		out.BerlinBlock = big.NewInt(3950000)
 		out.LondonBlock = big.NewInt(105235063)
 		out.ArrowGlacierBlock = big.NewInt(105235063)
 		out.GrayGlacierBlock = big.NewInt(105235063)
 		out.MergeNetsplitBlock = big.NewInt(105235063)
 		out.BedrockBlock = big.NewInt(105235063)
-	case 84531:
+	case BaseGoerliChainID:
 		out.RegolithTime = &BaseGoerliRegolithTime
 	}
 

--- a/params/superchain.go
+++ b/params/superchain.go
@@ -1,0 +1,81 @@
+package params
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum-optimism/superchain-registry/superchain"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func LoadOPStackChainConfig(chainID uint64) (*ChainConfig, error) {
+	chConfig, ok := superchain.OPChains[chainID]
+	if !ok {
+		return nil, fmt.Errorf("unknown chain ID: %d", chainID)
+	}
+	superchainConfig, ok := superchain.Superchains[chConfig.Superchain]
+	if !ok {
+		return nil, fmt.Errorf("unknown superchain %q: %w", chConfig.Superchain)
+	}
+
+	genesisActivation := uint64(0)
+	out := &ChainConfig{
+		ChainID:                       new(big.Int).SetUint64(chainID),
+		HomesteadBlock:                common.Big0,
+		DAOForkBlock:                  nil,
+		DAOForkSupport:                false,
+		EIP150Block:                   common.Big0,
+		EIP155Block:                   common.Big0,
+		EIP158Block:                   common.Big0,
+		ByzantiumBlock:                common.Big0,
+		ConstantinopleBlock:           common.Big0,
+		PetersburgBlock:               common.Big0,
+		IstanbulBlock:                 common.Big0,
+		MuirGlacierBlock:              common.Big0,
+		BerlinBlock:                   common.Big0,
+		LondonBlock:                   common.Big0,
+		ArrowGlacierBlock:             common.Big0,
+		GrayGlacierBlock:              common.Big0,
+		MergeNetsplitBlock:            common.Big0,
+		ShanghaiTime:                  nil,
+		CancunTime:                    nil,
+		PragueTime:                    nil,
+		BedrockBlock:                  common.Big0,
+		RegolithTime:                  &genesisActivation,
+		TerminalTotalDifficulty:       common.Big0,
+		TerminalTotalDifficultyPassed: true,
+		Ethash:                        nil,
+		Clique:                        nil,
+		Optimism:                      &OptimismConfig{
+			EIP1559Elasticity:  6,
+			EIP1559Denominator: 50,
+		},
+	}
+
+	// note: no actual parameters are being loaded, yet.
+	// Future superchain upgrades are loaded from the superchain chConfig and applied to the geth ChainConfig here.
+	_ = superchainConfig.Config
+
+	// special overrides for OP-Stack chains with pre-Regolith upgrade history
+	switch chainID {
+	case 420:
+		out.LondonBlock = big.NewInt(4061224)
+		out.ArrowGlacierBlock = big.NewInt(4061224)
+		out.GrayGlacierBlock = big.NewInt(4061224)
+		out.MergeNetsplitBlock = big.NewInt(4061224)
+		out.BedrockBlock = big.NewInt(4061224)
+		out.RegolithTime = &OptimismGoerliRegolithTime
+		out.Optimism.EIP1559Elasticity = 10
+	case 10:
+		out.BerlinBlock =                   big.NewInt(3950000)
+		out.LondonBlock =                   big.NewInt(105235063)
+		out.ArrowGlacierBlock =             big.NewInt(105235063)
+		out.GrayGlacierBlock =              big.NewInt(105235063)
+		out.MergeNetsplitBlock =            big.NewInt(105235063)
+		out.BedrockBlock =                  big.NewInt(105235063)
+	case 84531:
+		out.RegolithTime = &BaseGoerliRegolithTime
+	}
+
+	return out, nil
+}

--- a/params/superchain.go
+++ b/params/superchain.go
@@ -15,7 +15,7 @@ func LoadOPStackChainConfig(chainID uint64) (*ChainConfig, error) {
 	}
 	superchainConfig, ok := superchain.Superchains[chConfig.Superchain]
 	if !ok {
-		return nil, fmt.Errorf("unknown superchain %q: %w", chConfig.Superchain)
+		return nil, fmt.Errorf("unknown superchain %q", chConfig.Superchain)
 	}
 
 	genesisActivation := uint64(0)
@@ -46,7 +46,7 @@ func LoadOPStackChainConfig(chainID uint64) (*ChainConfig, error) {
 		TerminalTotalDifficultyPassed: true,
 		Ethash:                        nil,
 		Clique:                        nil,
-		Optimism:                      &OptimismConfig{
+		Optimism: &OptimismConfig{
 			EIP1559Elasticity:  6,
 			EIP1559Denominator: 50,
 		},
@@ -67,12 +67,12 @@ func LoadOPStackChainConfig(chainID uint64) (*ChainConfig, error) {
 		out.RegolithTime = &OptimismGoerliRegolithTime
 		out.Optimism.EIP1559Elasticity = 10
 	case 10:
-		out.BerlinBlock =                   big.NewInt(3950000)
-		out.LondonBlock =                   big.NewInt(105235063)
-		out.ArrowGlacierBlock =             big.NewInt(105235063)
-		out.GrayGlacierBlock =              big.NewInt(105235063)
-		out.MergeNetsplitBlock =            big.NewInt(105235063)
-		out.BedrockBlock =                  big.NewInt(105235063)
+		out.BerlinBlock = big.NewInt(3950000)
+		out.LondonBlock = big.NewInt(105235063)
+		out.ArrowGlacierBlock = big.NewInt(105235063)
+		out.GrayGlacierBlock = big.NewInt(105235063)
+		out.MergeNetsplitBlock = big.NewInt(105235063)
+		out.BedrockBlock = big.NewInt(105235063)
 	case 84531:
 		out.RegolithTime = &BaseGoerliRegolithTime
 	}

--- a/params/superchain.go
+++ b/params/superchain.go
@@ -8,6 +8,15 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
+func OPStackChainIDByName(name string) (uint64, error) {
+	for id, ch := range superchain.OPChains {
+		if ch.Chain+"-"+ch.Superchain == name {
+			return id, nil
+		}
+	}
+	return 0, fmt.Errorf("unknown chain %q", name)
+}
+
 func LoadOPStackChainConfig(chainID uint64) (*ChainConfig, error) {
 	chConfig, ok := superchain.OPChains[chainID]
 	if !ok {


### PR DESCRIPTION
**Description**

To make OP-Stack chain configurations available across OP-Stack client implementations, we are experimenting with a "superchain-registry": one place that hosts all superchain configurations, which can then be embedded into the software for convenience & OP-Stack wide rollout of config changes.

These config utils are optional functionality (`geth init` with a custom genesis setup will always work, chains can be registered after launch at any time), but aims to increase convenience of running a node.

Using the registry data, a `core.Genesis` can be created from the embedded block-contents and genesis-allocation. This depends on tooling to build the genesis-allocation from a list of contract-references + contract bytecode registry: we need to deduplicate the many predeploy proxies, and deduplicate contracts between OP-Stack chains, to make embedding of the genesis-data sustainable while the number of OP-Stack chains in the Superchain grows.

This also provides a new CLI option: `--beta.op-network=...`: to choose the network configuration. Alternative ways to configure/load a chain are still fully supported. Geth does not have a `--network=name` flag like many consensus-layer clients do, and adding new flags for each network is not sustainable. Thus the choice for a CLI flag that picks an OP-Stack network. This a *beta* feautre, and may be changed or removed at a later point, since the superchain-registry is a work-in-progress that has not been approved yet by Optimism Governance.

**Note about OP-Mainnet and OP-Goerli legacy**: these two networks currently rely on a datadir to run post-bedrock. Building the chain-config is useful for `op-program`, but the genesis is not, yet (!). With the recent introduction of snap-sync, we can re-introduce the OP-Mainnet/Goerli genesis setup, and utilize snap-sync to fetch the state (instead of requiring a datadir!) and skip pre-bedrock block verification (other than data-consistency checks like the header hash-chain).


**Metadata**

Fix CLI-4208
