### PR TITLE
flags: remove beta prefix from rollup.halt flag

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -893,7 +893,7 @@ var (
 		Category: flags.RollupCategory,
 	}
 	RollupHaltOnIncompatibleProtocolVersionFlag = &cli.StringFlag{
-		Name:     "beta.rollup.halt",
+		Name:     "rollup.halt",
 		Usage:    "Opt-in option to halt on incompatible protocol version requirements of the given level (major/minor/patch/none), as signaled through the Engine API by the rollup node",
 		Category: flags.RollupCategory,
 	}


### PR DESCRIPTION
**Description**

This functionality is going out of beta, into regular release-candidate and release cycle.
