### PR TITLE
Run `go generate` for `Genesis`

### DIFF
--- a/core/gen_genesis.go
+++ b/core/gen_genesis.go
@@ -31,6 +31,7 @@ func (g Genesis) MarshalJSON() ([]byte, error) {
 		GasUsed    math.HexOrDecimal64                         `json:"gasUsed"`
 		ParentHash common.Hash                                 `json:"parentHash"`
 		BaseFee    *math.HexOrDecimal256                       `json:"baseFeePerGas"`
+		StateHash  *common.Hash                                `json:"stateHash,omitempty"`
 	}
 	var enc Genesis
 	enc.Config = g.Config
@@ -51,6 +52,7 @@ func (g Genesis) MarshalJSON() ([]byte, error) {
 	enc.GasUsed = math.HexOrDecimal64(g.GasUsed)
 	enc.ParentHash = g.ParentHash
 	enc.BaseFee = (*math.HexOrDecimal256)(g.BaseFee)
+	enc.StateHash = g.StateHash
 	return json.Marshal(&enc)
 }
 
@@ -70,6 +72,7 @@ func (g *Genesis) UnmarshalJSON(input []byte) error {
 		GasUsed    *math.HexOrDecimal64                        `json:"gasUsed"`
 		ParentHash *common.Hash                                `json:"parentHash"`
 		BaseFee    *math.HexOrDecimal256                       `json:"baseFeePerGas"`
+		StateHash  *common.Hash                                `json:"stateHash,omitempty"`
 	}
 	var dec Genesis
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -119,6 +122,9 @@ func (g *Genesis) UnmarshalJSON(input []byte) error {
 	}
 	if dec.BaseFee != nil {
 		g.BaseFee = (*big.Int)(dec.BaseFee)
+	}
+	if dec.StateHash != nil {
+		g.StateHash = dec.StateHash
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

https://github.com/ethereum-optimism/op-geth/pull/113 added the `StateHash` field to `Genesis`. However, the (de)serialisation code wasn't updated, so that the additional field cannot be (de)serialised.

This PR includes the changes form running `go generate`.

