### PR TITLE
params: add note about Delta, update protocol version to indicate Delta pre-release support

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -358,6 +358,7 @@ type ChainConfig struct {
 	BedrockBlock *big.Int `json:"bedrockBlock,omitempty"` // Bedrock switch block (nil = no fork, 0 = already on optimism bedrock)
 	RegolithTime *uint64  `json:"regolithTime,omitempty"` // Regolith switch time (nil = no fork, 0 = already on optimism regolith)
 	CanyonTime   *uint64  `json:"canyonTime,omitempty"`   // Canyon switch time (nil = no fork, 0 = already on optimism canyon)
+	// Delta: the Delta upgrade does not affect the execution-layer, and is thus not configurable in the chain config.
 
 	InteropTime *uint64 `json:"interopTime,omitempty"` // Interop switch time (nil = no fork, 0 = already on optimism interop)
 

--- a/params/superchain.go
+++ b/params/superchain.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-var OPStackSupport = ProtocolVersionV0{Build: [8]byte{}, Major: 4, Minor: 0, Patch: 0, PreRelease: 1}.Encode()
+var OPStackSupport = ProtocolVersionV0{Build: [8]byte{}, Major: 5, Minor: 0, Patch: 0, PreRelease: 1}.Encode()
 
 func init() {
 	for id, ch := range superchain.OPChains {


### PR DESCRIPTION
**Description**

See https://github.com/ethereum-optimism/optimism/pull/8354

Even though op-geth does not change with the Delta superchain upgrade (as of current pre-release), it does need to signal that it supports the non-change.
