### PR TITLE
op-network option: promote from beta stage & apply chain-config overrides

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -310,8 +310,8 @@ func prepare(ctx *cli.Context) {
      to 0, and discovery is disabled.
 `)
 
-	case ctx.IsSet(utils.BetaOPNetworkFlag.Name):
-		log.Info("Starting geth on an OP network...", "network", ctx.String(utils.BetaOPNetworkFlag.Name))
+	case ctx.IsSet(utils.OPNetworkFlag.Name):
+		log.Info("Starting geth on an OP network...", "network", ctx.String(utils.OPNetworkFlag.Name))
 
 	case !ctx.IsSet(utils.NetworkIdFlag.Name):
 		log.Info("Starting Geth on Ethereum mainnet...")
@@ -328,10 +328,10 @@ func prepare(ctx *cli.Context) {
 			log.Info("Bumping default cache on mainnet", "provided", ctx.Int(utils.CacheFlag.Name), "updated", 4096)
 			ctx.Set(utils.CacheFlag.Name, strconv.Itoa(4096))
 		}
-	} else if ctx.String(utils.SyncModeFlag.Name) != "light" && !ctx.IsSet(utils.CacheFlag.Name) && ctx.IsSet(utils.BetaOPNetworkFlag.Name) {
+	} else if ctx.String(utils.SyncModeFlag.Name) != "light" && !ctx.IsSet(utils.CacheFlag.Name) && ctx.IsSet(utils.OPNetworkFlag.Name) {
 		// We haven't set the cache, but may used the OP network flag we may be on an OP stack mainnet.
-		if strings.Contains(ctx.String(utils.BetaOPNetworkFlag.Name), "mainnet") {
-			log.Info("Bumping default cache on mainnet", "provided", ctx.Int(utils.CacheFlag.Name), "updated", 4096, "network", ctx.String(utils.BetaOPNetworkFlag.Name))
+		if strings.Contains(ctx.String(utils.OPNetworkFlag.Name), "mainnet") {
+			log.Info("Bumping default cache on mainnet", "provided", ctx.Int(utils.CacheFlag.Name), "updated", 4096, "network", ctx.String(utils.OPNetworkFlag.Name))
 			ctx.Set(utils.CacheFlag.Name, strconv.Itoa(4096))
 		}
 	}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -157,9 +157,11 @@ var (
 		Category: flags.EthCategory,
 	}
 
-	BetaOPNetworkFlag = &cli.StringFlag{
-		Name:     "beta.op-network",
-		Usage:    "Beta feature: pick an OP Stack network configuration",
+	OPNetworkFlag = &cli.StringFlag{
+		Name:    "op-network",
+		Aliases: []string{"beta.op-network"},
+		Usage: "Select a pre-configured OP-Stack network (warning: op-mainnet and op-goerli require special sync," +
+			" datadir is recommended), options: " + strings.Join(params.OPStackChainNames(), ", "),
 		Category: flags.EthCategory,
 	}
 
@@ -1023,7 +1025,7 @@ var (
 		HoleskyFlag,
 	}
 	// NetworkFlags is the flag group of all built-in supported networks.
-	NetworkFlags = append([]cli.Flag{MainnetFlag, BetaOPNetworkFlag}, TestnetFlags...)
+	NetworkFlags = append([]cli.Flag{MainnetFlag, OPNetworkFlag}, TestnetFlags...)
 
 	// DatabaseFlags is the flag group of all database flags.
 	DatabaseFlags = []cli.Flag{
@@ -1055,8 +1057,8 @@ func MakeDataDir(ctx *cli.Context) string {
 		if ctx.Bool(HoleskyFlag.Name) {
 			return filepath.Join(path, "holesky")
 		}
-		if ctx.IsSet(BetaOPNetworkFlag.Name) {
-			return filepath.Join(path, ctx.String(BetaOPNetworkFlag.Name))
+		if ctx.IsSet(OPNetworkFlag.Name) {
+			return filepath.Join(path, ctx.String(OPNetworkFlag.Name))
 		}
 		return path
 	}
@@ -1570,8 +1572,8 @@ func SetDataDir(ctx *cli.Context, cfg *node.Config) {
 		cfg.DataDir = filepath.Join(node.DefaultDataDir(), "sepolia")
 	case ctx.Bool(HoleskyFlag.Name) && cfg.DataDir == node.DefaultDataDir():
 		cfg.DataDir = filepath.Join(node.DefaultDataDir(), "holesky")
-	case ctx.IsSet(BetaOPNetworkFlag.Name) && cfg.DataDir == node.DefaultDataDir():
-		cfg.DataDir = filepath.Join(node.DefaultDataDir(), ctx.String(BetaOPNetworkFlag.Name))
+	case ctx.IsSet(OPNetworkFlag.Name) && cfg.DataDir == node.DefaultDataDir():
+		cfg.DataDir = filepath.Join(node.DefaultDataDir(), ctx.String(OPNetworkFlag.Name))
 	}
 }
 
@@ -1737,7 +1739,7 @@ func CheckExclusive(ctx *cli.Context, args ...interface{}) {
 // SetEthConfig applies eth-related command line flags to the config.
 func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	// Avoid conflicting network flags
-	CheckExclusive(ctx, MainnetFlag, DeveloperFlag, GoerliFlag, SepoliaFlag, HoleskyFlag, BetaOPNetworkFlag)
+	CheckExclusive(ctx, MainnetFlag, DeveloperFlag, GoerliFlag, SepoliaFlag, HoleskyFlag, OPNetworkFlag)
 	CheckExclusive(ctx, LightServeFlag, SyncModeFlag, "light")
 	CheckExclusive(ctx, DeveloperFlag, ExternalSignerFlag) // Can't use both ephemeral unlocked and external signer
 
@@ -1978,7 +1980,7 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		if !ctx.IsSet(MinerGasPriceFlag.Name) {
 			cfg.Miner.GasPrice = big.NewInt(1)
 		}
-	case ctx.IsSet(BetaOPNetworkFlag.Name):
+	case ctx.IsSet(OPNetworkFlag.Name):
 		genesis := MakeGenesis(ctx)
 		if !ctx.IsSet(NetworkIdFlag.Name) {
 			cfg.NetworkId = genesis.Config.ChainID.Uint64()
@@ -2237,8 +2239,8 @@ func MakeGenesis(ctx *cli.Context) *core.Genesis {
 		genesis = core.DefaultSepoliaGenesisBlock()
 	case ctx.Bool(GoerliFlag.Name):
 		genesis = core.DefaultGoerliGenesisBlock()
-	case ctx.IsSet(BetaOPNetworkFlag.Name):
-		name := ctx.String(BetaOPNetworkFlag.Name)
+	case ctx.IsSet(OPNetworkFlag.Name):
+		name := ctx.String(OPNetworkFlag.Name)
 		ch, err := params.OPStackChainIDByName(name)
 		if err != nil {
 			Fatalf("failed to load OP-Stack chain %q: %v", name, err)

--- a/params/superchain.go
+++ b/params/superchain.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math/big"
+	"sort"
 	"strings"
 
 	"github.com/ethereum-optimism/superchain-registry/superchain"
@@ -25,6 +26,14 @@ func OPStackChainIDByName(name string) (uint64, error) {
 		}
 	}
 	return 0, fmt.Errorf("unknown chain %q", name)
+}
+
+func OPStackChainNames() (out []string) {
+	for _, ch := range superchain.OPChains {
+		out = append(out, ch.Chain+"-"+ch.Superchain)
+	}
+	sort.Strings(out)
+	return
 }
 
 func LoadOPStackChainConfig(chainID uint64) (*ChainConfig, error) {


### PR DESCRIPTION
**Description**

- Promote `--beta.op-network` to `--op-network`  (keep `beta.op-network` as alias for compatibility)
- Improve `--op-network` usage description, with shortlist of options:
```
   
    --op-network value, --beta.op-network value                                    ($GETH_OP_NETWORK)
          Select a pre-configured OP-Stack network (warning: op-mainnet and op-goerli
          require special sync, datadir is recommended), options: base-goerli,
          base-mainnet, base-sepolia, op-goerli, op-labs-chaosnet-0-goerli-dev-0,
          op-labs-devnet-0-goerli-dev-0, op-mainnet, op-sepolia, pgn-mainnet, pgn-sepolia,
          zora-goerli, zora-mainnet
   

```

~Depends on #148 (fixes CI, and implements remaining beta functionality).~

**Metadata**

Fix https://github.com/ethereum-optimism/client-pod/issues/82
