### PR TITLE
subjective-safe head support

### DIFF
--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -62,6 +62,11 @@ func (bc *BlockChain) CurrentSafeBlock() *types.Header {
 	return bc.currentSafeBlock.Load()
 }
 
+// CurrentSubjectiveSafeBlock retrieves the current subjective-safe block (from cache).
+func (bc *BlockChain) CurrentSubjectiveSafeBlock() *types.Header {
+	return bc.currentSubjectiveSafeBlock.Load()
+}
+
 // HasHeader checks if a block header is present in the database or not, caching
 // it if present.
 func (bc *BlockChain) HasHeader(hash common.Hash, number uint64) bool {

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -232,6 +232,22 @@ func WriteFinalizedBlockHash(db ethdb.KeyValueWriter, hash common.Hash) {
 	}
 }
 
+// ReadSubjectiveSafeBlockHash retrieves the hash of the subjective-safe block.
+func ReadSubjectiveSafeBlockHash(db ethdb.KeyValueReader) common.Hash {
+	data, _ := db.Get(headSubjectiveSafeBlockKey)
+	if len(data) == 0 {
+		return common.Hash{}
+	}
+	return common.BytesToHash(data)
+}
+
+// WriteSubjectiveSafeBlockHash stores the hash of the subjective-safe block.
+func WriteSubjectiveSafeBlockHash(db ethdb.KeyValueWriter, hash common.Hash) {
+	if err := db.Put(headSubjectiveSafeBlockKey, hash.Bytes()); err != nil {
+		log.Crit("Failed to store last subjective-safe block's hash", "err", err)
+	}
+}
+
 // ReadLastPivotNumber retrieves the number of the last pivot block. If the node
 // full synced, the last pivot will always be nil.
 func ReadLastPivotNumber(db ethdb.KeyValueReader) *uint64 {

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -43,6 +43,9 @@ var (
 	// headFinalizedBlockKey tracks the latest known finalized block hash.
 	headFinalizedBlockKey = []byte("LastFinalized")
 
+	// headSubjectiveSafeBlockKey tracks the latest known subjective-safe block hash.
+	headSubjectiveSafeBlockKey = []byte("LastSubjectiveSafe")
+
 	// lastPivotKey tracks the last pivot block used by fast sync (to reenable on sethead).
 	lastPivotKey = []byte("LastPivot")
 

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -98,6 +98,13 @@ func (b *EthAPIBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumb
 		}
 		return nil, errors.New("safe block not found")
 	}
+	if number == rpc.SubjectiveSafeBlockNumber {
+		block := b.eth.blockchain.CurrentSubjectiveSafeBlock()
+		if block != nil {
+			return block, nil
+		}
+		return nil, errors.New("subjective safe block not found")
+	}
 	return b.eth.blockchain.GetHeaderByNumber(uint64(number)), nil
 }
 
@@ -150,6 +157,13 @@ func (b *EthAPIBackend) BlockByNumber(ctx context.Context, number rpc.BlockNumbe
 		header := b.eth.blockchain.CurrentSafeBlock()
 		if header == nil {
 			return nil, errors.New("safe block not found")
+		}
+		return b.eth.blockchain.GetBlock(header.Hash(), header.Number.Uint64()), nil
+	}
+	if number == rpc.SubjectiveSafeBlockNumber {
+		header := b.eth.blockchain.CurrentSubjectiveSafeBlock()
+		if header == nil {
+			return nil, errors.New("subjective safe block not found")
 		}
 		return b.eth.blockchain.GetBlock(header.Hash(), header.Number.Uint64()), nil
 	}

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -63,11 +63,12 @@ type jsonWriter interface {
 type BlockNumber int64
 
 const (
-	SafeBlockNumber      = BlockNumber(-4)
-	FinalizedBlockNumber = BlockNumber(-3)
-	LatestBlockNumber    = BlockNumber(-2)
-	PendingBlockNumber   = BlockNumber(-1)
-	EarliestBlockNumber  = BlockNumber(0)
+	SubjectiveSafeBlockNumber = BlockNumber(-10)
+	SafeBlockNumber           = BlockNumber(-4)
+	FinalizedBlockNumber      = BlockNumber(-3)
+	LatestBlockNumber         = BlockNumber(-2)
+	PendingBlockNumber        = BlockNumber(-1)
+	EarliestBlockNumber       = BlockNumber(0)
 )
 
 // UnmarshalJSON parses the given JSON fragment into a BlockNumber. It supports:
@@ -97,6 +98,9 @@ func (bn *BlockNumber) UnmarshalJSON(data []byte) error {
 		return nil
 	case "safe":
 		*bn = SafeBlockNumber
+		return nil
+	case "subjective-safe":
+		*bn = SubjectiveSafeBlockNumber
 		return nil
 	}
 
@@ -135,6 +139,8 @@ func (bn BlockNumber) String() string {
 		return "finalized"
 	case SafeBlockNumber:
 		return "safe"
+	case SubjectiveSafeBlockNumber:
+		return "subjective-safe"
 	default:
 		if bn < 0 {
 			return fmt.Sprintf("<invalid %d>", bn)
@@ -186,6 +192,10 @@ func (bnh *BlockNumberOrHash) UnmarshalJSON(data []byte) error {
 		return nil
 	case "safe":
 		bn := SafeBlockNumber
+		bnh.BlockNumber = &bn
+		return nil
+	case "subjective-safe":
+		bn := SubjectiveSafeBlockNumber
 		bnh.BlockNumber = &bn
 		return nil
 	default:


### PR DESCRIPTION
**Description**

Support for the notion of a "subjective safe head": when safety is assured locally, and not guaranteed objectively onchain, but possible to defend onchain with the local data.

This PR is a DRAFT, and should not be merged as-is. This is just to show the potential diff, for external OP-Stack mods to experiment with. This functionality should be end-to-end tested in op-e2e if integrated into a mod.
