### PR TITLE
Add regolith override time for base goerli devnet

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -32,12 +32,13 @@ var (
 )
 
 const (
-	OPMainnetChainID   = 10
-	OPGoerliChainID    = 420
-	BaseMainnetChainID = 8453
-	BaseGoerliChainID  = 84531
-	devnetChainID      = 997
-	chaosnetChainID    = 888
+	OPMainnetChainID        = 10
+	OPGoerliChainID         = 420
+	BaseMainnetChainID      = 8453
+	BaseGoerliChainID       = 84531
+	baseGoerliDevnetChainID = 11763071
+	devnetChainID           = 997
+	chaosnetChainID         = 888
 )
 
 // OP Stack chain config
@@ -46,6 +47,8 @@ var (
 	OptimismGoerliRegolithTime = uint64(1679079600)
 	// May 4, 2023 @ 5:00:00 pm UTC
 	BaseGoerliRegolithTime = uint64(1683219600)
+	// Apr 21, 2023 @ 6:30:00 pm UTC
+	baseGoerliDevnetRegolithTime = uint64(1682101800)
 	// March 5, 2023 @ 2:48:00 am UTC
 	devnetRegolithTime = uint64(1677984480)
 	// August 16, 2023 @ 3:34:22 am UTC

--- a/params/superchain.go
+++ b/params/superchain.go
@@ -105,6 +105,8 @@ func LoadOPStackChainConfig(chainID uint64) (*ChainConfig, error) {
 		out.BedrockBlock = big.NewInt(105235063)
 	case BaseGoerliChainID:
 		out.RegolithTime = &BaseGoerliRegolithTime
+	case baseGoerliDevnetChainID:
+		out.RegolithTime = &baseGoerliDevnetRegolithTime
 	case devnetChainID:
 		out.RegolithTime = &devnetRegolithTime
 		out.Optimism.EIP1559Elasticity = 10


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

With the removal of `--override.regolith` with #133, Base needs a way to opt-in to the regolith override for our goerli devnet. This PR hardcodes the timestamp we used.

**Tests**

No tests added.