### PR TITLE
L2 Cancun support, activate on Ecotone

### DIFF
--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -69,6 +69,9 @@ func ValidateTransaction(tx *types.Transaction, head *types.Header, signer types
 	if tx.Type() == types.DepositTxType {
 		return core.ErrTxTypeNotSupported
 	}
+	if opts.Config.IsOptimism() && tx.Type() == types.BlobTxType {
+		return core.ErrTxTypeNotSupported
+	}
 	// Ensure transactions not implemented by the calling pool are rejected
 	if opts.Accept&(1<<tx.Type()) == 0 {
 		return fmt.Errorf("%w: tx type %v not supported by this pool", core.ErrTxTypeNotSupported, tx.Type())

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -40,7 +40,7 @@ type sigCache struct {
 func MakeSigner(config *params.ChainConfig, blockNumber *big.Int, blockTime uint64) Signer {
 	var signer Signer
 	switch {
-	case config.IsCancun(blockNumber, blockTime):
+	case config.IsCancun(blockNumber, blockTime) && !config.IsOptimism():
 		signer = NewCancunSigner(config.ChainID)
 	case config.IsLondon(blockNumber):
 		signer = NewLondonSigner(config.ChainID)
@@ -65,7 +65,7 @@ func MakeSigner(config *params.ChainConfig, blockNumber *big.Int, blockTime uint
 // have the current block number available, use MakeSigner instead.
 func LatestSigner(config *params.ChainConfig) Signer {
 	if config.ChainID != nil {
-		if config.CancunTime != nil {
+		if config.CancunTime != nil && !config.IsOptimism() {
 			return NewCancunSigner(config.ChainID)
 		}
 		if config.LondonBlock != nil {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -293,6 +293,9 @@ func (b *EthAPIBackend) SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscri
 }
 
 func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction) error {
+	if b.ChainConfig().IsOptimism() && signedTx.Type() == types.BlobTxType {
+		return types.ErrTxTypeNotSupported
+	}
 	if b.eth.seqRPCService != nil {
 		data, err := signedTx.MarshalBinary()
 		if err != nil {

--- a/go.sum
+++ b/go.sum
@@ -181,8 +181,6 @@ github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.m
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/etcd-io/bbolt v1.3.3/go.mod h1:ZF2nL25h33cCyBtcyWeZ2/I3HQOfTP+0PIEvHjkjCrw=
-github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20231220193740-b624008369ea h1:eG415nqsRtvN9TtsyqreAmtBOCisRtG9M9JICYXNI5c=
-github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20231220193740-b624008369ea/go.mod h1:/70H/KqrtKcvWvNGVj6S3rAcLC+kUPr3t2aDmYIS+Xk=
 github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240103191009-655947053753 h1:DL667cfM6peU8H9Ut/uu9h9Bd4gQCcJrjq+yYsfYwjk=
 github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240103191009-655947053753/go.mod h1:/70H/KqrtKcvWvNGVj6S3rAcLC+kUPr3t2aDmYIS+Xk=
 github.com/ethereum/c-kzg-4844 v0.4.0 h1:3MS1s4JtA868KpJxroZoepdV0ZKBp3u/O5HcZ7R3nlY=

--- a/params/superchain.go
+++ b/params/superchain.go
@@ -65,8 +65,8 @@ func LoadOPStackChainConfig(chainID uint64) (*ChainConfig, error) {
 		ArrowGlacierBlock:             common.Big0,
 		GrayGlacierBlock:              common.Big0,
 		MergeNetsplitBlock:            common.Big0,
-		ShanghaiTime:                  superchainConfig.Config.CanyonTime, // Shanghai activates with Canyon
-		CancunTime:                    nil,
+		ShanghaiTime:                  superchainConfig.Config.CanyonTime,  // Shanghai activates with Canyon
+		CancunTime:                    superchainConfig.Config.EcotoneTime, // Cancun activates with Ecotone
 		PragueTime:                    nil,
 		BedrockBlock:                  common.Big0,
 		RegolithTime:                  &genesisActivation,


### PR DESCRIPTION
**Description**

Changes:
- explicitly disable Blob transactions
- explicitly change signer methods to use London signer instead of Cancun signer
- activate Cancun when Ecotone superchain fork is set
- update superchain-registry dep (for Ecotone rename)

**Tests**

To be tested in op-e2e. Draft PR for now.


**Metadata**

Part of https://github.com/ethereum-optimism/optimism/issues/8701
