### PR TITLE
Disable tx admission into the txpool if `--rollup.sequencerhttp` is set

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1843,7 +1843,7 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		cfg.RollupHistoricalRPCTimeout = ctx.Duration(RollupHistoricalRPCTimeoutFlag.Name)
 	}
 	cfg.RollupDisableTxPoolGossip = ctx.Bool(RollupDisableTxPoolGossipFlag.Name)
-	cfg.RollupEnableTxPoolAdmission = cfg.RollupSequencerHTTP == "" || ctx.Bool(RollupEnableTxPoolAdmissionFlag.Name)
+	cfg.RollupDisableTxPoolAdmission = cfg.RollupSequencerHTTP != "" && !ctx.Bool(RollupEnableTxPoolAdmissionFlag.Name)
 	cfg.RollupAllowPendingTxFilters = ctx.Bool(RollupAllowPendingTxFilters.Name)
 	// Override any default configs for hard coded networks.
 	switch {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -883,9 +883,9 @@ var (
 		Usage:    "Disable transaction pool gossip.",
 		Category: flags.RollupCategory,
 	}
-	RollupDisableTxPoolAdmissionFlag = &cli.BoolFlag{
-		Name:     "rollup.disabletxpooladmission",
-		Usage:    "Do not add RPC-submitted transactions to the txpool (--rollup.sequencerhttp should be set).",
+	RollupEnableTxPoolAdmissionFlag = &cli.BoolFlag{
+		Name:     "rollup.enabletxpooladmission",
+		Usage:    "Add RPC-submitted transactions to the txpool (on by default if --rollup.sequencerhttp is not set).",
 		Category: flags.RollupCategory,
 	}
 	RollupComputePendingBlock = &cli.BoolFlag{
@@ -1843,7 +1843,7 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		cfg.RollupHistoricalRPCTimeout = ctx.Duration(RollupHistoricalRPCTimeoutFlag.Name)
 	}
 	cfg.RollupDisableTxPoolGossip = ctx.Bool(RollupDisableTxPoolGossipFlag.Name)
-	cfg.RollupDisableTxPoolAdmission = ctx.Bool(RollupDisableTxPoolAdmissionFlag.Name)
+	cfg.RollupEnableTxPoolAdmission = cfg.RollupSequencerHTTP == "" || ctx.Bool(RollupEnableTxPoolAdmissionFlag.Name)
 	cfg.RollupAllowPendingTxFilters = ctx.Bool(RollupAllowPendingTxFilters.Name)
 	// Override any default configs for hard coded networks.
 	switch {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -883,6 +883,11 @@ var (
 		Usage:    "Disable transaction pool gossip.",
 		Category: flags.RollupCategory,
 	}
+	RollupDisableTxPoolAdmissionFlag = &cli.BoolFlag{
+		Name:     "rollup.disabletxpooladmission",
+		Usage:    "Do not add RPC-submitted transactions to the txpool (--rollup.sequencerhttp should be set).",
+		Category: flags.RollupCategory,
+	}
 	RollupComputePendingBlock = &cli.BoolFlag{
 		Name:     "rollup.computependingblock",
 		Usage:    "By default the pending block equals the latest block to save resources and not leak txs from the tx-pool, this flag enables computing of the pending block from the tx-pool instead.",
@@ -1838,6 +1843,7 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		cfg.RollupHistoricalRPCTimeout = ctx.Duration(RollupHistoricalRPCTimeoutFlag.Name)
 	}
 	cfg.RollupDisableTxPoolGossip = ctx.Bool(RollupDisableTxPoolGossipFlag.Name)
+	cfg.RollupDisableTxPoolAdmission = ctx.Bool(RollupDisableTxPoolAdmissionFlag.Name)
 	cfg.RollupAllowPendingTxFilters = ctx.Bool(RollupAllowPendingTxFilters.Name)
 	// Override any default configs for hard coded networks.
 	switch {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -49,7 +49,7 @@ import (
 type EthAPIBackend struct {
 	extRPCEnabled       bool
 	allowUnprotectedTxs bool
-	enableTxPool        bool
+	disableTxPool       bool
 	eth                 *Ethereum
 	gpo                 *gasprice.Oracle
 }
@@ -301,7 +301,7 @@ func (b *EthAPIBackend) SendTx(ctx context.Context, tx *types.Transaction) error
 		if err := b.eth.seqRPCService.CallContext(ctx, nil, "eth_sendRawTransaction", hexutil.Encode(data)); err != nil {
 			return err
 		}
-		if !b.enableTxPool {
+		if b.disableTxPool {
 			return nil
 		}
 		// Retain tx in local tx pool after forwarding, for local RPC usage.
@@ -310,7 +310,7 @@ func (b *EthAPIBackend) SendTx(ctx context.Context, tx *types.Transaction) error
 		}
 		return nil
 	}
-	if !b.enableTxPool {
+	if b.disableTxPool {
 		return nil
 	}
 	return b.eth.txPool.AddLocal(tx)

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -49,7 +49,7 @@ import (
 type EthAPIBackend struct {
 	extRPCEnabled       bool
 	allowUnprotectedTxs bool
-	disableTxPool       bool
+	enableTxPool        bool
 	eth                 *Ethereum
 	gpo                 *gasprice.Oracle
 }
@@ -301,7 +301,7 @@ func (b *EthAPIBackend) SendTx(ctx context.Context, tx *types.Transaction) error
 		if err := b.eth.seqRPCService.CallContext(ctx, nil, "eth_sendRawTransaction", hexutil.Encode(data)); err != nil {
 			return err
 		}
-		if b.disableTxPool {
+		if !b.enableTxPool {
 			return nil
 		}
 		// Retain tx in local tx pool after forwarding, for local RPC usage.
@@ -310,7 +310,7 @@ func (b *EthAPIBackend) SendTx(ctx context.Context, tx *types.Transaction) error
 		}
 		return nil
 	}
-	if b.disableTxPool {
+	if !b.enableTxPool {
 		return nil
 	}
 	return b.eth.txPool.AddLocal(tx)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -251,7 +251,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	eth.miner = miner.New(eth, &config.Miner, eth.blockchain.Config(), eth.EventMux(), eth.engine, eth.isLocalBlock)
 	eth.miner.SetExtra(makeExtraData(config.Miner.ExtraData))
 
-	eth.APIBackend = &EthAPIBackend{stack.Config().ExtRPCEnabled(), stack.Config().AllowUnprotectedTxs, eth, nil}
+	eth.APIBackend = &EthAPIBackend{stack.Config().ExtRPCEnabled(), stack.Config().AllowUnprotectedTxs, config.RollupDisableTxPoolAdmission, eth, nil}
 	if eth.APIBackend.allowUnprotectedTxs {
 		log.Info("Unprotected transactions allowed")
 	}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -251,7 +251,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	eth.miner = miner.New(eth, &config.Miner, eth.blockchain.Config(), eth.EventMux(), eth.engine, eth.isLocalBlock)
 	eth.miner.SetExtra(makeExtraData(config.Miner.ExtraData))
 
-	eth.APIBackend = &EthAPIBackend{stack.Config().ExtRPCEnabled(), stack.Config().AllowUnprotectedTxs, config.RollupDisableTxPoolAdmission, eth, nil}
+	eth.APIBackend = &EthAPIBackend{stack.Config().ExtRPCEnabled(), stack.Config().AllowUnprotectedTxs, config.RollupEnableTxPoolAdmission, eth, nil}
 	if eth.APIBackend.allowUnprotectedTxs {
 		log.Info("Unprotected transactions allowed")
 	}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -251,7 +251,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	eth.miner = miner.New(eth, &config.Miner, eth.blockchain.Config(), eth.EventMux(), eth.engine, eth.isLocalBlock)
 	eth.miner.SetExtra(makeExtraData(config.Miner.ExtraData))
 
-	eth.APIBackend = &EthAPIBackend{stack.Config().ExtRPCEnabled(), stack.Config().AllowUnprotectedTxs, config.RollupEnableTxPoolAdmission, eth, nil}
+	eth.APIBackend = &EthAPIBackend{stack.Config().ExtRPCEnabled(), stack.Config().AllowUnprotectedTxs, config.RollupDisableTxPoolAdmission, eth, nil}
 	if eth.APIBackend.allowUnprotectedTxs {
 		log.Info("Unprotected transactions allowed")
 	}

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -168,11 +168,12 @@ type Config struct {
 	OverrideOptimismRegolith *uint64 `toml:",omitempty"`
 	OverrideOptimism         *bool
 
-	RollupSequencerHTTP         string
-	RollupHistoricalRPC         string
-	RollupHistoricalRPCTimeout  time.Duration
-	RollupDisableTxPoolGossip   bool
-	RollupAllowPendingTxFilters bool
+	RollupSequencerHTTP          string
+	RollupHistoricalRPC          string
+	RollupHistoricalRPCTimeout   time.Duration
+	RollupDisableTxPoolGossip    bool
+	RollupDisableTxPoolAdmission bool
+	RollupAllowPendingTxFilters  bool
 }
 
 // CreateConsensusEngine creates a consensus engine for the given chain config.

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -168,12 +168,12 @@ type Config struct {
 	OverrideOptimismRegolith *uint64 `toml:",omitempty"`
 	OverrideOptimism         *bool
 
-	RollupSequencerHTTP         string
-	RollupHistoricalRPC         string
-	RollupHistoricalRPCTimeout  time.Duration
-	RollupDisableTxPoolGossip   bool
-	RollupEnableTxPoolAdmission bool
-	RollupAllowPendingTxFilters bool
+	RollupSequencerHTTP          string
+	RollupHistoricalRPC          string
+	RollupHistoricalRPCTimeout   time.Duration
+	RollupDisableTxPoolGossip    bool
+	RollupDisableTxPoolAdmission bool
+	RollupAllowPendingTxFilters  bool
 }
 
 // CreateConsensusEngine creates a consensus engine for the given chain config.

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -168,12 +168,12 @@ type Config struct {
 	OverrideOptimismRegolith *uint64 `toml:",omitempty"`
 	OverrideOptimism         *bool
 
-	RollupSequencerHTTP          string
-	RollupHistoricalRPC          string
-	RollupHistoricalRPCTimeout   time.Duration
-	RollupDisableTxPoolGossip    bool
-	RollupDisableTxPoolAdmission bool
-	RollupAllowPendingTxFilters  bool
+	RollupSequencerHTTP         string
+	RollupHistoricalRPC         string
+	RollupHistoricalRPCTimeout  time.Duration
+	RollupDisableTxPoolGossip   bool
+	RollupEnableTxPoolAdmission bool
+	RollupAllowPendingTxFilters bool
 }
 
 // CreateConsensusEngine creates a consensus engine for the given chain config.


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Disables the local txpool, so that transactions submitted to the RPC will not get added to the txpool. This is enabled by default flag for any nodes that have `--rollup.sequencerhttp` and not `--mine`, and can be opted-out using `--rollup.enabletxpooladmission`.

**Tests**
No tests added.

**Additional context**

We are seeing some MEV issues with node providers with shared txpools.