### PR TITLE
Increase the maximum size for engine API requests via http

### DIFF
--- a/rpc/http.go
+++ b/rpc/http.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	maxRequestContentLength = 1024 * 1024 * 5
+	maxRequestContentLength = 1024 * 1024 * 32
 	contentType             = "application/json"
 )
 


### PR DESCRIPTION
**Description**

Bumps up the maximum payload size for Engine API http requests to 32Mb so they're equivalent with web sockets.
