### PR TITLE
consensus: EnsureCreate2Deployer check hardfork boundary, not exact block time

### DIFF
--- a/consensus/misc/create2deployer.go
+++ b/consensus/misc/create2deployer.go
@@ -28,8 +28,9 @@ func init() {
 	create2DeployerCode = code
 }
 
-func EnsureCreate2Deployer(c *params.ChainConfig, timestamp uint64, db vm.StateDB) {
-	if !c.IsOptimism() || c.CanyonTime == nil || *c.CanyonTime != timestamp {
+func EnsureCreate2Deployer(c *params.ChainConfig, parentTimestamp, timestamp uint64, db vm.StateDB) {
+	// only ensure if Canyon is active, and if we just passed the fork-boundary or if this is genesis.
+	if !(c.IsOptimism() && c.IsCanyon(timestamp) && (!c.IsCanyon(parentTimestamp) || parentTimestamp == 0)) {
 		return
 	}
 	log.Info("Setting Create2Deployer code", "address", create2DeployerAddress, "codeHash", create2DeployerCodeHash)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -71,7 +71,8 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	if p.config.DAOForkSupport && p.config.DAOForkBlock != nil && p.config.DAOForkBlock.Cmp(block.Number()) == 0 {
 		misc.ApplyDAOHardFork(statedb)
 	}
-	misc.EnsureCreate2Deployer(p.config, block.Time(), statedb)
+	parent := p.bc.GetHeaderByHash(block.ParentHash())
+	misc.EnsureCreate2Deployer(p.config, parent.Time, block.Time(), statedb)
 	var (
 		context = NewEVMBlockContext(header, p.bc, nil, p.config, statedb)
 		vmenv   = vm.NewEVM(context, vm.TxContext{}, statedb, p.config, cfg)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1071,8 +1071,8 @@ func (w *worker) generateWork(genParams *generateParams) *newPayloadResult {
 	if work.gasPool == nil {
 		work.gasPool = new(core.GasPool).AddGas(work.header.GasLimit)
 	}
-
-	misc.EnsureCreate2Deployer(w.chainConfig, work.header.Time, work.state)
+	parent := w.chain.GetHeaderByHash(work.header.ParentHash)
+	misc.EnsureCreate2Deployer(w.chainConfig, parent.Time, work.header.Time, work.state)
 
 	for _, tx := range genParams.txs {
 		from, _ := types.Sender(work.signer, tx)


### PR DESCRIPTION
**Description**

This adds the parent block timestamp as input to `EnsureCreate2Deployer`, and updates the check to see if we crossed the hardfork boundary, rather than checking the exact timestamp.

This way the functionality is not dependent on genesis-time and block-time alignment with hardfork configuration.
E.g. if we have:
```
# chain A:
genesis_time=1002
block_time=10

# chain B:
genesis_time=1001
block_time=2

# chain C
genesis_time=1002
block_time=2

canyon_hardfork_time=1004
```
Then previously chain A and chain B would miss the `Create2Deployer`, since none of their blocks matched the exact hardfork time, even though they passed the hardfork.

**Tests**

Added test-cases.

**Additional context**

This should never happen if the block-time is 2 and the genesis is aligned with a L1 block (as default in chain creation currently), but some OP-Stack chains have a different config. And mainnet L1 has odd block-numbers, so we can't safely set the canyon hardfork time to a nice round number without this change.

