### PR TITLE
Snap Sync: consensus: handle legacy pre-bedrock header verification

### DIFF
--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -58,6 +58,7 @@ var (
 // is only used for necessary consensus checks. The legacy consensus engine can be any
 // engine implements the consensus interface (except the beacon itself).
 type Beacon struct {
+	// For migrated OP chains (OP mainnet, OP Goerli), ethone is a dummy legacy pre-Bedrock consensus
 	ethone consensus.Engine // Original consensus engine used in eth1, e.g. ethash or clique
 }
 

--- a/consensus/beacon/oplegacy.go
+++ b/consensus/beacon/oplegacy.go
@@ -29,8 +29,8 @@ func (o *OpLegacy) VerifyHeader(chain consensus.ChainHeaderReader, header *types
 func (o *OpLegacy) VerifyHeaders(chain consensus.ChainHeaderReader, headers []*types.Header) (chan<- struct{}, <-chan error) {
 	quit := make(chan struct{}, 1)
 	result := make(chan error, len(headers))
-	for range headers {
-		result <- nil
+	for _, h := range headers {
+		result <- o.VerifyHeader(chain, h)
 	}
 	return quit, result
 }

--- a/consensus/beacon/oplegacy.go
+++ b/consensus/beacon/oplegacy.go
@@ -1,0 +1,69 @@
+package beacon
+
+import (
+	"fmt"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rpc"
+	"math/big"
+)
+
+type OpLegacy struct {
+}
+
+func (o *OpLegacy) Author(header *types.Header) (common.Address, error) {
+	return header.Coinbase, nil
+}
+
+func (o *OpLegacy) VerifyHeader(chain consensus.ChainHeaderReader, header *types.Header) error {
+	return nil // legacy chain is verified by block-hash reverse sync
+}
+
+func (o *OpLegacy) VerifyHeaders(chain consensus.ChainHeaderReader, headers []*types.Header) (chan<- struct{}, <-chan error) {
+	quit := make(chan struct{}, 1)
+	result := make(chan error, len(headers))
+	for range headers {
+		result <- nil
+	}
+	return quit, result
+}
+
+func (o *OpLegacy) VerifyUncles(chain consensus.ChainReader, block *types.Block) error {
+	return nil
+}
+
+func (o *OpLegacy) Prepare(chain consensus.ChainHeaderReader, header *types.Header) error {
+	return fmt.Errorf("cannot prepare for legacy block header: %s (num %d)", header.Hash(), header.Number)
+}
+
+func (o *OpLegacy) Finalize(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, withdrawals []*types.Withdrawal) {
+	panic(fmt.Errorf("cannot finalize legacy block header: %s (num %d)", header.Hash(), header.Number))
+}
+
+func (o *OpLegacy) FinalizeAndAssemble(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt, withdrawals []*types.Withdrawal) (*types.Block, error) {
+	return nil, fmt.Errorf("cannot finalize and assemble for legacy block header: %s (num %d)", header.Hash(), header.Number)
+}
+
+func (o *OpLegacy) Seal(chain consensus.ChainHeaderReader, block *types.Block, results chan<- *types.Block, stop <-chan struct{}) error {
+	return fmt.Errorf("cannot seal legacy block header: %s (num %d)", block.Hash(), block.Number())
+}
+
+func (o *OpLegacy) SealHash(header *types.Header) common.Hash {
+	panic(fmt.Errorf("cannot compute pow/poa seal-hash for legacy block header: %s (num %d)", header.Hash(), header.Number))
+}
+
+func (o *OpLegacy) CalcDifficulty(chain consensus.ChainHeaderReader, time uint64, parent *types.Header) *big.Int {
+	return big.NewInt(0)
+}
+
+func (o *OpLegacy) APIs(chain consensus.ChainHeaderReader) []rpc.API {
+	return nil
+}
+
+func (o *OpLegacy) Close() error {
+	return nil
+}
+
+var _ consensus.Engine = (*OpLegacy)(nil)

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -319,7 +319,7 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 		// to a chain, so the difficulty will be left unset (nil). Set it here to the
 		// correct value.
 		if b.header.Difficulty == nil {
-			if config.TerminalTotalDifficulty == nil {
+			if config.TerminalTotalDifficulty == nil && !config.IsOptimismBedrock(b.header.Number) {
 				// Clique chain
 				b.header.Difficulty = big.NewInt(2)
 			} else {

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -569,7 +569,7 @@ func (rs Receipts) DeriveFields(config *params.ChainConfig, hash common.Hash, nu
 			logIndex++
 		}
 	}
-	if config.Optimism != nil && len(txs) >= 2 { // need at least an info tx and a non-info tx
+	if config.Optimism != nil && len(txs) >= 2 && config.IsBedrock(new(big.Int).SetUint64(number)) { // need at least an info tx and a non-info tx
 		l1BaseFee, costFunc, feeScalar, err := extractL1GasParams(config, time, txs[0].Data())
 		if err != nil {
 			return err

--- a/core/types/receipt_test.go
+++ b/core/types/receipt_test.go
@@ -34,8 +34,16 @@ import (
 )
 
 var (
+	bedrockGenesisTestConfig = func() *params.ChainConfig {
+		conf := *params.AllCliqueProtocolChanges // copy the config
+		conf.Clique = nil
+		conf.TerminalTotalDifficultyPassed = true
+		conf.BedrockBlock = big.NewInt(0)
+		conf.Optimism = &params.OptimismConfig{EIP1559Elasticity: 50, EIP1559Denominator: 10}
+		return &conf
+	}()
 	ecotoneTestConfig = func() *params.ChainConfig {
-		conf := *params.OptimismTestConfig // copy the config
+		conf := *bedrockGenesisTestConfig // copy the config
 		time := uint64(0)
 		conf.EcotoneTime = &time
 		return &conf
@@ -774,7 +782,7 @@ func TestDeriveOptimismBedrockTxReceipts(t *testing.T) {
 	// Re-derive receipts.
 	baseFee := big.NewInt(1000)
 	derivedReceipts := clearComputedFieldsOnReceipts(receipts)
-	err := Receipts(derivedReceipts).DeriveFields(params.OptimismTestConfig, blockHash, blockNumber.Uint64(), 0, baseFee, nil, txs)
+	err := Receipts(derivedReceipts).DeriveFields(bedrockGenesisTestConfig, blockHash, blockNumber.Uint64(), 0, baseFee, nil, txs)
 	if err != nil {
 		t.Fatalf("DeriveFields(...) = %v, want <nil>", err)
 	}
@@ -802,7 +810,7 @@ func TestDeriveOptimismEcotoneTxReceipts(t *testing.T) {
 	baseFee := big.NewInt(1000)
 	derivedReceipts := clearComputedFieldsOnReceipts(receipts)
 	// Should error out if we try to process this with a pre-Ecotone config
-	err := Receipts(derivedReceipts).DeriveFields(params.OptimismTestConfig, blockHash, blockNumber.Uint64(), 0, baseFee, nil, txs)
+	err := Receipts(derivedReceipts).DeriveFields(bedrockGenesisTestConfig, blockHash, blockNumber.Uint64(), 0, baseFee, nil, txs)
 	if err == nil {
 		t.Fatalf("expected error from deriving ecotone receipts with pre-ecotone config, got none")
 	}

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -190,6 +190,9 @@ type Config struct {
 // Clique is allowed for now to live standalone, but ethash is forbidden and can
 // only exist on already merged networks.
 func CreateConsensusEngine(config *params.ChainConfig, db ethdb.Database) (consensus.Engine, error) {
+	if config.Optimism != nil {
+		return beacon.New(&beacon.OpLegacy{}), nil
+	}
 	// If proof-of-authority is requested, set it up
 	if config.Clique != nil {
 		return beacon.New(clique.New(config.Clique, db)), nil

--- a/fork.yaml
+++ b/fork.yaml
@@ -80,8 +80,18 @@ def:
               description: |
                 The Engine API is activated at the Merge transition, with a Total Terminal Difficulty (TTD).
                 The rollup starts post-merge, and thus sets the TTD to 0.
+                The TTD is always "reached" starting at the bedrock block.
               globs:
                 - "consensus/beacon/consensus.go"
+            - title: "Legacy OP-mainnet / OP-goerli header-verification support"
+              description: |
+                Pre-Bedrock OP-mainnet and OP-Goerli had differently formatted block-headers, loosely compatible with the geth types (since it was based on Clique).
+                However, due to differences like the extra-data length (97+ bytes), these legacy block-headers need special verification.
+                The pre-merge "consensus" fallback is set to this custom but basic verifier, to accept these headers when syncing a pre-bedrock part of the chain,
+                independent of any clique code or configuration (which may be removed from geth at a later point).
+                All the custom verifier has to do is accept the headers, as the headers are already verified by block-hash through the reverse-header-sync.
+              globs:
+                - "consensus/beacon/oplegacy.go"
         - title: "Engine API modifications"
           description: |
             The Engine API is extended to insert transactions into the block and optionally exclude the tx-pool,


### PR DESCRIPTION
**Description**

Handle legacy pre-bedrock block-headers in consensus validation, to support snap-syncing without prior data-dir.

Very experimental. See optimism monorepo PR for context.
