### PR TITLE
Extend execution payload envelope to contain parent beacon block root

### DIFF
--- a/beacon/engine/gen_epe.go
+++ b/beacon/engine/gen_epe.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
@@ -15,26 +16,29 @@ var _ = (*executionPayloadEnvelopeMarshaling)(nil)
 // MarshalJSON marshals as JSON.
 func (e ExecutionPayloadEnvelope) MarshalJSON() ([]byte, error) {
 	type ExecutionPayloadEnvelope struct {
-		ExecutionPayload *ExecutableData `json:"executionPayload"  gencodec:"required"`
-		BlockValue       *hexutil.Big    `json:"blockValue"  gencodec:"required"`
-		BlobsBundle      *BlobsBundleV1  `json:"blobsBundle"`
-		Override         bool            `json:"shouldOverrideBuilder"`
+		ExecutionPayload      *ExecutableData `json:"executionPayload"  gencodec:"required"`
+		BlockValue            *hexutil.Big    `json:"blockValue"  gencodec:"required"`
+		BlobsBundle           *BlobsBundleV1  `json:"blobsBundle"`
+		Override              bool            `json:"shouldOverrideBuilder"`
+		ParentBeaconBlockRoot *common.Hash    `json:"parentBeaconBlockRoot,omitempty"`
 	}
 	var enc ExecutionPayloadEnvelope
 	enc.ExecutionPayload = e.ExecutionPayload
 	enc.BlockValue = (*hexutil.Big)(e.BlockValue)
 	enc.BlobsBundle = e.BlobsBundle
 	enc.Override = e.Override
+	enc.ParentBeaconBlockRoot = e.ParentBeaconBlockRoot
 	return json.Marshal(&enc)
 }
 
 // UnmarshalJSON unmarshals from JSON.
 func (e *ExecutionPayloadEnvelope) UnmarshalJSON(input []byte) error {
 	type ExecutionPayloadEnvelope struct {
-		ExecutionPayload *ExecutableData `json:"executionPayload"  gencodec:"required"`
-		BlockValue       *hexutil.Big    `json:"blockValue"  gencodec:"required"`
-		BlobsBundle      *BlobsBundleV1  `json:"blobsBundle"`
-		Override         *bool           `json:"shouldOverrideBuilder"`
+		ExecutionPayload      *ExecutableData `json:"executionPayload"  gencodec:"required"`
+		BlockValue            *hexutil.Big    `json:"blockValue"  gencodec:"required"`
+		BlobsBundle           *BlobsBundleV1  `json:"blobsBundle"`
+		Override              *bool           `json:"shouldOverrideBuilder"`
+		ParentBeaconBlockRoot *common.Hash    `json:"parentBeaconBlockRoot,omitempty"`
 	}
 	var dec ExecutionPayloadEnvelope
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -53,6 +57,9 @@ func (e *ExecutionPayloadEnvelope) UnmarshalJSON(input []byte) error {
 	}
 	if dec.Override != nil {
 		e.Override = *dec.Override
+	}
+	if dec.ParentBeaconBlockRoot != nil {
+		e.ParentBeaconBlockRoot = dec.ParentBeaconBlockRoot
 	}
 	return nil
 }

--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -98,6 +98,9 @@ type ExecutionPayloadEnvelope struct {
 	BlockValue       *big.Int        `json:"blockValue"  gencodec:"required"`
 	BlobsBundle      *BlobsBundleV1  `json:"blobsBundle"`
 	Override         bool            `json:"shouldOverrideBuilder"`
+
+	// OP-Stack: Ecotone specific fields
+	ParentBeaconBlockRoot *common.Hash `json:"parentBeaconBlockRoot,omitempty"`
 }
 
 type BlobsBundleV1 struct {
@@ -281,7 +284,13 @@ func BlockToExecutableData(block *types.Block, fees *big.Int, sidecars []*types.
 			bundle.Proofs = append(bundle.Proofs, hexutil.Bytes(sidecar.Proofs[j][:]))
 		}
 	}
-	return &ExecutionPayloadEnvelope{ExecutionPayload: data, BlockValue: fees, BlobsBundle: &bundle, Override: false}
+	return &ExecutionPayloadEnvelope{
+		ExecutionPayload:      data,
+		BlockValue:            fees,
+		BlobsBundle:           &bundle,
+		Override:              false,
+		ParentBeaconBlockRoot: block.BeaconRoot(),
+	}
 }
 
 // ExecutionPayloadBodyV1 is used in the response to GetPayloadBodiesByHashV1 and GetPayloadBodiesByRangeV1

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -458,7 +458,6 @@ func (api *ConsensusAPI) getPayload(payloadID engine.PayloadID, full bool) (*eng
 	if data == nil {
 		return nil, engine.UnknownPayload
 	}
-
 	return data, nil
 }
 

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -458,6 +458,7 @@ func (api *ConsensusAPI) getPayload(payloadID engine.PayloadID, full bool) (*eng
 	if data == nil {
 		return nil, engine.UnknownPayload
 	}
+
 	return data, nil
 }
 


### PR DESCRIPTION
**Description**

Extend `ExecutionPayloadEnvelope` to return parent beacon block root as discussed in this [specs PR](https://github.com/ethereum-optimism/optimism/pull/8852).

**Tests**

Added a e2e test for this behavior in `op_geth_test.go`. Happy to also port a a similar test here.