### PR TITLE
Set base testnets elasticity

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -36,6 +36,7 @@ const (
 	OPGoerliChainID         = 420
 	BaseMainnetChainID      = 8453
 	BaseGoerliChainID       = 84531
+	baseSepoliaChainId      = 84532
 	baseGoerliDevnetChainID = 11763071
 	devnetChainID           = 997
 	chaosnetChainID         = 888

--- a/params/config.go
+++ b/params/config.go
@@ -36,7 +36,7 @@ const (
 	OPGoerliChainID         = 420
 	BaseMainnetChainID      = 8453
 	BaseGoerliChainID       = 84531
-	baseSepoliaChainId      = 84532
+	baseSepoliaChainID      = 84532
 	baseGoerliDevnetChainID = 11763071
 	devnetChainID           = 997
 	chaosnetChainID         = 888

--- a/params/superchain.go
+++ b/params/superchain.go
@@ -105,6 +105,9 @@ func LoadOPStackChainConfig(chainID uint64) (*ChainConfig, error) {
 		out.BedrockBlock = big.NewInt(105235063)
 	case BaseGoerliChainID:
 		out.RegolithTime = &BaseGoerliRegolithTime
+		out.Optimism.EIP1559Elasticity = 10
+	case baseSepoliaChainId:
+		out.Optimism.EIP1559Elasticity = 10
 	case baseGoerliDevnetChainID:
 		out.RegolithTime = &baseGoerliDevnetRegolithTime
 	case devnetChainID:

--- a/params/superchain.go
+++ b/params/superchain.go
@@ -106,7 +106,7 @@ func LoadOPStackChainConfig(chainID uint64) (*ChainConfig, error) {
 	case BaseGoerliChainID:
 		out.RegolithTime = &BaseGoerliRegolithTime
 		out.Optimism.EIP1559Elasticity = 10
-	case baseSepoliaChainId:
+	case baseSepoliaChainID:
 		out.Optimism.EIP1559Elasticity = 10
 	case baseGoerliDevnetChainID:
 		out.RegolithTime = &baseGoerliDevnetRegolithTime


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

We opted in to the superchain params, which caused a node halt due to incorrect base fee change validation.

This PR adds the correct `EIP1559Elasticity` overrides for Base goerli + sepolia.

**Tests**

No tests added.

**Additional context**

Log:
```
########## BAD BLOCK #########
Block: 1485959 (0x5ea64e70db7d39a314dc63776e983e37638104a14ab100c8d60371da9f71bca9)
Error: invalid baseFee: have 52, want 51, parentBaseFee 50, parentGasUsed 7636391
Platform: geth (devel) go1.21.3 amd64 linux
VCS: 4a3209b4-20231027
Chain config: &params.ChainConfig{ChainID:84532, HomesteadBlock:0, DAOForkBlock:<nil>, DAOForkSupport:false, EIP150Block:0, EIP155Block:0, EIP158Block:0, ByzantiumBlock:0, ConstantinopleBlock:0, PetersburgBlock:0, IstanbulBlock:0, MuirGlacierBlock:0, BerlinBlock:0, LondonBlock:0, ArrowGlacierBlock:0, GrayGlacierBlock:0, MergeNetsplitBlock:0, ShanghaiTime:(*uint64)(nil), CancunTime:(*uint64)(nil), PragueTime:(*uint64)(nil), VerkleTime:(*uint64)(nil), BedrockBlock:0, RegolithTime:(*uint64)(0xc0005efd20), CanyonTime:(*uint64)(nil), TerminalTotalDifficulty:0, TerminalTotalDifficultyPassed:true, Ethash:(*params.EthashConfig)(nil), Clique:(*params.CliqueConfig)(nil), IsDevMode:false, Optimism:(*params.OptimismConfig)(0xc000044108)}
Receipts: 
##############################
```
