### PR TITLE
miner: Add block building interruption on payload resolution (getPayload)

### DIFF
--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -51,6 +51,10 @@ import (
 	"github.com/mattn/go-colorable"
 )
 
+func init() {
+	miner.IsPayloadBuildingTest = true
+}
+
 var (
 	// testKey is a private key to use for funding a tester account.
 	testKey, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")

--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -51,10 +51,6 @@ import (
 	"github.com/mattn/go-colorable"
 )
 
-func init() {
-	miner.IsPayloadBuildingTest = true
-}
-
 var (
 	// testKey is a private key to use for funding a tester account.
 	testKey, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
@@ -206,8 +202,7 @@ func TestEth2PrepareAndGetPayload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error preparing payload, err=%v", err)
 	}
-	// give the payload some time to be built
-	time.Sleep(100 * time.Millisecond)
+	waitForPayloadToBuild()
 	payloadID := (&miner.BuildPayloadArgs{
 		Parent:       fcState.HeadBlockHash,
 		Timestamp:    blockParams.Timestamp,
@@ -639,8 +634,7 @@ func TestNewPayloadOnInvalidChain(t *testing.T) {
 			if resp.PayloadStatus.Status != engine.VALID {
 				t.Fatalf("error preparing payload, invalid status: %v", resp.PayloadStatus.Status)
 			}
-			// give the payload some time to be built
-			time.Sleep(50 * time.Millisecond)
+			waitForPayloadToBuild()
 			if payload, err = api.GetPayloadV1(*resp.PayloadID); err != nil {
 				t.Fatalf("can't get payload: %v", err)
 			}
@@ -1650,4 +1644,9 @@ func TestParentBeaconBlockRoot(t *testing.T) {
 	if root := db.GetState(params.BeaconRootsStorageAddress, rootIdx); root != *blockParams.BeaconRoot {
 		t.Fatalf("incorrect root stored: want %s, got %s", *blockParams.BeaconRoot, root)
 	}
+}
+
+func waitForPayloadToBuild() {
+	// give the payload some time to be built
+	time.Sleep(1 * time.Second)
 }

--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -682,6 +682,7 @@ func assembleBlock(api *ConsensusAPI, parentHash common.Hash, params *engine.Pay
 	if err != nil {
 		return nil, err
 	}
+	waitForPayloadToBuild()
 	return payload.ResolveFull().ExecutionPayload, nil
 }
 
@@ -920,6 +921,7 @@ func TestNewPayloadOnInvalidTerminalBlock(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error preparing payload, err=%v", err)
 	}
+	waitForPayloadToBuild()
 	data := *payload.Resolve().ExecutionPayload
 	// We need to recompute the blockhash, since the miner computes a wrong (correct) blockhash
 	txs, _ := decodeTransactions(data.Transactions)

--- a/eth/catalyst/queue.go
+++ b/eth/catalyst/queue.go
@@ -17,6 +17,7 @@
 package catalyst
 
 import (
+	"errors"
 	"sync"
 
 	"github.com/ethereum/go-ethereum/beacon/engine"
@@ -93,18 +94,20 @@ func (q *payloadQueue) get(id engine.PayloadID, full bool) *engine.ExecutionPayl
 
 // waitFull waits until the first full payload has been built for the specified payload id
 // The method returns immediately if the payload is unknown.
-func (q *payloadQueue) waitFull(id engine.PayloadID) {
+func (q *payloadQueue) waitFull(id engine.PayloadID) error {
 	q.lock.RLock()
 	defer q.lock.RUnlock()
 
 	for _, item := range q.payloads {
 		if item == nil {
-			return // no more items
+			return errors.New("unknown payload")
 		}
 		if item.id == id {
 			item.payload.WaitFull()
+			return nil
 		}
 	}
+	return errors.New("unknown payload")
 }
 
 // has checks if a particular payload is already tracked.

--- a/eth/catalyst/queue.go
+++ b/eth/catalyst/queue.go
@@ -91,6 +91,22 @@ func (q *payloadQueue) get(id engine.PayloadID, full bool) *engine.ExecutionPayl
 	return nil
 }
 
+// waitFull waits until the first full payload has been built for the specified payload id
+// The method returns immediately if the payload is unknown.
+func (q *payloadQueue) waitFull(id engine.PayloadID) {
+	q.lock.RLock()
+	defer q.lock.RUnlock()
+
+	for _, item := range q.payloads {
+		if item == nil {
+			return // no more items
+		}
+		if item.id == id {
+			item.payload.WaitFull()
+		}
+	}
+}
+
 // has checks if a particular payload is already tracked.
 func (q *payloadQueue) has(id engine.PayloadID) bool {
 	q.lock.RLock()

--- a/eth/catalyst/simulated_beacon.go
+++ b/eth/catalyst/simulated_beacon.go
@@ -165,6 +165,7 @@ func (c *SimulatedBeacon) sealBlock(withdrawals []*types.Withdrawal) error {
 		return errors.New("chain rewind prevented invocation of payload creation")
 	}
 
+	c.engineAPI.localBlocks.waitFull(*fcResponse.PayloadID)
 	envelope, err := c.engineAPI.getPayload(*fcResponse.PayloadID, true)
 	if err != nil {
 		return err

--- a/eth/catalyst/simulated_beacon.go
+++ b/eth/catalyst/simulated_beacon.go
@@ -165,7 +165,9 @@ func (c *SimulatedBeacon) sealBlock(withdrawals []*types.Withdrawal) error {
 		return errors.New("chain rewind prevented invocation of payload creation")
 	}
 
-	c.engineAPI.localBlocks.waitFull(*fcResponse.PayloadID)
+	if err := c.engineAPI.localBlocks.waitFull(*fcResponse.PayloadID); err != nil {
+		return err
+	}
 	envelope, err := c.engineAPI.getPayload(*fcResponse.PayloadID, true)
 	if err != nil {
 		return err

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -250,5 +250,5 @@ func (miner *Miner) SubscribePendingLogs(ch chan<- []*types.Log) event.Subscript
 
 // BuildPayload builds the payload according to the provided parameters.
 func (miner *Miner) BuildPayload(args *BuildPayloadArgs) (*Payload, error) {
-	return miner.worker.buildPayload(args, nil)
+	return miner.worker.buildPayload(args)
 }

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -250,5 +250,5 @@ func (miner *Miner) SubscribePendingLogs(ch chan<- []*types.Log) event.Subscript
 
 // BuildPayload builds the payload according to the provided parameters.
 func (miner *Miner) BuildPayload(args *BuildPayloadArgs) (*Payload, error) {
-	return miner.worker.buildPayload(args)
+	return miner.worker.buildPayload(args, nil)
 }

--- a/miner/payload_building.go
+++ b/miner/payload_building.go
@@ -182,6 +182,12 @@ func (payload *Payload) ResolveFull() *engine.ExecutionPayloadEnvelope {
 	return payload.resolve(true)
 }
 
+func (payload *Payload) WaitFull() {
+	payload.lock.Lock()
+	defer payload.lock.Unlock()
+	payload.cond.Wait()
+}
+
 func (payload *Payload) resolve(onlyFull bool) *engine.ExecutionPayloadEnvelope {
 	payload.lock.Lock()
 	defer payload.lock.Unlock()

--- a/miner/payload_building.go
+++ b/miner/payload_building.go
@@ -297,7 +297,8 @@ func (w *worker) buildPayload(args *BuildPayloadArgs) (*Payload, error) {
 
 	// Since we skip building the empty block when using the tx pool, we need to explicitly
 	// validate the BuildPayloadArgs here.
-	if err := w.validateParams(fullParams); err != nil {
+	blockTime, err := w.validateParams(fullParams)
+	if err != nil {
 		return nil, err
 	}
 
@@ -314,10 +315,8 @@ func (w *worker) buildPayload(args *BuildPayloadArgs) (*Payload, error) {
 		defer timer.Stop()
 
 		start := time.Now()
-		const blockTime = 2 * time.Second // OP default block time
-		// Setup the timer for terminating the process if SECONDS_PER_SLOT (12s in
-		// the Mainnet configuration) have passed since the point in time identified
-		// by the timestamp parameter.
+		// Setup the timer for terminating the payload building process as determined
+		// by validateParams.
 		endTimer := time.NewTimer(blockTime)
 		defer endTimer.Stop()
 

--- a/miner/payload_building_test.go
+++ b/miner/payload_building_test.go
@@ -38,6 +38,7 @@ func TestBuildPayload(t *testing.T) {
 	defer w.close()
 
 	timestamp := uint64(time.Now().Unix())
+	// TODO: Add NoTxPool = true test case
 	args := &BuildPayloadArgs{
 		Parent:       b.chain.CurrentBlock().Hash(),
 		Timestamp:    timestamp,

--- a/miner/payload_building_test.go
+++ b/miner/payload_building_test.go
@@ -30,6 +30,7 @@ import (
 )
 
 func TestBuildPayload(t *testing.T) {
+	IsPayloadBuildingTest = true
 	t.Run("with-tx-pool", func(t *testing.T) { testBuildPayload(t, false) })
 	t.Run("no-tx-pool", func(t *testing.T) { testBuildPayload(t, true) })
 }
@@ -52,8 +53,7 @@ func testBuildPayload(t *testing.T, noTxPool bool) {
 	}
 	// payload resolution now interrupts block building, so we have to
 	// wait for the payloading building process to build its first block
-	tdone := make(chan struct{}, 1)
-	payload, err := w.buildPayload(args, tdone)
+	payload, err := w.buildPayload(args)
 	if err != nil {
 		t.Fatalf("Failed to build payload %v", err)
 	}
@@ -87,7 +87,6 @@ func testBuildPayload(t *testing.T, noTxPool bool) {
 		full := payload.ResolveFull()
 		verify(full, 0)
 	} else {
-		<-tdone
 		full := payload.ResolveFull()
 		verify(full, len(pendingTxs))
 	}

--- a/miner/payload_building_test.go
+++ b/miner/payload_building_test.go
@@ -30,7 +30,6 @@ import (
 )
 
 func TestBuildPayload(t *testing.T) {
-	IsPayloadBuildingTest = true
 	t.Run("with-tx-pool", func(t *testing.T) { testBuildPayload(t, false) })
 	t.Run("no-tx-pool", func(t *testing.T) { testBuildPayload(t, true) })
 }

--- a/miner/payload_building_test.go
+++ b/miner/payload_building_test.go
@@ -103,9 +103,7 @@ func testBuildPayload(t *testing.T, noTxPool, interrupt bool) {
 		full := payload.ResolveFull()
 		verify(full, len(pendingTxs)+numInterruptTxs)
 	} else { // tx-pool and no interrupt
-		// wait to fully build the first block
-		// if we call ResolveFull too fast, it interrupts it and doesn't add any tx
-		time.Sleep(time.Second)
+		payload.WaitFull()
 		full := payload.ResolveFull()
 		verify(full, len(pendingTxs))
 	}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1170,10 +1170,6 @@ func (w *worker) commitWork(interrupt *atomic.Int32, timestamp int64) {
 	}
 	// Fill pending transactions from the txpool into the block.
 	err = w.fillTransactions(interrupt, work)
-	// TODO: Why does this switch not need to do anything about a errBlockInterruptedByTimeout signal?
-	//   Is it because the commitWork path is only entered by signals from the newWork loop, so
-	//   errBlockInterruptedByTimeout cannot be the cause for interruption here?
-	//   So we can also safely ignore the new errBlockInterruptedByResolve signal here?
 	switch {
 	case err == nil:
 		// The entire block is filled, decrease resubmit interval in case


### PR DESCRIPTION
**Description**

- Block building is interrupted on a `getPayload` engine api call.
- Empty block is now only built for `NoTxPool` FCU calls, and as before, FCU blocks on building the empty block. This has the advantage that if generating a lot of empty blocks, `getPayload` can immediately be called after `forkchoiceUpdated` to return that empty block.
- If using the tx pool, FCU doesn't block on any block building but returns immediately after creating the payload promise.
    - Resolution of the payload promise (`getPayload`) now waits for the first full block to be built, as there is no empty block to return. If at least one block has already been built, as before, it is returned immediately, while block building is interrupted in the background.

**Tests**

Extended the `TestBuildPayload` test to cover both cases of `NoTxPool`.

Added an ugly global bool to indicate that a test is running, which guarantees one full block is built and block building is not interrupted. This seemed to be the least-invasive way to make all tests still pass. This was necessary because a couple of test call `Resolve` or `getPayload` immediately after a FCU, but this would now interrupts the block building process, which made tests fail.

**Additional context**



**Metadata**

- Fixes https://github.com/ethereum-optimism/client-pod/issues/173
- Fixes https://github.com/ethereum-optimism/client-pod/issues/187
- Fixes https://github.com/ethereum-optimism/client-pod/issues/163
