### PR TITLE
interop: MPT verification precompile draft

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -41,6 +41,8 @@ type (
 func (evm *EVM) precompile(addr common.Address) (PrecompiledContract, bool) {
 	var precompiles map[common.Address]PrecompiledContract
 	switch {
+	case evm.chainRules.IsOptimismInterop:
+		precompiles = PrecompiledContractsInterop
 	case evm.chainRules.IsCancun:
 		precompiles = PrecompiledContractsCancun
 	case evm.chainRules.IsBerlin:

--- a/params/config.go
+++ b/params/config.go
@@ -647,6 +647,9 @@ func (c *ChainConfig) IsOptimismRegolith(time uint64) bool {
 func (c *ChainConfig) IsOptimismCanyon(time uint64) bool {
 	return c.IsOptimism() && c.IsCanyon(time)
 }
+func (c *ChainConfig) IsOptimismInterop(time uint64) bool {
+	return c.IsOptimism() && c.IsInterop(time)
+}
 
 // IsOptimismPreBedrock returns true iff this is an optimism node & bedrock is not yet active
 func (c *ChainConfig) IsOptimismPreBedrock(num *big.Int) bool {
@@ -972,6 +975,7 @@ type Rules struct {
 	IsVerkle                                                bool
 	IsOptimismBedrock, IsOptimismRegolith                   bool
 	IsOptimismCanyon                                        bool
+	IsOptimismInterop                                       bool
 }
 
 // Rules ensures c's ChainID is not nil.
@@ -1001,5 +1005,6 @@ func (c *ChainConfig) Rules(num *big.Int, isMerge bool, timestamp uint64) Rules 
 		IsOptimismBedrock:  c.IsOptimismBedrock(num),
 		IsOptimismRegolith: c.IsOptimismRegolith(timestamp),
 		IsOptimismCanyon:   c.IsOptimismCanyon(timestamp),
+		IsOptimismInterop:  c.IsOptimismInterop(timestamp),
 	}
 }


### PR DESCRIPTION
**Description**

Introducing a MPT state verification precompile as part of the interop update allows the L2 to verify MPT proofs with native geth code securely and efficiently, without introducing new MPT verification logic.

Potentially some version of this can be upstreamed to L1, as part of https://eips.ethereum.org/EIPS/eip-7545, for MPT verification. Or maybe a rollcall "RIP" (rollup EIP equivalent).

Also, we may want to upstream `VerifyProofStrictKey` to geth: the default `VerifyProof` does not actually check if the full key was used. The secure-merkle-trie (key hashing) generally protects against problems like the above, but it's better safe than sorry to check, for any non-rollup/L1 uses with weird short keys.

**Tests**

Added basic unit tests based on the example in the ethereum MPT wiki, and another test-case to see what happens with 32-byte large keys.


**Metadata**

Fix https://github.com/ethereum-optimism/interop/issues/23
