### PR TITLE
params: handle protocol-version semver prerelease edge-case in version comparison

### DIFF
--- a/eth/catalyst/superchain.go
+++ b/eth/catalyst/superchain.go
@@ -60,5 +60,7 @@ func LogProtocolVersionSupport(logger log.Logger, local, other params.ProtocolVe
 		logger.Warn(fmt.Sprintf("Failed to recognize %s protocol version signal version-type", name))
 	case params.EmptyVersion:
 		logger.Debug(fmt.Sprintf("No %s protocol version available to check", name))
+	case params.InvalidVersion:
+		logger.Warn(fmt.Sprintf("Invalid protocol version comparison with %s", name))
 	}
 }

--- a/eth/catalyst/superchain_test.go
+++ b/eth/catalyst/superchain_test.go
@@ -69,7 +69,6 @@ func TestSignalSuperchainV1Halt(t *testing.T) {
 			if preRelease != 0 { // transform back from prerelease, so we can do a clean version bump
 				if patch != 0 {
 					patch -= 1
-					preRelease = 0
 				} else if minor != 0 {
 					// can't patch-bump e.g. v3.1.0-1, the prerelease forces a minor bump:
 					// v3.0.999 is lower than the prerelease, v3.1.1-1 is a prerelease of v3.1.1.

--- a/eth/catalyst/superchain_test.go
+++ b/eth/catalyst/superchain_test.go
@@ -39,6 +39,7 @@ func TestSignalSuperchainV1(t *testing.T) {
 }
 
 func TestSignalSuperchainV1Halt(t *testing.T) {
+	// Note: depending on the params.OPStackSupport some types of bumps are not possible with active prerelease
 	testCases := []struct {
 		cfg  string
 		bump string
@@ -56,6 +57,7 @@ func TestSignalSuperchainV1Halt(t *testing.T) {
 		{"patch", "patch", true},
 	}
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.cfg+"_"+tc.bump, func(t *testing.T) {
 			genesis, preMergeBlocks := generateMergeChain(2, false)
 			ethcfg := &ethconfig.Config{Genesis: genesis, SyncMode: downloader.FullSync, TrieTimeout: time.Minute, TrieDirtyCache: 256, TrieCleanCache: 256}
@@ -64,6 +66,25 @@ func TestSignalSuperchainV1Halt(t *testing.T) {
 			defer n.Close() // close at the end, regardless of any prior (failed) closing
 			api := NewConsensusAPI(ethservice)
 			_, build, major, minor, patch, preRelease := params.OPStackSupport.Parse()
+			if preRelease != 0 { // transform back from prerelease, so we can do a clean version bump
+				if patch != 0 {
+					patch -= 1
+					preRelease = 0
+				} else if minor != 0 {
+					// can't patch-bump e.g. v3.1.0-1, the prerelease forces a minor bump:
+					// v3.0.999 is lower than the prerelease, v3.1.1-1 is a prerelease of v3.1.1.
+					if tc.bump == "patch" {
+						t.Skip()
+					}
+					minor -= 1
+				} else if major != 0 {
+					if tc.bump == "minor" || tc.bump == "patch" { // can't minor-bump or patch-bump
+						t.Skip()
+					}
+					major -= 1
+				}
+				preRelease = 0
+			}
 			majorSignal, minorSignal, patchSignal := major, minor, patch
 			switch tc.bump {
 			case "major":
@@ -84,14 +105,14 @@ func TestSignalSuperchainV1Halt(t *testing.T) {
 				t.Fatalf("expected %s but got %s", params.OPStackSupport, out)
 			}
 			closeErr := n.Close()
-			if tc.halt {
+			if !tc.halt {
 				// assert no halt by closing, and not getting any error
-				if closeErr == nil {
+				if closeErr != nil {
 					t.Fatalf("expected not to have closed already, but just closed without error")
 				}
 			} else {
-				// assert halt by closing again, and seeing if things error
-				if closeErr == node.ErrNodeStopped {
+				// assert halt by closing again, and seeing if we are not stopped already
+				if closeErr != node.ErrNodeStopped {
 					t.Fatalf("expected to have already closed and get a ErrNodeStopped error, but got %v", closeErr)
 				}
 			}

--- a/params/superchain_test.go
+++ b/params/superchain_test.go
@@ -59,8 +59,69 @@ func TestProtocolVersion_Compare(t *testing.T) {
 			B:   HumanProtocolVersion{0, 1, 3, 3, 3, [8]byte{3}},
 			Cmp: EmptyVersion,
 		},
+		{
+			A:   HumanProtocolVersion{0, 4, 0, 0, 0, [8]byte{}},
+			B:   HumanProtocolVersion{0, 4, 0, 0, 1, [8]byte{}},
+			Cmp: AheadMajor,
+		},
+		{
+			A:   HumanProtocolVersion{0, 4, 1, 0, 0, [8]byte{}},
+			B:   HumanProtocolVersion{0, 4, 1, 0, 1, [8]byte{}},
+			Cmp: AheadMinor,
+		},
+		{
+			A:   HumanProtocolVersion{0, 4, 0, 1, 0, [8]byte{}},
+			B:   HumanProtocolVersion{0, 4, 0, 1, 1, [8]byte{}},
+			Cmp: AheadPatch,
+		},
+		{
+			A:   HumanProtocolVersion{0, 4, 0, 0, 2, [8]byte{}},
+			B:   HumanProtocolVersion{0, 4, 0, 0, 1, [8]byte{}},
+			Cmp: AheadPrerelease,
+		},
+		{
+			A:   HumanProtocolVersion{0, 4, 1, 0, 1, [8]byte{}},
+			B:   HumanProtocolVersion{0, 4, 0, 0, 0, [8]byte{}},
+			Cmp: AheadPatch,
+		},
+		{
+			A:   HumanProtocolVersion{0, 4, 0, 1, 1, [8]byte{}},
+			B:   HumanProtocolVersion{0, 4, 0, 0, 0, [8]byte{}},
+			Cmp: AheadPrerelease,
+		},
+		{
+			A:   HumanProtocolVersion{0, 4, 1, 1, 1, [8]byte{}},
+			B:   HumanProtocolVersion{0, 4, 0, 0, 0, [8]byte{}},
+			Cmp: AheadMinor,
+		},
+		{
+			A:   HumanProtocolVersion{0, 4, 0, 2, 1, [8]byte{}},
+			B:   HumanProtocolVersion{0, 4, 0, 0, 0, [8]byte{}},
+			Cmp: AheadPatch,
+		},
+		{
+			A:   HumanProtocolVersion{0, 5, 0, 1, 1, [8]byte{}},
+			B:   HumanProtocolVersion{0, 4, 0, 0, 0, [8]byte{}},
+			Cmp: AheadMajor,
+		},
+		{
+			A:   HumanProtocolVersion{0, 1, 0, 0, 1, [8]byte{}},
+			B:   HumanProtocolVersion{0, 0, 9, 0, 0, [8]byte{}},
+			Cmp: AheadMinor,
+		},
+		{
+			A:   HumanProtocolVersion{0, 0, 1, 0, 1, [8]byte{}},
+			B:   HumanProtocolVersion{0, 0, 0, 9, 0, [8]byte{}},
+			Cmp: AheadPatch,
+		},
+		{
+			A:   HumanProtocolVersion{0, 1, ^uint32(0), 0, 1, [8]byte{}},
+			B:   HumanProtocolVersion{0, 0, 1, 0, 0, [8]byte{}},
+			Cmp: InvalidVersion,
+		},
 	}
 	for i, tc := range testCases {
+		tc := tc // not a parallel sub-test, but better than a flake
 		t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
 			a := ProtocolVersionV0{tc.A.Build, tc.A.Major, tc.A.Minor, tc.A.Patch, tc.A.Prerelease}.Encode()
 			a[0] = tc.A.VersionType


### PR DESCRIPTION
**Description**

`v3.1.0` should be considered *higher* than `v3.1.0-1`.
And the version difference should be reported accurattely, so that there's differentiation between major/minor/patch pre-release differences.

**Tests**

Adds new test cases to cover the different ways A can be ahead of B. The test-runner automatically tests the inverse too, to cover the outdated-cases.
