### PR TITLE
Bump the geth cache on OP stack mainnet chains

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -311,6 +311,9 @@ func prepare(ctx *cli.Context) {
      to 0, and discovery is disabled.
 `)
 
+	case ctx.IsSet(utils.BetaOPNetworkFlag.Name):
+		log.Info("Starting geth on an OP network...", "network", ctx.String(utils.BetaOPNetworkFlag.Name))
+
 	case !ctx.IsSet(utils.NetworkIdFlag.Name):
 		log.Info("Starting Geth on Ethereum mainnet...")
 	}
@@ -322,7 +325,14 @@ func prepare(ctx *cli.Context) {
 			!ctx.IsSet(utils.GoerliFlag.Name) &&
 			!ctx.IsSet(utils.DeveloperFlag.Name) {
 			// Nope, we're really on mainnet. Bump that cache up!
+			// Note: If we don't set the OPNetworkFlag and have already initialized the database, we may hit this case.
 			log.Info("Bumping default cache on mainnet", "provided", ctx.Int(utils.CacheFlag.Name), "updated", 4096)
+			ctx.Set(utils.CacheFlag.Name, strconv.Itoa(4096))
+		}
+	} else if ctx.String(utils.SyncModeFlag.Name) != "light" && !ctx.IsSet(utils.CacheFlag.Name) && ctx.IsSet(utils.BetaOPNetworkFlag.Name) {
+		// We haven't set the cache, but may used the OP network flag we may be on an OP stack mainnet.
+		if strings.Contains(ctx.String(utils.BetaOPNetworkFlag.Name), "mainnet") {
+			log.Info("Bumping default cache on mainnet", "provided", ctx.Int(utils.CacheFlag.Name), "updated", 4096, "network", ctx.String(utils.BetaOPNetworkFlag.Name))
 			ctx.Set(utils.CacheFlag.Name, strconv.Itoa(4096))
 		}
 	}


### PR DESCRIPTION
**Description**

This now checks if the `--beta.op-network` flag is set & then further checks if it is a mainnet network or a testnet. If it is a mainnet network, the cache sized is bumped to 4 gigs.

**Tests**

None. Not even manual.

**Metadata**

- Fixes #155 
