### PR TITLE
superchain: beta feature flag for overriding chain-config with superchain-registry

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -153,6 +153,7 @@ var (
 		utils.RollupDisableTxPoolGossipFlag,
 		utils.RollupComputePendingBlock,
 		utils.RollupHaltOnIncompatibleProtocolVersionFlag,
+		utils.RollupSuperchainUpgradesFlag,
 		configFileFlag,
 	}, utils.NetworkFlags, utils.DatabasePathFlags)
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -918,6 +918,11 @@ var (
 		Usage:    "Opt-in option to halt on incompatible protocol version requirements of the given level (major/minor/patch/none), as signaled through the Engine API by the rollup node",
 		Category: flags.RollupCategory,
 	}
+	RollupSuperchainUpgradesFlag = &cli.BoolFlag{
+		Name:     "beta.rollup.superchain-upgrades",
+		Usage:    "Beta feature: apply superchain-registry config changes to the local chain-configuration",
+		Category: flags.EthCategory,
+	}
 
 	// Metrics flags
 	MetricsEnabledFlag = &cli.BoolFlag{
@@ -1884,6 +1889,7 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	cfg.RollupDisableTxPoolGossip = ctx.Bool(RollupDisableTxPoolGossipFlag.Name)
 	cfg.RollupDisableTxPoolAdmission = cfg.RollupSequencerHTTP != "" && !ctx.Bool(RollupEnableTxPoolAdmissionFlag.Name)
 	cfg.RollupHaltOnIncompatibleProtocolVersion = ctx.String(RollupHaltOnIncompatibleProtocolVersionFlag.Name)
+	cfg.ApplySuperchainUpgrades = ctx.Bool(RollupSuperchainUpgradesFlag.Name)
 	// Override any default configs for hard coded networks.
 	switch {
 	case ctx.Bool(MainnetFlag.Name):

--- a/core/gen_genesis.go
+++ b/core/gen_genesis.go
@@ -18,22 +18,22 @@ var _ = (*genesisSpecMarshaling)(nil)
 // MarshalJSON marshals as JSON.
 func (g Genesis) MarshalJSON() ([]byte, error) {
 	type Genesis struct {
-		Config     *params.ChainConfig                         `json:"config"`
-		Nonce      math.HexOrDecimal64                         `json:"nonce"`
-		Timestamp  math.HexOrDecimal64                         `json:"timestamp"`
-		ExtraData  hexutil.Bytes                               `json:"extraData"`
-		GasLimit   math.HexOrDecimal64                         `json:"gasLimit"   gencodec:"required"`
-		Difficulty *math.HexOrDecimal256                       `json:"difficulty" gencodec:"required"`
-		Mixhash    common.Hash                                 `json:"mixHash"`
-		Coinbase   common.Address                              `json:"coinbase"`
-		Alloc      map[common.UnprefixedAddress]GenesisAccount `json:"alloc"      gencodec:"required"`
-		Number     math.HexOrDecimal64                         `json:"number"`
-		GasUsed    math.HexOrDecimal64                         `json:"gasUsed"`
-		ParentHash common.Hash                                 `json:"parentHash"`
-		BaseFee    *math.HexOrDecimal256                       `json:"baseFeePerGas"`
+		Config        *params.ChainConfig                         `json:"config"`
+		Nonce         math.HexOrDecimal64                         `json:"nonce"`
+		Timestamp     math.HexOrDecimal64                         `json:"timestamp"`
+		ExtraData     hexutil.Bytes                               `json:"extraData"`
+		GasLimit      math.HexOrDecimal64                         `json:"gasLimit"   gencodec:"required"`
+		Difficulty    *math.HexOrDecimal256                       `json:"difficulty" gencodec:"required"`
+		Mixhash       common.Hash                                 `json:"mixHash"`
+		Coinbase      common.Address                              `json:"coinbase"`
+		Alloc         map[common.UnprefixedAddress]GenesisAccount `json:"alloc"      gencodec:"required"`
+		Number        math.HexOrDecimal64                         `json:"number"`
+		GasUsed       math.HexOrDecimal64                         `json:"gasUsed"`
+		ParentHash    common.Hash                                 `json:"parentHash"`
+		BaseFee       *math.HexOrDecimal256                       `json:"baseFeePerGas"`
 		ExcessBlobGas *math.HexOrDecimal64                        `json:"excessBlobGas"`
 		BlobGasUsed   *math.HexOrDecimal64                        `json:"blobGasUsed"`
-		StateHash  *common.Hash                                `json:"stateHash,omitempty"`
+		StateHash     *common.Hash                                `json:"stateHash,omitempty"`
 	}
 	var enc Genesis
 	enc.Config = g.Config
@@ -78,7 +78,7 @@ func (g *Genesis) UnmarshalJSON(input []byte) error {
 		BaseFee       *math.HexOrDecimal256                       `json:"baseFeePerGas"`
 		ExcessBlobGas *math.HexOrDecimal64                        `json:"excessBlobGas"`
 		BlobGasUsed   *math.HexOrDecimal64                        `json:"blobGasUsed"`
-		StateHash  *common.Hash                                `json:"stateHash,omitempty"`
+		StateHash     *common.Hash                                `json:"stateHash,omitempty"`
 	}
 	var dec Genesis
 	if err := json.Unmarshal(input, &dec); err != nil {

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -25,6 +25,8 @@ import (
 	"math/big"
 	"strings"
 
+	"github.com/ethereum-optimism/superchain-registry/superchain"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
@@ -288,7 +290,8 @@ type ChainOverrides struct {
 	OverrideCancun *uint64
 	OverrideVerkle *uint64
 	// optimism
-	OverrideOptimismCanyon *uint64
+	OverrideOptimismCanyon  *uint64
+	ApplySuperchainUpgrades bool
 }
 
 // SetupGenesisBlock writes or updates the genesis block in db.
@@ -314,6 +317,19 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *trie.Database, gen
 	}
 	applyOverrides := func(config *params.ChainConfig) {
 		if config != nil {
+			// If applying the superchain-registry to a known OP-Stack chain,
+			// then override the local chain-config with that from the registry.
+			if overrides != nil && overrides.ApplySuperchainUpgrades && config.IsOptimism() && config.ChainID != nil && genesis.Config.ChainID.IsUint64() {
+				if _, ok := superchain.OPChains[config.ChainID.Uint64()]; ok {
+					conf, err := params.LoadOPStackChainConfig(config.ChainID.Uint64())
+					if err != nil {
+						log.Warn("failed to load chain config from superchain-registry, skipping override", "err", err, "chain_id", config.ChainID)
+					} else {
+						*config = *conf
+					}
+				}
+			}
+
 			if config.IsOptimism() && config.ChainID != nil && config.ChainID.Cmp(big.NewInt(params.OPGoerliChainID)) == 0 {
 				// Apply Optimism Goerli regolith time
 				config.RegolithTime = &params.OptimismGoerliRegolithTime

--- a/core/superchain_test.go
+++ b/core/superchain_test.go
@@ -28,6 +28,7 @@ func TestRegistryChainConfigOverride(t *testing.T) {
 	if genesis.Config.RegolithTime == nil {
 		t.Fatal("expected non-nil regolith time")
 	}
+	expectedRegolithTime := *genesis.Config.RegolithTime
 	genesis.Config.RegolithTime = nil
 
 	// initialize the DB
@@ -47,5 +48,7 @@ func TestRegistryChainConfigOverride(t *testing.T) {
 	// check if we have a corrected chain config
 	if chainConfig.RegolithTime == nil {
 		t.Fatal("expected regolith time to be corrected, but time is still nil")
+	} else if *chainConfig.RegolithTime != expectedRegolithTime {
+		t.Fatalf("expected regolith time to be %d, but got %d", expectedRegolithTime, *chainConfig.RegolithTime)
 	}
 }

--- a/core/superchain_test.go
+++ b/core/superchain_test.go
@@ -4,6 +4,9 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/superchain-registry/superchain"
+
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/trie"
 )
 
 func TestOPStackGenesis(t *testing.T) {
@@ -13,5 +16,36 @@ func TestOPStackGenesis(t *testing.T) {
 			t.Fatal(err)
 		}
 		t.Logf("chain: %d, genesis block hash: %s", id, gen.ToBlock().Hash())
+	}
+}
+
+func TestRegistryChainConfigOverride(t *testing.T) {
+	db := rawdb.NewMemoryDatabase()
+	genesis, err := LoadOPStackGenesis(10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if genesis.Config.RegolithTime == nil {
+		t.Fatal("expected non-nil regolith time")
+	}
+	genesis.Config.RegolithTime = nil
+
+	// initialize the DB
+	tdb := trie.NewDatabase(db, newDbConfig(rawdb.PathScheme))
+	genesis.MustCommit(db, tdb)
+	bl := genesis.ToBlock()
+	rawdb.WriteCanonicalHash(db, bl.Hash(), 0)
+	rawdb.WriteBlock(db, bl)
+
+	// create chain config, even with incomplete genesis input: the chain config should be corrected
+	chainConfig, _, err := SetupGenesisBlockWithOverride(db, tdb, genesis, &ChainOverrides{
+		ApplySuperchainUpgrades: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// check if we have a corrected chain config
+	if chainConfig.RegolithTime == nil {
+		t.Fatal("expected regolith time to be corrected, but time is still nil")
 	}
 }

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -215,6 +215,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	if config.OverrideOptimismCanyon != nil {
 		overrides.OverrideOptimismCanyon = config.OverrideOptimismCanyon
 	}
+	overrides.ApplySuperchainUpgrades = config.ApplySuperchainUpgrades
 	eth.blockchain, err = core.NewBlockChain(chainDb, cacheConfig, config.Genesis, &overrides, eth.engine, vmConfig, eth.shouldPreserve, &config.TransactionHistory)
 	if err != nil {
 		return nil, err

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -170,6 +170,9 @@ type Config struct {
 
 	OverrideOptimismCanyon *uint64 `toml:",omitempty"`
 
+	// ApplySuperchainUpgrades requests the node to load chain-configuration from the superchain-registry.
+	ApplySuperchainUpgrades bool `toml:",omitempty"`
+
 	RollupSequencerHTTP                     string
 	RollupHistoricalRPC                     string
 	RollupHistoricalRPCTimeout              time.Duration

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -57,6 +57,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		OverrideCancun                          *uint64 `toml:",omitempty"`
 		OverrideVerkle                          *uint64 `toml:",omitempty"`
 		OverrideOptimismCanyon                  *uint64 `toml:",omitempty"`
+		ApplySuperchainUpgrades                 bool    `toml:",omitempty"`
 		RollupSequencerHTTP                     string
 		RollupHistoricalRPC                     string
 		RollupHistoricalRPCTimeout              time.Duration
@@ -105,6 +106,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.OverrideCancun = c.OverrideCancun
 	enc.OverrideVerkle = c.OverrideVerkle
 	enc.OverrideOptimismCanyon = c.OverrideOptimismCanyon
+	enc.ApplySuperchainUpgrades = c.ApplySuperchainUpgrades
 	enc.RollupSequencerHTTP = c.RollupSequencerHTTP
 	enc.RollupHistoricalRPC = c.RollupHistoricalRPC
 	enc.RollupHistoricalRPCTimeout = c.RollupHistoricalRPCTimeout
@@ -157,6 +159,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		OverrideCancun                          *uint64 `toml:",omitempty"`
 		OverrideVerkle                          *uint64 `toml:",omitempty"`
 		OverrideOptimismCanyon                  *uint64 `toml:",omitempty"`
+		ApplySuperchainUpgrades                 *bool   `toml:",omitempty"`
 		RollupSequencerHTTP                     *string
 		RollupHistoricalRPC                     *string
 		RollupHistoricalRPCTimeout              *time.Duration
@@ -287,6 +290,9 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.OverrideOptimismCanyon != nil {
 		c.OverrideOptimismCanyon = dec.OverrideOptimismCanyon
+	}
+	if dec.ApplySuperchainUpgrades != nil {
+		c.ApplySuperchainUpgrades = *dec.ApplySuperchainUpgrades
 	}
 	if dec.RollupSequencerHTTP != nil {
 		c.RollupSequencerHTTP = *dec.RollupSequencerHTTP


### PR DESCRIPTION
**Description**

Adds chain-config override functionality, to upgrade existing chain configs (in DB, from previous runs) with the chain config as defined in the superchain-registry.
This is optional, and behind a beta feature-flag for rollout: `--beta.rollup.superchain-upgrades`

This also fixes some formatting in the genesis config for CI, which appeared to be formatted incorrectly due to prior merges.

**Tests**

Test that with `overrides.ApplySuperchainUpgrades` the superchain-registry chain-configuration is applied to the local chain configuration.

**Metadata**

Fix https://github.com/ethereum-optimism/client-pod/issues/73
