### PR TITLE
Ensure that the EIP1559DenominatorCanyon is set if the canyon override is set

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -314,6 +314,9 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *trie.Database, gen
 			if overrides != nil && overrides.OverrideOptimismCanyon != nil {
 				config.CanyonTime = overrides.OverrideOptimismCanyon
 				config.ShanghaiTime = overrides.OverrideOptimismCanyon
+				if config.Optimism != nil && config.Optimism.EIP1559DenominatorCanyon == 0 {
+					config.Optimism.EIP1559DenominatorCanyon = 250
+				}
 			}
 		}
 	}


### PR DESCRIPTION
**Description**

One of the ways to opt-in to canyon is to use the `--override.canyon` flag. However, currently this does not set the `EIP1559DenominatorCanyon` chain configuration value, which causes panics in the EIP-1559 code due to divide-by-zero errors.

This PR introduces a quick fix to set the `EIP1559DenominatorCanyon` to `250` if it's `0`. We can follow up with a longer term fix for better default hardfork configuration for chains that are not in the superchain registry.

**Tests**

Tested on our sepolia devnet.

**Additional context**

panic:
```
panic: division by zero

goroutine 4232 [running]:
math/big.nat.div({0xc00055cc60?, 0x1?, 0x6?}, {0x0?, 0x0?, 0x0?}, {0xc00055cc60?, 0x1?, 0x6?}, {0xc0009d6510, ...})
	math/big/natdiv.go:520 +0x32e
math/big.(*Int).QuoRem(0xc000157f20, 0xc000157f20, 0xc000aad7e0, 0xc000aad720)
	math/big/int.go:294 +0x7b
math/big.(*Int).Div(0xc0009d6510?, 0xc000157f20?, 0xc000157ee0?)
	math/big/int.go:305 +0x38
github.com/ethereum/go-ethereum/consensus/misc/eip1559.CalcBaseFee(0xc000ad4960, 0xc0001ff400, 0x653c16c0)
	github.com/ethereum/go-ethereum/consensus/misc/eip1559/eip1559.go:93 +0x547
github.com/ethereum/go-ethereum/miner.(*worker).prepareWork(0xc0000406c0, 0xc000b896b0)
	github.com/ethereum/go-ethereum/miner/worker.go:987 +0x54d
github.com/ethereum/go-ethereum/miner.(*worker).generateWork(0xc0000406c0, 0xc000b896b0)
	github.com/ethereum/go-ethereum/miner/worker.go:1066 +0x4f
github.com/ethereum/go-ethereum/miner.(*worker).mainLoop(0xc0000406c0)
	github.com/ethereum/go-ethereum/miner/worker.go:556 +0x44c
created by github.com/ethereum/go-ethereum/miner.newWorker in goroutine 1
	github.com/ethereum/go-ethereum/miner/worker.go:294 +0x846
```