### PR TITLE
params: add chaosnet, update superchain-registry

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2199,8 +2199,7 @@ func tryMakeReadOnlyDatabase(ctx *cli.Context, stack *node.Node) ethdb.Database 
 
 func IsNetworkPreset(ctx *cli.Context) bool {
 	for _, flag := range NetworkFlags {
-		bFlag, _ := flag.(*cli.BoolFlag)
-		if ctx.IsSet(bFlag.Name) {
+		if ctx.IsSet(flag.Names()[0]) {
 			return true
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/deckarep/golang-set/v2 v2.1.0
 	github.com/docker/docker v24.0.5+incompatible
 	github.com/dop251/goja v0.0.0-20230806174421-c933cf95e127
-	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20230921190252-f29074de9e36
+	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20231001123245-7b48d3818686
 	github.com/ethereum/c-kzg-4844 v0.3.1
 	github.com/fatih/color v1.7.0
 	github.com/fjl/gencodec v0.0.0-20230517082657-f9840df7b83e

--- a/go.sum
+++ b/go.sum
@@ -173,8 +173,8 @@ github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.m
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/etcd-io/bbolt v1.3.3/go.mod h1:ZF2nL25h33cCyBtcyWeZ2/I3HQOfTP+0PIEvHjkjCrw=
-github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20230921190252-f29074de9e36 h1:HGDz8DcAkHvZy+iPnBa8yr4MdLqKpb7oAks01P08JOg=
-github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20230921190252-f29074de9e36/go.mod h1:q0u2UbyOr1q/y94AgMOj/V8b1KO05ZwILTR/qKt7Auo=
+github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20231001123245-7b48d3818686 h1:f57hd8G96c8ORWd4ameFpveSnHcb0hA2D1VatviwoDc=
+github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20231001123245-7b48d3818686/go.mod h1:q0u2UbyOr1q/y94AgMOj/V8b1KO05ZwILTR/qKt7Auo=
 github.com/ethereum/c-kzg-4844 v0.3.1 h1:sR65+68+WdnMKxseNWxSJuAv2tsUrihTpVBTfM/U5Zg=
 github.com/ethereum/c-kzg-4844 v0.3.1/go.mod h1:VewdlzQmpT5QSrVhbBuGoCdFJkpaJlO1aQputP83wc0=
 github.com/fasthttp-contrib/websocket v0.0.0-20160511215533-1f3b11f56072/go.mod h1:duJ4Jxv5lDcvg4QuQr0oowTf7dz4/CR8NtyCooz9HL8=

--- a/params/config.go
+++ b/params/config.go
@@ -36,6 +36,7 @@ const (
 	OPGoerliChainID   = 420
 	BaseGoerliChainID = 84531
 	devnetChainID     = 997
+	chaosnetChainID   = 888
 )
 
 // OP Stack chain config
@@ -46,6 +47,8 @@ var (
 	BaseGoerliRegolithTime = uint64(1683219600)
 	// March 5, 2023 @ 2:48:00 am UTC
 	devnetRegolithTime = uint64(1677984480)
+	// August 16, 2023 @ 3:34:22 am UTC
+	chaosnetRegolithTime = uint64(1692156862)
 )
 
 func newUint64(val uint64) *uint64 { return &val }

--- a/params/superchain.go
+++ b/params/superchain.go
@@ -98,6 +98,7 @@ func LoadOPStackChainConfig(chainID uint64) (*ChainConfig, error) {
 		out.RegolithTime = &devnetRegolithTime
 	case chaosnetChainID:
 		out.RegolithTime = &chaosnetRegolithTime
+		out.Optimism.EIP1559Elasticity = 10
 	}
 
 	return out, nil

--- a/params/superchain.go
+++ b/params/superchain.go
@@ -96,6 +96,8 @@ func LoadOPStackChainConfig(chainID uint64) (*ChainConfig, error) {
 		out.RegolithTime = &BaseGoerliRegolithTime
 	case devnetChainID:
 		out.RegolithTime = &devnetRegolithTime
+	case chaosnetChainID:
+		out.RegolithTime = &chaosnetRegolithTime
 	}
 
 	return out, nil


### PR DESCRIPTION
**Description**

- Update superchain-registry, to include chaosnet configuration
- Update regolith exceptions: Chaosnet is another edge-case. If we have any more of these we can add it to the registry instead, but with op-goerli/base/devnet/chaosnet I think we are done. (and there are `rollup.json` specific exceptions to the chaosnet too, compared to prod chains).
- Update EIP1559Elasticity exception

Testing the chaosnet config:
```bash
mkdir tmp
curl https://storage.googleapis.com/chaos-chain/genesis.json > tmp/genesis.json
go run ./cmd/geth init --datadir=tmp/gethdata tmp/genesis.json
go run ./cmd/geth dumpgenesis --datadir=tmp/gethdata > tmp/dump_genesis.json
diff <(jq --sort-keys . tmp/genesis.json) <(jq --sort-keys . tmp/dump_genesis.json)

go run ./cmd/geth dumpgenesis --beta.op-network=op-labs-chaosnet-0-goerli-dev-0 > tmp/superchain_dump_genesis.json
diff <(jq --sort-keys . tmp/genesis.json) <(jq --sort-keys . tmp/superchain_dump_genesis.json)
```
