### PR TITLE
Fix potential nil pointer dereference panic in superchain overrides

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -286,7 +286,7 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *trie.Database, gen
 		if config != nil {
 			// If applying the superchain-registry to a known OP-Stack chain,
 			// then override the local chain-config with that from the registry.
-			if overrides != nil && overrides.ApplySuperchainUpgrades && config.IsOptimism() && config.ChainID != nil && genesis.Config.ChainID.IsUint64() {
+			if overrides != nil && overrides.ApplySuperchainUpgrades && config.IsOptimism() && config.ChainID != nil && config.ChainID.IsUint64() {
 				if _, ok := superchain.OPChains[config.ChainID.Uint64()]; ok {
 					conf, err := params.LoadOPStackChainConfig(config.ChainID.Uint64())
 					if err != nil {


### PR DESCRIPTION
**Description**

Running geth with `--rollup.superchain-upgrades` but no `--op-network` will panic in the superchain config overrides code, because `genesis` is `nil`. This PR fixes that codepath.

**Tests**

No tests added, hotfix for canyon hardfork today.

**Additional context**

We are seeing this on our sepolia devnet, which is not yet part of the superchain config.
