### PR TITLE
Add make target to create local forkdiff output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,3 +36,9 @@ devtools:
 	env GOBIN= go install ./cmd/abigen
 	@type "solc" 2> /dev/null || echo 'Please install solc'
 	@type "protoc" 2> /dev/null || echo 'Please install protoc'
+
+forkdiff:
+	docker run --rm \
+		--mount src=$(shell pwd),target=/host-pwd,type=bind \
+		protolambda/forkdiff:latest \
+		-repo /host-pwd/ -fork /host-pwd/fork.yaml -out /host-pwd/forkdiff.html


### PR DESCRIPTION
When changing fork.yaml, it is useful to check the updated output without relying on CI.

Feel free to close the PR without comment, if this is not useful to you.