### PR TITLE
Remove ChainID + GetCodeSize check from create2deployer precompile deployment

### DIFF
--- a/consensus/misc/create2deployer.go
+++ b/consensus/misc/create2deployer.go
@@ -16,15 +16,7 @@ import (
 // file applies the contract code to the canonical address manually in the Canyon
 // hardfork.
 
-// create2deployer is already deployed to Base testnets at 0x13b0D85CcB8bf860b6b79AF3029fCA081AE9beF2,
-// so we deploy it to 0x13b0D85CcB8bf860b6b79AF3029fCA081AE9beF1 for hardfork testing purposes
-var create2DeployerAddresses = map[uint64]common.Address{
-	11763071:                  common.HexToAddress("0x13b0D85CcB8bf860b6b79AF3029fCA081AE9beF1"), // Base Goerli devnet
-	params.BaseGoerliChainID:  common.HexToAddress("0x13b0D85CcB8bf860b6b79AF3029fCA081AE9beF1"), // Base Goerli testnet
-	11763072:                  common.HexToAddress("0x13b0D85CcB8bf860b6b79AF3029fCA081AE9beF1"), // Base Sepolia devnet
-	84532:                     common.HexToAddress("0x13b0D85CcB8bf860b6b79AF3029fCA081AE9beF1"), // Base Sepolia testnet
-	params.BaseMainnetChainID: common.HexToAddress("0x13b0D85CcB8bf860b6b79AF3029fCA081AE9beF2"), // Base mainnet
-}
+var create2DeployerAddress = common.HexToAddress("0x13b0D85CcB8bf860b6b79AF3029fCA081AE9beF2")
 var create2DeployerCodeHash = common.HexToHash("0xb0550b5b431e30d38000efb7107aaa0ade03d48a7198a140edda9d27134468b2")
 var create2DeployerCode []byte
 
@@ -40,10 +32,9 @@ func EnsureCreate2Deployer(c *params.ChainConfig, timestamp uint64, db vm.StateD
 	if !c.IsOptimism() || c.CanyonTime == nil || *c.CanyonTime != timestamp {
 		return
 	}
-	address, ok := create2DeployerAddresses[c.ChainID.Uint64()]
-	if !ok || db.GetCodeSize(address) > 0 {
+	if db.GetCodeSize(create2DeployerAddress) > 0 {
 		return
 	}
-	log.Info("Setting Create2Deployer code", "address", address, "codeHash", create2DeployerCodeHash)
-	db.SetCode(address, create2DeployerCode)
+	log.Info("Setting Create2Deployer code", "address", create2DeployerAddress, "codeHash", create2DeployerCodeHash)
+	db.SetCode(create2DeployerAddress, create2DeployerCode)
 }

--- a/consensus/misc/create2deployer.go
+++ b/consensus/misc/create2deployer.go
@@ -32,9 +32,6 @@ func EnsureCreate2Deployer(c *params.ChainConfig, timestamp uint64, db vm.StateD
 	if !c.IsOptimism() || c.CanyonTime == nil || *c.CanyonTime != timestamp {
 		return
 	}
-	if db.GetCodeSize(create2DeployerAddress) > 0 {
-		return
-	}
 	log.Info("Setting Create2Deployer code", "address", create2DeployerAddress, "codeHash", create2DeployerCodeHash)
 	db.SetCode(create2DeployerAddress, create2DeployerCode)
 }

--- a/consensus/misc/create2deployer_test.go
+++ b/consensus/misc/create2deployer_test.go
@@ -26,20 +26,12 @@ func TestEnsureCreate2Deployer(t *testing.T) {
 			applied:   true,
 		},
 		{
-			name: "non-optimism chain",
-			override: func(cfg *params.ChainConfig) {
-				cfg.Optimism = nil
-			},
-			timestamp: canyonTime,
-			applied:   false,
-		},
-		{
-			name: "non-base chain",
+			name: "another chain ID",
 			override: func(cfg *params.ChainConfig) {
 				cfg.ChainID = big.NewInt(params.OPMainnetChainID)
 			},
 			timestamp: canyonTime,
-			applied:   false,
+			applied:   true,
 		},
 		{
 			name:      "pre canyon",

--- a/consensus/misc/create2deployer_test.go
+++ b/consensus/misc/create2deployer_test.go
@@ -34,6 +34,12 @@ func TestEnsureCreate2Deployer(t *testing.T) {
 			applied:   true,
 		},
 		{
+			name:       "code already exists",
+			timestamp:  canyonTime,
+			codeExists: true,
+			applied:    true,
+		},
+		{
 			name:      "pre canyon",
 			timestamp: canyonTime - 1,
 			applied:   false,
@@ -50,12 +56,6 @@ func TestEnsureCreate2Deployer(t *testing.T) {
 			},
 			timestamp: canyonTime,
 			applied:   false,
-		},
-		{
-			name:       "code already exists",
-			timestamp:  canyonTime,
-			codeExists: true,
-			applied:    false,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

We aligned on removing any branching logic that involves chain ID from the state transition function. This means removing the chain ID conditional for the `create2deployer` deployment introduced in #126. We also removed the `GetCodeSize` check which means the code is overridden on all op-stack chains.

**Tests**

Updated tests.