### PR TITLE
debug: debug RPC to view underpriced tx-fetcher state and util to clear

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -54,6 +54,14 @@ type EthAPIBackend struct {
 	gpo                 *gasprice.Oracle
 }
 
+func (b *EthAPIBackend) ClearUnderpriced() {
+	b.eth.ClearUnderpriced()
+}
+
+func (b *EthAPIBackend) ListUnderpriced() []common.Hash {
+	return b.eth.ListUnderpriced()
+}
+
 // ChainConfig returns the active chain configuration.
 func (b *EthAPIBackend) ChainConfig() *params.ChainConfig {
 	return b.eth.blockchain.Config()

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -355,6 +355,14 @@ func (s *Ethereum) APIs() []rpc.API {
 	}...)
 }
 
+func (s *Ethereum) ClearUnderpriced() {
+	s.handler.txFetcher.ClearUnderpriced()
+}
+
+func (s *Ethereum) ListUnderpriced() []common.Hash {
+	return s.handler.txFetcher.ListUnderpriced()
+}
+
 func (s *Ethereum) ResetWithGenesisBlock(gb *types.Block) {
 	s.blockchain.ResetWithGenesisBlock(gb)
 }

--- a/eth/fetcher/tx_fetcher.go
+++ b/eth/fetcher/tx_fetcher.go
@@ -95,6 +95,7 @@ var (
 	txFetcherQueueingHashes = metrics.NewRegisteredGauge("eth/fetcher/transaction/queueing/hashes", nil)
 	txFetcherFetchingPeers  = metrics.NewRegisteredGauge("eth/fetcher/transaction/fetching/peers", nil)
 	txFetcherFetchingHashes = metrics.NewRegisteredGauge("eth/fetcher/transaction/fetching/hashes", nil)
+	totalUnderpricedTxs     = metrics.NewRegisteredGauge("eth/fetcher/transaction/underpriced/total", nil)
 )
 
 // txAnnounce is the notification of the availability of a batch
@@ -211,6 +212,14 @@ func NewTxFetcherForTests(
 	}
 }
 
+func (f *TxFetcher) ClearUnderpriced() {
+	f.underpriced.Clear()
+}
+
+func (f *TxFetcher) ListUnderpriced() []common.Hash {
+	return f.underpriced.ToSlice()
+}
+
 // Notify announces the fetcher of the potential availability of a new batch of
 // transactions in the network.
 func (f *TxFetcher) Notify(peer string, hashes []common.Hash) error {
@@ -322,6 +331,7 @@ func (f *TxFetcher) Enqueue(peer string, txs []*types.Transaction, direct bool) 
 		knownMeter.Mark(duplicate)
 		underpricedMeter.Mark(underpriced)
 		otherRejectMeter.Mark(otherreject)
+		totalUnderpricedTxs.Update(int64(f.underpriced.Cardinality()))
 
 		// If 'other reject' is >25% of the deliveries in any batch, sleep a bit.
 		if otherreject > 128/4 {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -2154,17 +2154,21 @@ func NewDebugAPI(b Backend) *DebugAPI {
 	return &DebugAPI{b: b}
 }
 
-func (api *DebugAPI) ClearUnderpriced() {
+func (api *DebugAPI) ClearUnderpriced() error {
 	if cl, ok := api.b.(interface{ ClearUnderpriced() }); ok {
 		cl.ClearUnderpriced()
+		return nil
+	} else {
+		return errors.New("API backend unable to clear underpriced txs")
 	}
 }
 
-func (api *DebugAPI) ListUnderpriced() []common.Hash {
+func (api *DebugAPI) ListUnderpriced() ([]common.Hash, error) {
 	if cl, ok := api.b.(interface{ ListUnderpriced() []common.Hash }); ok {
-		return cl.ListUnderpriced()
+		return cl.ListUnderpriced(), nil
+	} else {
+		return nil, errors.New("API backend unable to list underpriced txs")
 	}
-	return nil
 }
 
 // GetRawHeader retrieves the RLP encoding for a single header.

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -2154,6 +2154,19 @@ func NewDebugAPI(b Backend) *DebugAPI {
 	return &DebugAPI{b: b}
 }
 
+func (api *DebugAPI) ClearUnderpriced() {
+	if cl, ok := api.b.(interface{ ClearUnderpriced() }); ok {
+		cl.ClearUnderpriced()
+	}
+}
+
+func (api *DebugAPI) ListUnderpriced() []common.Hash {
+	if cl, ok := api.b.(interface{ ListUnderpriced() []common.Hash }); ok {
+		return cl.ListUnderpriced()
+	}
+	return nil
+}
+
 // GetRawHeader retrieves the RLP encoding for a single header.
 func (api *DebugAPI) GetRawHeader(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (hexutil.Bytes, error) {
 	var hash common.Hash


### PR DESCRIPTION
**Description**

Debug utils to review the tx-fetcher underpriced-txs state.

The issue is already fixed in upstream geth, in `v1.13.2`. This PR is based on an older op-geth version (`v1.101200.1`, based on upstream `v1.12.0`), to act in prior deployments where necessary.

- `debug_clearUnderpriced` to clear state
- `debug_listUnderpriced` to see tx-hashes that are considered too underpriced to refetch

