### PR TITLE
Change EIP 1559 Denominator with Canyon

### DIFF
--- a/consensus/misc/eip1559/eip1559.go
+++ b/consensus/misc/eip1559/eip1559.go
@@ -79,7 +79,7 @@ func CalcBaseFee(config *params.ChainConfig, parent *types.Header) *big.Int {
 		num.SetUint64(parent.GasUsed - parentGasTarget)
 		num.Mul(num, parent.BaseFee)
 		num.Div(num, denom.SetUint64(parentGasTarget))
-		num.Div(num, denom.SetUint64(config.BaseFeeChangeDenominator()))
+		num.Div(num, denom.SetUint64(config.BaseFeeChangeDenominator(parent.Time)))
 		baseFeeDelta := math.BigMax(num, common.Big1)
 
 		return num.Add(parent.BaseFee, baseFeeDelta)
@@ -89,7 +89,7 @@ func CalcBaseFee(config *params.ChainConfig, parent *types.Header) *big.Int {
 		num.SetUint64(parentGasTarget - parent.GasUsed)
 		num.Mul(num, parent.BaseFee)
 		num.Div(num, denom.SetUint64(parentGasTarget))
-		num.Div(num, denom.SetUint64(config.BaseFeeChangeDenominator()))
+		num.Div(num, denom.SetUint64(config.BaseFeeChangeDenominator(parent.Time)))
 		baseFee := num.Sub(parent.BaseFee, num)
 
 		return math.BigMax(baseFee, common.Big0)

--- a/consensus/misc/eip1559/eip1559_test.go
+++ b/consensus/misc/eip1559/eip1559_test.go
@@ -55,6 +55,20 @@ func config() *params.ChainConfig {
 	return config
 }
 
+func opConfig() *params.ChainConfig {
+	config := copyConfig(params.TestChainConfig)
+	config.LondonBlock = big.NewInt(5)
+	ct := uint64(10)
+	config.CanyonTime = &ct
+	config.Optimism = &params.OptimismConfig{
+		EIP1559Elasticity:            6,
+		EIP1559Denominator:           50,
+		EIP1559DenominatorPostCanyon: 250,
+		L2BlockTime:                  2,
+	}
+	return config
+}
+
 // TestBlockGasLimits tests the gasLimit checks for blocks both across
 // the EIP-1559 boundary and post-1559 blocks
 func TestBlockGasLimits(t *testing.T) {
@@ -125,6 +139,39 @@ func TestCalcBaseFee(t *testing.T) {
 			BaseFee:  big.NewInt(test.parentBaseFee),
 		}
 		if have, want := CalcBaseFee(config(), parent), big.NewInt(test.expectedBaseFee); have.Cmp(want) != 0 {
+			t.Errorf("test %d: have %d  want %d, ", i, have, want)
+		}
+	}
+}
+
+// TestCalcBaseFeeOptimism assumes all blocks are 1559-blocks but tests the Canyon activation
+func TestCalcBaseFeeOptimism(t *testing.T) {
+	tests := []struct {
+		parentBaseFee   int64
+		parentGasLimit  uint64
+		parentGasUsed   uint64
+		expectedBaseFee int64
+		postCanyon      bool
+	}{
+		{params.InitialBaseFee, 30_000_000, 5_000_000, params.InitialBaseFee, false}, // usage == target
+		{params.InitialBaseFee, 30_000_000, 4_000_000, 996000000, false},             // usage below target
+		{params.InitialBaseFee, 30_000_000, 10_000_000, 1020000000, false},           // usage above target
+		{params.InitialBaseFee, 30_000_000, 5_000_000, params.InitialBaseFee, true},  // usage == target
+		{params.InitialBaseFee, 30_000_000, 4_000_000, 999200000, true},              // usage below target
+		{params.InitialBaseFee, 30_000_000, 10_000_000, 1004000000, true},            // usage above target
+	}
+	for i, test := range tests {
+		parent := &types.Header{
+			Number:   common.Big32,
+			GasLimit: test.parentGasLimit,
+			GasUsed:  test.parentGasUsed,
+			BaseFee:  big.NewInt(test.parentBaseFee),
+			Time:     6,
+		}
+		if test.postCanyon {
+			parent.Time = 8
+		}
+		if have, want := CalcBaseFee(opConfig(), parent), big.NewInt(test.expectedBaseFee); have.Cmp(want) != 0 {
 			t.Errorf("test %d: have %d  want %d, ", i, have, want)
 		}
 	}

--- a/params/config.go
+++ b/params/config.go
@@ -392,8 +392,10 @@ func (c *CliqueConfig) String() string {
 
 // OptimismConfig is the optimism config.
 type OptimismConfig struct {
-	EIP1559Elasticity  uint64 `json:"eip1559Elasticity"`
-	EIP1559Denominator uint64 `json:"eip1559Denominator"`
+	EIP1559Elasticity            uint64 `json:"eip1559Elasticity"`
+	EIP1559Denominator           uint64 `json:"eip1559Denominator"`
+	EIP1559DenominatorPostCanyon uint64 `json:"eip1559DenominatorPostCanyon"`
+	L2BlockTime                  uint64 `json:"l2BlockTime"`
 }
 
 // String implements the stringer interface, returning the optimism fee config details.
@@ -798,8 +800,11 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, headNumber *big.Int, 
 }
 
 // BaseFeeChangeDenominator bounds the amount the base fee can change between blocks.
-func (c *ChainConfig) BaseFeeChangeDenominator() uint64 {
+func (c *ChainConfig) BaseFeeChangeDenominator(parentTime uint64) uint64 {
 	if c.Optimism != nil {
+		if c.IsCanyon(parentTime + c.Optimism.L2BlockTime) {
+			return c.Optimism.EIP1559DenominatorPostCanyon
+		}
 		return c.Optimism.EIP1559Denominator
 	}
 	return DefaultBaseFeeChangeDenominator

--- a/params/superchain.go
+++ b/params/superchain.go
@@ -75,8 +75,10 @@ func LoadOPStackChainConfig(chainID uint64) (*ChainConfig, error) {
 		Ethash:                        nil,
 		Clique:                        nil,
 		Optimism: &OptimismConfig{
-			EIP1559Elasticity:  6,
-			EIP1559Denominator: 50,
+			EIP1559Elasticity:            6,
+			EIP1559Denominator:           50,
+			EIP1559DenominatorPostCanyon: 250,
+			L2BlockTime:                  2, // TODO: Make sure to override this if this is set in the superchain registry
 		},
 	}
 


### PR DESCRIPTION
**Description**

This adds implements changing the EIP 1559 denominator from 50 to 250 with the Canyon network upgrade.

I chose to add the L2 block time to the chain config because of some complexities around how `CalcBaseFee` is used. CalcBaseFee simply takes the parent header & not any information about the new block. It is used in several places where information about the new block is not readily available (like in estimating what the basefee should be for the pending block or for tx pool purposes). It required less modifications to assume that in the L2 case, we can know the next block timestamp based on the parent block timestamp. This does introduce a risk around having to configure the L2 block time.

Providing the new block's timestamp was possible in some cases, but not in others and would require significantly larger modifications.

**Tests**

Unit tests for this OP 1559 behavior.

**Metadata**

- Fixes #143 
