### PR TITLE
event: fix Resubscribe deadlock when unsubscribing after inner sub ends

### DIFF
--- a/event/subscription.go
+++ b/event/subscription.go
@@ -120,7 +120,7 @@ func ResubscribeErr(backoffMax time.Duration, fn ResubscribeErrFunc) Subscriptio
 		backoffMax: backoffMax,
 		fn:         fn,
 		err:        make(chan error),
-		unsub:      make(chan struct{}),
+		unsub:      make(chan struct{}, 1),
 	}
 	go s.loop()
 	return s


### PR DESCRIPTION
**Description**

Cherry-pick changes from https://github.com/ethereum/go-ethereum/pull/28359/ to fix deadlock affecting op-node shutdown.

**Metadata**

- https://github.com/ethereum-optimism/optimism/issues/8086
