### PR TITLE
Enable Canyon via superchain in op-geth

### DIFF
--- a/consensus/misc/eip1559/eip1559_test.go
+++ b/consensus/misc/eip1559/eip1559_test.go
@@ -61,9 +61,9 @@ func opConfig() *params.ChainConfig {
 	ct := uint64(10)
 	config.CanyonTime = &ct
 	config.Optimism = &params.OptimismConfig{
-		EIP1559Elasticity:            6,
-		EIP1559Denominator:           50,
-		EIP1559DenominatorPostCanyon: 250,
+		EIP1559Elasticity:        6,
+		EIP1559Denominator:       50,
+		EIP1559DenominatorCanyon: 250,
 	}
 	return config
 }

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -313,6 +313,7 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *trie.Database, gen
 			}
 			if overrides != nil && overrides.OverrideOptimismCanyon != nil {
 				config.CanyonTime = overrides.OverrideOptimismCanyon
+				config.ShanghaiTime = overrides.OverrideOptimismCanyon
 			}
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/deckarep/golang-set/v2 v2.1.0
 	github.com/docker/docker v24.0.5+incompatible
 	github.com/dop251/goja v0.0.0-20230806174421-c933cf95e127
-	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20231018164214-046f42968aec
+	github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20231026175037-2cff0d130e74
 	github.com/ethereum/c-kzg-4844 v0.3.1
 	github.com/fatih/color v1.13.0
 	github.com/fjl/gencodec v0.0.0-20230517082657-f9840df7b83e
@@ -146,3 +146,5 @@ require (
 	gotest.tools/v3 v3.5.1 // indirect
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
+
+//replace github.com/ethereum-optimism/superchain-registry/superchain => ../superchain-registry/superchain

--- a/go.sum
+++ b/go.sum
@@ -183,8 +183,8 @@ github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.m
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/etcd-io/bbolt v1.3.3/go.mod h1:ZF2nL25h33cCyBtcyWeZ2/I3HQOfTP+0PIEvHjkjCrw=
-github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20231018164214-046f42968aec h1:4wWqpBeK7nwMVncglr9XLYIFmU8j5w2XmhtklztraNY=
-github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20231018164214-046f42968aec/go.mod h1:/70H/KqrtKcvWvNGVj6S3rAcLC+kUPr3t2aDmYIS+Xk=
+github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20231026175037-2cff0d130e74 h1:02gXBD+Cas7xj9rpkke5wD1+vpfYxyF/+31M5tosP9A=
+github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20231026175037-2cff0d130e74/go.mod h1:/70H/KqrtKcvWvNGVj6S3rAcLC+kUPr3t2aDmYIS+Xk=
 github.com/ethereum/c-kzg-4844 v0.3.1 h1:sR65+68+WdnMKxseNWxSJuAv2tsUrihTpVBTfM/U5Zg=
 github.com/ethereum/c-kzg-4844 v0.3.1/go.mod h1:VewdlzQmpT5QSrVhbBuGoCdFJkpaJlO1aQputP83wc0=
 github.com/fasthttp-contrib/websocket v0.0.0-20160511215533-1f3b11f56072/go.mod h1:duJ4Jxv5lDcvg4QuQr0oowTf7dz4/CR8NtyCooz9HL8=

--- a/params/config.go
+++ b/params/config.go
@@ -393,9 +393,9 @@ func (c *CliqueConfig) String() string {
 
 // OptimismConfig is the optimism config.
 type OptimismConfig struct {
-	EIP1559Elasticity            uint64 `json:"eip1559Elasticity"`
-	EIP1559Denominator           uint64 `json:"eip1559Denominator"`
-	EIP1559DenominatorPostCanyon uint64 `json:"eip1559DenominatorPostCanyon"`
+	EIP1559Elasticity        uint64 `json:"eip1559Elasticity"`
+	EIP1559Denominator       uint64 `json:"eip1559Denominator"`
+	EIP1559DenominatorCanyon uint64 `json:"eip1559DenominatorCanyon"`
 }
 
 // String implements the stringer interface, returning the optimism fee config details.
@@ -807,7 +807,7 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, headNumber *big.Int, 
 func (c *ChainConfig) BaseFeeChangeDenominator(time uint64) uint64 {
 	if c.Optimism != nil {
 		if c.IsCanyon(time) {
-			return c.Optimism.EIP1559DenominatorPostCanyon
+			return c.Optimism.EIP1559DenominatorCanyon
 		}
 		return c.Optimism.EIP1559Denominator
 	}

--- a/params/superchain.go
+++ b/params/superchain.go
@@ -76,9 +76,9 @@ func LoadOPStackChainConfig(chainID uint64) (*ChainConfig, error) {
 		Ethash:                        nil,
 		Clique:                        nil,
 		Optimism: &OptimismConfig{
-			EIP1559Elasticity:            6,
-			EIP1559Denominator:           50,
-			EIP1559DenominatorPostCanyon: 250,
+			EIP1559Elasticity:        6,
+			EIP1559Denominator:       50,
+			EIP1559DenominatorCanyon: 250,
 		},
 	}
 

--- a/params/superchain.go
+++ b/params/superchain.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-var OPStackSupport = ProtocolVersionV0{Build: [8]byte{}, Major: 3, Minor: 1, Patch: 0, PreRelease: 0}.Encode()
+var OPStackSupport = ProtocolVersionV0{Build: [8]byte{}, Major: 4, Minor: 0, Patch: 0, PreRelease: 1}.Encode()
 
 func init() {
 	for id, ch := range superchain.OPChains {
@@ -65,11 +65,12 @@ func LoadOPStackChainConfig(chainID uint64) (*ChainConfig, error) {
 		ArrowGlacierBlock:             common.Big0,
 		GrayGlacierBlock:              common.Big0,
 		MergeNetsplitBlock:            common.Big0,
-		ShanghaiTime:                  nil,
+		ShanghaiTime:                  superchainConfig.Config.CanyonTime, // Shanghai activates with Canyon
 		CancunTime:                    nil,
 		PragueTime:                    nil,
 		BedrockBlock:                  common.Big0,
 		RegolithTime:                  &genesisActivation,
+		CanyonTime:                    superchainConfig.Config.CanyonTime,
 		TerminalTotalDifficulty:       common.Big0,
 		TerminalTotalDifficultyPassed: true,
 		Ethash:                        nil,


### PR DESCRIPTION
**Description**

This is the final touches for Canyon. It enables it via the superchain and includes the baked in devnet activation. This also renames EIP1559DenominatorPostCanyon to EIP1559DenominatorCanyon. Lastly, it activates Shanghai at the same time as Canyon.

**TODO**: Wait until https://github.com/ethereum-optimism/superchain-registry/pull/28 is merged & pull in the tip of the superchain registry.

**Tests**

Manually tested that a local registry was pulling in the right values & that the override was working correctly.


