### PR TITLE
Do not prefix deposit tx type twice when calculating receipt trie root.

### DIFF
--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -471,10 +471,7 @@ func (rs Receipts) EncodeIndex(i int, w *bytes.Buffer) {
 	}
 	w.WriteByte(r.Type)
 	switch r.Type {
-	case AccessListTxType, DynamicFeeTxType, BlobTxType:
-		rlp.Encode(w, data)
-	case DepositTxType:
-		w.WriteByte(DepositTxType)
+	case AccessListTxType, DynamicFeeTxType, BlobTxType, DepositTxType:
 		rlp.Encode(w, data)
 	default:
 		// For unsupported types, write nothing. Since this is for


### PR DESCRIPTION
**Description**

The upstream v1.12.2 update refactored the `Receipts.EncodeIndex` method so there was a single call to prefix the receipt tx type before switching on the tx type rather than needing code to write the type prefix for each separate type.

The deposit tx type case is added in our diff but wasn't updated to _not_ write the prefix so wound up with a duplicate prefix and so calculated the incorrect receipt root.