### PR TITLE
Deterministically wait for payloads to build the first full block

### DIFF
--- a/eth/catalyst/queue.go
+++ b/eth/catalyst/queue.go
@@ -17,6 +17,7 @@
 package catalyst
 
 import (
+	"errors"
 	"sync"
 
 	"github.com/ethereum/go-ethereum/beacon/engine"
@@ -93,18 +94,20 @@ func (q *payloadQueue) get(id engine.PayloadID, full bool) *engine.ExecutionPayl
 
 // waitFull waits until the first full payload has been built for the specified payload id
 // The method returns immediately if the payload is unknown.
-func (q *payloadQueue) waitFull(id engine.PayloadID) {
+func (q *payloadQueue) waitFull(id engine.PayloadID) error {
 	q.lock.RLock()
 	defer q.lock.RUnlock()
 
 	for _, item := range q.payloads {
 		if item == nil {
-			return // no more items
+			return errors.New("unknown payload")
 		}
 		if item.id == id {
 			item.payload.WaitFull()
+			return nil
 		}
 	}
+	return errors.New("unknown payload")
 }
 
 // has checks if a particular payload is already tracked.

--- a/eth/catalyst/queue.go
+++ b/eth/catalyst/queue.go
@@ -91,6 +91,22 @@ func (q *payloadQueue) get(id engine.PayloadID, full bool) *engine.ExecutionPayl
 	return nil
 }
 
+// waitFull waits until the first full payload has been built for the specified payload id
+// The method returns immediately if the payload is unknown.
+func (q *payloadQueue) waitFull(id engine.PayloadID) {
+	q.lock.RLock()
+	defer q.lock.RUnlock()
+
+	for _, item := range q.payloads {
+		if item == nil {
+			return // no more items
+		}
+		if item.id == id {
+			item.payload.WaitFull()
+		}
+	}
+}
+
 // has checks if a particular payload is already tracked.
 func (q *payloadQueue) has(id engine.PayloadID) bool {
 	q.lock.RLock()

--- a/eth/catalyst/simulated_beacon.go
+++ b/eth/catalyst/simulated_beacon.go
@@ -165,6 +165,7 @@ func (c *SimulatedBeacon) sealBlock(withdrawals []*types.Withdrawal) error {
 		return errors.New("chain rewind prevented invocation of payload creation")
 	}
 
+	c.engineAPI.localBlocks.waitFull(*fcResponse.PayloadID)
 	envelope, err := c.engineAPI.getPayload(*fcResponse.PayloadID, true)
 	if err != nil {
 		return err

--- a/eth/catalyst/simulated_beacon.go
+++ b/eth/catalyst/simulated_beacon.go
@@ -165,7 +165,9 @@ func (c *SimulatedBeacon) sealBlock(withdrawals []*types.Withdrawal) error {
 		return errors.New("chain rewind prevented invocation of payload creation")
 	}
 
-	c.engineAPI.localBlocks.waitFull(*fcResponse.PayloadID)
+	if err := c.engineAPI.localBlocks.waitFull(*fcResponse.PayloadID); err != nil {
+		return err
+	}
 	envelope, err := c.engineAPI.getPayload(*fcResponse.PayloadID, true)
 	if err != nil {
 		return err

--- a/miner/payload_building.go
+++ b/miner/payload_building.go
@@ -182,6 +182,12 @@ func (payload *Payload) ResolveFull() *engine.ExecutionPayloadEnvelope {
 	return payload.resolve(true)
 }
 
+func (payload *Payload) WaitFull() {
+	payload.lock.Lock()
+	defer payload.lock.Unlock()
+	payload.cond.Wait()
+}
+
 func (payload *Payload) resolve(onlyFull bool) *engine.ExecutionPayloadEnvelope {
 	payload.lock.Lock()
 	defer payload.lock.Unlock()

--- a/miner/payload_building_test.go
+++ b/miner/payload_building_test.go
@@ -103,9 +103,7 @@ func testBuildPayload(t *testing.T, noTxPool, interrupt bool) {
 		full := payload.ResolveFull()
 		verify(full, len(pendingTxs)+numInterruptTxs)
 	} else { // tx-pool and no interrupt
-		// wait to fully build the first block
-		// if we call ResolveFull too fast, it interrupts it and doesn't add any tx
-		time.Sleep(time.Second)
+		payload.WaitFull()
 		full := payload.ResolveFull()
 		verify(full, len(pendingTxs))
 	}


### PR DESCRIPTION
**Description**

Rather than waiting for a fixed amount of time, expose methods to allow waiting for the payload to complete building the first block.


