### PR TITLE
params: devnet config fix

### DIFF
--- a/params/superchain.go
+++ b/params/superchain.go
@@ -96,6 +96,7 @@ func LoadOPStackChainConfig(chainID uint64) (*ChainConfig, error) {
 		out.RegolithTime = &BaseGoerliRegolithTime
 	case devnetChainID:
 		out.RegolithTime = &devnetRegolithTime
+		out.Optimism.EIP1559Elasticity = 10
 	case chaosnetChainID:
 		out.RegolithTime = &chaosnetRegolithTime
 		out.Optimism.EIP1559Elasticity = 10


### PR DESCRIPTION
Fix the devnet config.

Based on chaosnet PR, which fixes the `dumpgenesis` command.

Verify with:
```bash
curl https://storage.googleapis.com/oplabs-network-data/internal-devnet/genesis.json > tmp/devnet_genesis.json
go run ./cmd/geth init --datadir=tmp/devnetdata tmp/devnet_genesis.json
go run ./cmd/geth dumpgenesis --datadir=tmp/devnetdata > tmp/devnet_dump_genesis.json
diff <(jq --sort-keys . tmp/devnet_genesis.json) <(jq --sort-keys . tmp/devnet_dump_genesis.json)

go run ./cmd/geth dumpgenesis --beta.op-network=op-labs-devnet-0-goerli-dev-0 > tmp/superchain_devnet_dump_genesis.json
diff <(jq --sort-keys . tmp/devnet_genesis.json) <(jq --sort-keys . tmp/superchain_devnet_dump_genesis.json)
```


The existing devnets did not adopt the previous malformed superchain-registry sourced configuration yet, it reports eip1559Elasticity=10.
```bash
# 1) port-forward to the devnet sequencer
# 2) pull chain config:
cast rpc --rpc-url=http://localhost:8545 debug_chainConfig
```
```
{"chainId":997,"homesteadBlock":0,"eip150Block":0,"eip155Block":0,"eip158Block":0,"byzantiumBlock":0,"constantinopleBlock":0,"petersburgBlock":0,"istanbulBlock":0,"muirGlacierBlock":0,"berlinBlock":0,"londonBlock":0,"arrowGlacierBlock":0,"grayGlacierBlock":0,"mergeNetsplitBlock":0,"bedrockBlock":0,"regolithTime":1677984480,"terminalTotalDifficulty":0,"terminalTotalDifficultyPassed":true,"optimism":{"eip1559Elasticity":10,"eip1559Denominator":50}}
```