### PR TITLE
fix receipt json marshaling/unmarshaling

### DIFF
--- a/core/types/gen_receipt_json.go
+++ b/core/types/gen_receipt_json.go
@@ -16,25 +16,27 @@ var _ = (*receiptMarshaling)(nil)
 // MarshalJSON marshals as JSON.
 func (r Receipt) MarshalJSON() ([]byte, error) {
 	type Receipt struct {
-		Type              hexutil.Uint64 `json:"type,omitempty"`
-		PostState         hexutil.Bytes  `json:"root"`
-		Status            hexutil.Uint64 `json:"status"`
-		CumulativeGasUsed hexutil.Uint64 `json:"cumulativeGasUsed" gencodec:"required"`
-		Bloom             Bloom          `json:"logsBloom"         gencodec:"required"`
-		Logs              []*Log         `json:"logs"              gencodec:"required"`
-		TxHash            common.Hash    `json:"transactionHash" gencodec:"required"`
-		ContractAddress   common.Address `json:"contractAddress"`
-		GasUsed           hexutil.Uint64 `json:"gasUsed" gencodec:"required"`
-		EffectiveGasPrice *hexutil.Big   `json:"effectiveGasPrice"`
-		BlobGasUsed       hexutil.Uint64 `json:"blobGasUsed,omitempty"`
-		BlobGasPrice      *hexutil.Big   `json:"blobGasPrice,omitempty"`
-		BlockHash         common.Hash    `json:"blockHash,omitempty"`
-		BlockNumber       *hexutil.Big   `json:"blockNumber,omitempty"`
-		TransactionIndex  hexutil.Uint   `json:"transactionIndex"`
-		L1GasPrice        *hexutil.Big   `json:"l1GasPrice,omitempty"`
-		L1GasUsed         *hexutil.Big   `json:"l1GasUsed,omitempty"`
-		L1Fee             *hexutil.Big   `json:"l1Fee,omitempty"`
-		FeeScalar         *big.Float     `json:"l1FeeScalar,omitempty"`
+		Type                  hexutil.Uint64  `json:"type,omitempty"`
+		PostState             hexutil.Bytes   `json:"root"`
+		Status                hexutil.Uint64  `json:"status"`
+		CumulativeGasUsed     hexutil.Uint64  `json:"cumulativeGasUsed" gencodec:"required"`
+		Bloom                 Bloom           `json:"logsBloom"         gencodec:"required"`
+		Logs                  []*Log          `json:"logs"              gencodec:"required"`
+		TxHash                common.Hash     `json:"transactionHash" gencodec:"required"`
+		ContractAddress       common.Address  `json:"contractAddress"`
+		GasUsed               hexutil.Uint64  `json:"gasUsed" gencodec:"required"`
+		EffectiveGasPrice     *hexutil.Big    `json:"effectiveGasPrice"`
+		BlobGasUsed           hexutil.Uint64  `json:"blobGasUsed,omitempty"`
+		BlobGasPrice          *hexutil.Big    `json:"blobGasPrice,omitempty"`
+		DepositNonce          *hexutil.Uint64 `json:"depositNonce,omitempty"`
+		DepositReceiptVersion *hexutil.Uint64 `json:"depositReceiptVersion,omitempty"`
+		BlockHash             common.Hash     `json:"blockHash,omitempty"`
+		BlockNumber           *hexutil.Big    `json:"blockNumber,omitempty"`
+		TransactionIndex      hexutil.Uint    `json:"transactionIndex"`
+		L1GasPrice            *hexutil.Big    `json:"l1GasPrice,omitempty"`
+		L1GasUsed             *hexutil.Big    `json:"l1GasUsed,omitempty"`
+		L1Fee                 *hexutil.Big    `json:"l1Fee,omitempty"`
+		FeeScalar             *big.Float      `json:"l1FeeScalar,omitempty"`
 	}
 	var enc Receipt
 	enc.Type = hexutil.Uint64(r.Type)
@@ -49,6 +51,8 @@ func (r Receipt) MarshalJSON() ([]byte, error) {
 	enc.EffectiveGasPrice = (*hexutil.Big)(r.EffectiveGasPrice)
 	enc.BlobGasUsed = hexutil.Uint64(r.BlobGasUsed)
 	enc.BlobGasPrice = (*hexutil.Big)(r.BlobGasPrice)
+	enc.DepositNonce = (*hexutil.Uint64)(r.DepositNonce)
+	enc.DepositReceiptVersion = (*hexutil.Uint64)(r.DepositReceiptVersion)
 	enc.BlockHash = r.BlockHash
 	enc.BlockNumber = (*hexutil.Big)(r.BlockNumber)
 	enc.TransactionIndex = hexutil.Uint(r.TransactionIndex)
@@ -62,26 +66,27 @@ func (r Receipt) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON unmarshals from JSON.
 func (r *Receipt) UnmarshalJSON(input []byte) error {
 	type Receipt struct {
-		Type              *hexutil.Uint64 `json:"type,omitempty"`
-		PostState         *hexutil.Bytes  `json:"root"`
-		Status            *hexutil.Uint64 `json:"status"`
-		CumulativeGasUsed *hexutil.Uint64 `json:"cumulativeGasUsed" gencodec:"required"`
-		Bloom             *Bloom          `json:"logsBloom"         gencodec:"required"`
-		Logs              []*Log          `json:"logs"              gencodec:"required"`
-		TxHash            *common.Hash    `json:"transactionHash" gencodec:"required"`
-		ContractAddress   *common.Address `json:"contractAddress"`
-		GasUsed           *hexutil.Uint64 `json:"gasUsed" gencodec:"required"`
-		EffectiveGasPrice *hexutil.Big    `json:"effectiveGasPrice"`
-		BlobGasUsed       *hexutil.Uint64 `json:"blobGasUsed,omitempty"`
-		BlobGasPrice      *hexutil.Big    `json:"blobGasPrice,omitempty"`
-		BlockHash         *common.Hash    `json:"blockHash,omitempty"`
-		BlockNumber       *hexutil.Big    `json:"blockNumber,omitempty"`
-		TransactionIndex  *hexutil.Uint   `json:"transactionIndex"`
-		L1GasPrice        *hexutil.Big    `json:"l1GasPrice,omitempty"`
-		L1GasUsed         *hexutil.Big    `json:"l1GasUsed,omitempty"`
-		L1Fee             *hexutil.Big    `json:"l1Fee,omitempty"`
-		FeeScalar         *big.Float      `json:"l1FeeScalar,omitempty"`
-		DepositNonce      *hexutil.Uint64 `json:"depositNonce,omitempty"`
+		Type                  *hexutil.Uint64 `json:"type,omitempty"`
+		PostState             *hexutil.Bytes  `json:"root"`
+		Status                *hexutil.Uint64 `json:"status"`
+		CumulativeGasUsed     *hexutil.Uint64 `json:"cumulativeGasUsed" gencodec:"required"`
+		Bloom                 *Bloom          `json:"logsBloom"         gencodec:"required"`
+		Logs                  []*Log          `json:"logs"              gencodec:"required"`
+		TxHash                *common.Hash    `json:"transactionHash" gencodec:"required"`
+		ContractAddress       *common.Address `json:"contractAddress"`
+		GasUsed               *hexutil.Uint64 `json:"gasUsed" gencodec:"required"`
+		EffectiveGasPrice     *hexutil.Big    `json:"effectiveGasPrice"`
+		BlobGasUsed           *hexutil.Uint64 `json:"blobGasUsed,omitempty"`
+		BlobGasPrice          *hexutil.Big    `json:"blobGasPrice,omitempty"`
+		DepositNonce          *hexutil.Uint64 `json:"depositNonce,omitempty"`
+		DepositReceiptVersion *hexutil.Uint64 `json:"depositReceiptVersion,omitempty"`
+		BlockHash             *common.Hash    `json:"blockHash,omitempty"`
+		BlockNumber           *hexutil.Big    `json:"blockNumber,omitempty"`
+		TransactionIndex      *hexutil.Uint   `json:"transactionIndex"`
+		L1GasPrice            *hexutil.Big    `json:"l1GasPrice,omitempty"`
+		L1GasUsed             *hexutil.Big    `json:"l1GasUsed,omitempty"`
+		L1Fee                 *hexutil.Big    `json:"l1Fee,omitempty"`
+		FeeScalar             *big.Float      `json:"l1FeeScalar,omitempty"`
 	}
 	var dec Receipt
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -128,6 +133,12 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 	if dec.BlobGasPrice != nil {
 		r.BlobGasPrice = (*big.Int)(dec.BlobGasPrice)
 	}
+	if dec.DepositNonce != nil {
+		r.DepositNonce = (*uint64)(dec.DepositNonce)
+	}
+	if dec.DepositReceiptVersion != nil {
+		r.DepositReceiptVersion = (*uint64)(dec.DepositReceiptVersion)
+	}
 	if dec.BlockHash != nil {
 		r.BlockHash = *dec.BlockHash
 	}
@@ -148,9 +159,6 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 	}
 	if dec.FeeScalar != nil {
 		r.FeeScalar = dec.FeeScalar
-	}
-	if dec.DepositNonce != nil {
-		r.DepositNonce = (*uint64)(dec.DepositNonce)
 	}
 	return nil
 }

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -103,11 +103,13 @@ type receiptMarshaling struct {
 	BlockNumber       *hexutil.Big
 	TransactionIndex  hexutil.Uint
 
-	// Optimism: extend receipts with their L1 price (if a rollup tx)
-	L1GasPrice *hexutil.Big
-	L1GasUsed  *hexutil.Big
-	L1Fee      *hexutil.Big
-	FeeScalar  *big.Float
+	// Optimism
+	L1GasPrice            *hexutil.Big
+	L1GasUsed             *hexutil.Big
+	L1Fee                 *hexutil.Big
+	FeeScalar             *big.Float
+	DepositNonce          *hexutil.Uint64
+	DepositReceiptVersion *hexutil.Uint64
 }
 
 // receiptRLP is the consensus encoding of a receipt.

--- a/core/types/receipt_test.go
+++ b/core/types/receipt_test.go
@@ -488,6 +488,18 @@ func TestReceiptJSON(t *testing.T) {
 		if err != nil {
 			t.Fatal("error unmarshaling receipt from json:", err)
 		}
+
+		// Make sure marshal/unmarshal doesn't affect receipt hash root computation by comparing
+		// the output of EncodeIndex
+		rsBefore := Receipts([]*Receipt{receipts[i]})
+		rsAfter := Receipts([]*Receipt{&r})
+
+		encBefore, encAfter := bytes.Buffer{}, bytes.Buffer{}
+		rsBefore.EncodeIndex(0, &encBefore)
+		rsAfter.EncodeIndex(0, &encAfter)
+		if !bytes.Equal(encBefore.Bytes(), encAfter.Bytes()) {
+			t.Errorf("%v: EncodeIndex differs after JSON marshal/unmarshal", i)
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Make JSON marshaling/unmarshaling of receipts handle deposit nonce & new deposit receipt version. 

"go generate" was used to regenerate gen_receipt_json.go which appeared to have been manually edited before.

**Tests**

modified receipt json marshal/unmarshal test to confirm receipt root computation is not affected by json encoding

**Additional context**

Looks like deposit nonce never was included in the json serialization of a deposit transaction, but since the value wasn't previously being used in receipt hash generation (due to a different bug) this wasn't ever detected.


**Metadata**

- Fixes #[Link to Issue]
