### PR TITLE
params: update op-stack protocol version to v3.1.0

### DIFF
--- a/params/superchain.go
+++ b/params/superchain.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-var OPStackSupport = ProtocolVersionV0{Build: [8]byte{}, Major: 3, Minor: 1, Patch: 0, PreRelease: 1}.Encode()
+var OPStackSupport = ProtocolVersionV0{Build: [8]byte{}, Major: 3, Minor: 1, Patch: 0, PreRelease: 0}.Encode()
 
 func init() {
 	for id, ch := range superchain.OPChains {


### PR DESCRIPTION
**Description**

Update the protocol-version support param, now that the superchain-parameters (all opt-in, no breaking changes) functionality is completely available.


