### PR TITLE
update transaction_args to latest for blob support

### DIFF
--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -26,10 +26,12 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/holiman/uint256"
 )
 
 // TransactionArgs represents the arguments to construct a new transaction
@@ -53,6 +55,10 @@ type TransactionArgs struct {
 	// Introduced by AccessListTxType transaction.
 	AccessList *types.AccessList `json:"accessList,omitempty"`
 	ChainID    *hexutil.Big      `json:"chainId,omitempty"`
+
+	// Introduced by EIP-4844.
+	BlobFeeCap *hexutil.Big  `json:"maxFeePerBlobGas"`
+	BlobHashes []common.Hash `json:"blobVersionedHashes,omitempty"`
 }
 
 // from retrieves the transaction sender address.
@@ -92,6 +98,12 @@ func (args *TransactionArgs) setDefaults(ctx context.Context, b Backend) error {
 	if args.Data != nil && args.Input != nil && !bytes.Equal(*args.Data, *args.Input) {
 		return errors.New(`both "data" and "input" are set and not equal. Please use "input" to pass transaction call data`)
 	}
+	if args.BlobHashes != nil && args.To == nil {
+		return errors.New(`blob transactions cannot have the form of a create transaction`)
+	}
+	if args.BlobHashes != nil && len(args.BlobHashes) == 0 {
+		return errors.New(`need at least 1 blob for a blob transaction`)
+	}
 	if args.To == nil && len(args.data()) == 0 {
 		return errors.New(`contract creation without any data provided`)
 	}
@@ -110,8 +122,8 @@ func (args *TransactionArgs) setDefaults(ctx context.Context, b Backend) error {
 			Data:                 (*hexutil.Bytes)(&data),
 			AccessList:           args.AccessList,
 		}
-		pendingBlockNr := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
-		estimated, err := DoEstimateGas(ctx, b, callArgs, pendingBlockNr, nil, b.RPCGasCap())
+		latestBlockNr := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
+		estimated, err := DoEstimateGas(ctx, b, callArgs, latestBlockNr, nil, b.RPCGasCap())
 		if err != nil {
 			return err
 		}
@@ -137,27 +149,53 @@ func (args *TransactionArgs) setFeeDefaults(ctx context.Context, b Backend) erro
 	if args.GasPrice != nil && (args.MaxFeePerGas != nil || args.MaxPriorityFeePerGas != nil) {
 		return errors.New("both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified")
 	}
-	// If the tx has completely specified a fee mechanism, no default is needed. This allows users
-	// who are not yet synced past London to get defaults for other tx values. See
-	// https://github.com/ethereum/go-ethereum/pull/23274 for more information.
+	// If the tx has completely specified a fee mechanism, no default is needed.
+	// This allows users who are not yet synced past London to get defaults for
+	// other tx values. See https://github.com/ethereum/go-ethereum/pull/23274
+	// for more information.
 	eip1559ParamsSet := args.MaxFeePerGas != nil && args.MaxPriorityFeePerGas != nil
-	if (args.GasPrice != nil && !eip1559ParamsSet) || (args.GasPrice == nil && eip1559ParamsSet) {
-		// Sanity check the EIP-1559 fee parameters if present.
-		if args.GasPrice == nil && args.MaxFeePerGas.ToInt().Cmp(args.MaxPriorityFeePerGas.ToInt()) < 0 {
+
+	// Sanity check the EIP-1559 fee parameters if present.
+	if args.GasPrice == nil && eip1559ParamsSet {
+		if args.MaxFeePerGas.ToInt().Sign() == 0 {
+			return errors.New("maxFeePerGas must be non-zero")
+		}
+		if args.MaxFeePerGas.ToInt().Cmp(args.MaxPriorityFeePerGas.ToInt()) < 0 {
 			return fmt.Errorf("maxFeePerGas (%v) < maxPriorityFeePerGas (%v)", args.MaxFeePerGas, args.MaxPriorityFeePerGas)
 		}
-		return nil
+		return nil // No need to set anything, user already set MaxFeePerGas and MaxPriorityFeePerGas
 	}
-	// Now attempt to fill in default value depending on whether London is active or not.
+	// Sanity check the EIP-4844 fee parameters.
+	if args.BlobFeeCap != nil && args.BlobFeeCap.ToInt().Sign() == 0 {
+		return errors.New("maxFeePerBlobGas must be non-zero")
+	}
+	// Sanity check the non-EIP-1559 fee parameters.
 	head := b.CurrentHeader()
-	if b.ChainConfig().IsLondon(head.Number) {
+	isLondon := b.ChainConfig().IsLondon(head.Number)
+	if args.GasPrice != nil && !eip1559ParamsSet {
+		// Zero gas-price is not allowed after London fork
+		if args.GasPrice.ToInt().Sign() == 0 && isLondon {
+			return errors.New("gasPrice must be non-zero after london fork")
+		}
+		return nil // No need to set anything, user already set GasPrice
+	}
+
+	// Now attempt to fill in default value depending on whether London is active or not.
+	if b.ChainConfig().IsCancun(head.Number, head.Time) {
+		if err := args.setCancunFeeDefaults(ctx, head, b); err != nil {
+			return err
+		}
+	} else if isLondon {
+		if args.BlobFeeCap != nil {
+			return errors.New("maxFeePerBlobGas is not valid before Cancun is active")
+		}
 		// London is active, set maxPriorityFeePerGas and maxFeePerGas.
 		if err := args.setLondonFeeDefaults(ctx, head, b); err != nil {
 			return err
 		}
 	} else {
-		if args.MaxFeePerGas != nil || args.MaxPriorityFeePerGas != nil {
-			return errors.New("maxFeePerGas and maxPriorityFeePerGas are not valid before London is active")
+		if args.MaxFeePerGas != nil || args.MaxPriorityFeePerGas != nil || args.BlobFeeCap != nil {
+			return errors.New("maxFeePerGas and maxPriorityFeePerGas and maxFeePerBlobGas are not valid before London is active")
 		}
 		// London not active, set gas price.
 		price, err := b.SuggestGasTipCap(ctx)
@@ -167,6 +205,21 @@ func (args *TransactionArgs) setFeeDefaults(ctx context.Context, b Backend) erro
 		args.GasPrice = (*hexutil.Big)(price)
 	}
 	return nil
+}
+
+// setCancunFeeDefaults fills in reasonable default fee values for unspecified fields.
+func (args *TransactionArgs) setCancunFeeDefaults(ctx context.Context, head *types.Header, b Backend) error {
+	// Set maxFeePerBlobGas if it is missing.
+	if args.BlobHashes != nil && args.BlobFeeCap == nil {
+		// ExcessBlobGas must be set for a Cancun block.
+		blobBaseFee := eip4844.CalcBlobFee(*head.ExcessBlobGas)
+		// Set the max fee to be 2 times larger than the previous block's blob base fee.
+		// The additional slack allows the tx to not become invalidated if the base
+		// fee is rising.
+		val := new(big.Int).Mul(blobBaseFee, big.NewInt(2))
+		args.BlobFeeCap = (*hexutil.Big)(val)
+	}
+	return args.setLondonFeeDefaults(ctx, head, b)
 }
 
 // setLondonFeeDefaults fills in reasonable default fee values for unspecified fields.
@@ -221,9 +274,10 @@ func (args *TransactionArgs) ToMessage(globalGasCap uint64, baseFee *big.Int) (*
 		gas = globalGasCap
 	}
 	var (
-		gasPrice  *big.Int
-		gasFeeCap *big.Int
-		gasTipCap *big.Int
+		gasPrice   *big.Int
+		gasFeeCap  *big.Int
+		gasTipCap  *big.Int
+		blobFeeCap *big.Int
 	)
 	if baseFee == nil {
 		// If there's no basefee, then it must be a non-1559 execution
@@ -255,6 +309,11 @@ func (args *TransactionArgs) ToMessage(globalGasCap uint64, baseFee *big.Int) (*
 			}
 		}
 	}
+	if args.BlobFeeCap != nil {
+		blobFeeCap = args.BlobFeeCap.ToInt()
+	} else if args.BlobHashes != nil {
+		blobFeeCap = new(big.Int)
+	}
 	value := new(big.Int)
 	if args.Value != nil {
 		value = args.Value.ToInt()
@@ -274,6 +333,8 @@ func (args *TransactionArgs) ToMessage(globalGasCap uint64, baseFee *big.Int) (*
 		GasTipCap:         gasTipCap,
 		Data:              data,
 		AccessList:        accessList,
+		BlobGasFeeCap:     blobFeeCap,
+		BlobHashes:        args.BlobHashes,
 		SkipAccountChecks: true,
 	}
 	return msg, nil
@@ -284,6 +345,24 @@ func (args *TransactionArgs) ToMessage(globalGasCap uint64, baseFee *big.Int) (*
 func (args *TransactionArgs) toTransaction() *types.Transaction {
 	var data types.TxData
 	switch {
+	case args.BlobHashes != nil:
+		al := types.AccessList{}
+		if args.AccessList != nil {
+			al = *args.AccessList
+		}
+		data = &types.BlobTx{
+			To:         *args.To,
+			ChainID:    uint256.MustFromBig((*big.Int)(args.ChainID)),
+			Nonce:      uint64(*args.Nonce),
+			Gas:        uint64(*args.Gas),
+			GasFeeCap:  uint256.MustFromBig((*big.Int)(args.MaxFeePerGas)),
+			GasTipCap:  uint256.MustFromBig((*big.Int)(args.MaxPriorityFeePerGas)),
+			Value:      uint256.MustFromBig((*big.Int)(args.Value)),
+			Data:       args.data(),
+			AccessList: al,
+			BlobHashes: args.BlobHashes,
+			BlobFeeCap: uint256.MustFromBig((*big.Int)(args.BlobFeeCap)),
+		}
 	case args.MaxFeePerGas != nil:
 		al := types.AccessList{}
 		if args.AccessList != nil {
@@ -328,4 +407,9 @@ func (args *TransactionArgs) toTransaction() *types.Transaction {
 // This assumes that setDefaults has been called.
 func (args *TransactionArgs) ToTransaction() *types.Transaction {
 	return args.toTransaction()
+}
+
+// IsEIP4844 returns an indicator if the args contains EIP4844 fields.
+func (args *TransactionArgs) IsEIP4844() bool {
+	return args.BlobHashes != nil || args.BlobFeeCap != nil
 }

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -43,15 +43,16 @@ import (
 // TestSetFeeDefaults tests the logic for filling in default fee values works as expected.
 func TestSetFeeDefaults(t *testing.T) {
 	type test struct {
-		name     string
-		isLondon bool
-		in       *TransactionArgs
-		want     *TransactionArgs
-		err      error
+		name string
+		fork string // options: legacy, london, cancun
+		in   *TransactionArgs
+		want *TransactionArgs
+		err  error
 	}
 
 	var (
 		b        = newBackendMock()
+		zero     = (*hexutil.Big)(big.NewInt(0))
 		fortytwo = (*hexutil.Big)(big.NewInt(42))
 		maxFee   = (*hexutil.Big)(new(big.Int).Add(new(big.Int).Mul(b.current.BaseFee, big.NewInt(2)), fortytwo.ToInt()))
 		al       = &types.AccessList{types.AccessTuple{Address: common.Address{0xaa}, StorageKeys: []common.Hash{{0x01}}}}
@@ -61,51 +62,65 @@ func TestSetFeeDefaults(t *testing.T) {
 		// Legacy txs
 		{
 			"legacy tx pre-London",
-			false,
+			"legacy",
 			&TransactionArgs{},
 			&TransactionArgs{GasPrice: fortytwo},
 			nil,
 		},
 		{
+			"legacy tx pre-London with zero price",
+			"legacy",
+			&TransactionArgs{GasPrice: zero},
+			&TransactionArgs{GasPrice: zero},
+			nil,
+		},
+		{
 			"legacy tx post-London, explicit gas price",
-			true,
+			"london",
 			&TransactionArgs{GasPrice: fortytwo},
 			&TransactionArgs{GasPrice: fortytwo},
 			nil,
+		},
+		{
+			"legacy tx post-London with zero price",
+			"london",
+			&TransactionArgs{GasPrice: zero},
+			nil,
+			errors.New("gasPrice must be non-zero after london fork"),
 		},
 
 		// Access list txs
 		{
 			"access list tx pre-London",
-			false,
+			"legacy",
 			&TransactionArgs{AccessList: al},
 			&TransactionArgs{AccessList: al, GasPrice: fortytwo},
 			nil,
 		},
 		{
 			"access list tx post-London, explicit gas price",
-			false,
+			"legacy",
 			&TransactionArgs{AccessList: al, GasPrice: fortytwo},
 			&TransactionArgs{AccessList: al, GasPrice: fortytwo},
 			nil,
 		},
 		{
 			"access list tx post-London",
-			true,
+			"london",
 			&TransactionArgs{AccessList: al},
 			&TransactionArgs{AccessList: al, MaxFeePerGas: maxFee, MaxPriorityFeePerGas: fortytwo},
 			nil,
 		},
 		{
 			"access list tx post-London, only max fee",
-			true,
+			"london",
 			&TransactionArgs{AccessList: al, MaxFeePerGas: maxFee},
 			&TransactionArgs{AccessList: al, MaxFeePerGas: maxFee, MaxPriorityFeePerGas: fortytwo},
 			nil,
 		},
 		{
 			"access list tx post-London, only priority fee",
-			true,
+			"london",
 			&TransactionArgs{AccessList: al, MaxFeePerGas: maxFee},
 			&TransactionArgs{AccessList: al, MaxFeePerGas: maxFee, MaxPriorityFeePerGas: fortytwo},
 			nil,
@@ -114,84 +129,118 @@ func TestSetFeeDefaults(t *testing.T) {
 		// Dynamic fee txs
 		{
 			"dynamic tx post-London",
-			true,
+			"london",
 			&TransactionArgs{},
 			&TransactionArgs{MaxFeePerGas: maxFee, MaxPriorityFeePerGas: fortytwo},
 			nil,
 		},
 		{
 			"dynamic tx post-London, only max fee",
-			true,
+			"london",
 			&TransactionArgs{MaxFeePerGas: maxFee},
 			&TransactionArgs{MaxFeePerGas: maxFee, MaxPriorityFeePerGas: fortytwo},
 			nil,
 		},
 		{
 			"dynamic tx post-London, only priority fee",
-			true,
+			"london",
 			&TransactionArgs{MaxFeePerGas: maxFee},
 			&TransactionArgs{MaxFeePerGas: maxFee, MaxPriorityFeePerGas: fortytwo},
 			nil,
 		},
 		{
 			"dynamic fee tx pre-London, maxFee set",
-			false,
+			"legacy",
 			&TransactionArgs{MaxFeePerGas: maxFee},
 			nil,
-			errors.New("maxFeePerGas and maxPriorityFeePerGas are not valid before London is active"),
+			errors.New("maxFeePerGas and maxPriorityFeePerGas and maxFeePerBlobGas are not valid before London is active"),
 		},
 		{
 			"dynamic fee tx pre-London, priorityFee set",
-			false,
+			"legacy",
 			&TransactionArgs{MaxPriorityFeePerGas: fortytwo},
 			nil,
-			errors.New("maxFeePerGas and maxPriorityFeePerGas are not valid before London is active"),
+			errors.New("maxFeePerGas and maxPriorityFeePerGas and maxFeePerBlobGas are not valid before London is active"),
 		},
 		{
 			"dynamic fee tx, maxFee < priorityFee",
-			true,
+			"london",
 			&TransactionArgs{MaxFeePerGas: maxFee, MaxPriorityFeePerGas: (*hexutil.Big)(big.NewInt(1000))},
 			nil,
 			errors.New("maxFeePerGas (0x3e) < maxPriorityFeePerGas (0x3e8)"),
 		},
 		{
 			"dynamic fee tx, maxFee < priorityFee while setting default",
-			true,
+			"london",
 			&TransactionArgs{MaxFeePerGas: (*hexutil.Big)(big.NewInt(7))},
 			nil,
 			errors.New("maxFeePerGas (0x7) < maxPriorityFeePerGas (0x2a)"),
+		},
+		{
+			"dynamic fee tx post-London, explicit gas price",
+			"london",
+			&TransactionArgs{MaxFeePerGas: zero, MaxPriorityFeePerGas: zero},
+			nil,
+			errors.New("maxFeePerGas must be non-zero"),
 		},
 
 		// Misc
 		{
 			"set all fee parameters",
-			false,
+			"legacy",
 			&TransactionArgs{GasPrice: fortytwo, MaxFeePerGas: maxFee, MaxPriorityFeePerGas: fortytwo},
 			nil,
 			errors.New("both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified"),
 		},
 		{
 			"set gas price and maxPriorityFee",
-			false,
+			"legacy",
 			&TransactionArgs{GasPrice: fortytwo, MaxPriorityFeePerGas: fortytwo},
 			nil,
 			errors.New("both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified"),
 		},
 		{
 			"set gas price and maxFee",
-			true,
+			"london",
 			&TransactionArgs{GasPrice: fortytwo, MaxFeePerGas: maxFee},
 			nil,
 			errors.New("both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified"),
+		},
+		// EIP-4844
+		{
+			"set maxFeePerBlobGas pre cancun",
+			"london",
+			&TransactionArgs{BlobFeeCap: fortytwo},
+			nil,
+			errors.New("maxFeePerBlobGas is not valid before Cancun is active"),
+		},
+		{
+			"set maxFeePerBlobGas pre london",
+			"legacy",
+			&TransactionArgs{BlobFeeCap: fortytwo},
+			nil,
+			errors.New("maxFeePerGas and maxPriorityFeePerGas and maxFeePerBlobGas are not valid before London is active"),
+		},
+		{
+			"set gas price and maxFee for blob transaction",
+			"cancun",
+			&TransactionArgs{GasPrice: fortytwo, MaxFeePerGas: maxFee, BlobHashes: []common.Hash{}},
+			nil,
+			errors.New("both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified"),
+		},
+		{
+			"fill maxFeePerBlobGas",
+			"cancun",
+			&TransactionArgs{BlobHashes: []common.Hash{}},
+			&TransactionArgs{BlobHashes: []common.Hash{}, BlobFeeCap: (*hexutil.Big)(big.NewInt(4)), MaxFeePerGas: maxFee, MaxPriorityFeePerGas: fortytwo},
+			nil,
 		},
 	}
 
 	ctx := context.Background()
 	for i, test := range tests {
-		if test.isLondon {
-			b.activateLondon()
-		} else {
-			b.deactivateLondon()
+		if err := b.setFork(test.fork); err != nil {
+			t.Fatalf("failed to set fork: %v", err)
 		}
 		got := test.in
 		err := got.setFeeDefaults(ctx, b)
@@ -213,6 +262,7 @@ type backendMock struct {
 }
 
 func newBackendMock() *backendMock {
+	var cancunTime uint64 = 600
 	config := &params.ChainConfig{
 		ChainID:             big.NewInt(42),
 		HomesteadBlock:      big.NewInt(0),
@@ -228,6 +278,7 @@ func newBackendMock() *backendMock {
 		MuirGlacierBlock:    big.NewInt(0),
 		BerlinBlock:         big.NewInt(0),
 		LondonBlock:         big.NewInt(1000),
+		CancunTime:          &cancunTime,
 	}
 	return &backendMock{
 		current: &types.Header{
@@ -243,13 +294,25 @@ func newBackendMock() *backendMock {
 	}
 }
 
-func (b *backendMock) activateLondon() {
-	b.current.Number = big.NewInt(1100)
+func (b *backendMock) setFork(fork string) error {
+	if fork == "legacy" {
+		b.current.Number = big.NewInt(900)
+		b.current.Time = 555
+	} else if fork == "london" {
+		b.current.Number = big.NewInt(1100)
+		b.current.Time = 555
+	} else if fork == "cancun" {
+		b.current.Number = big.NewInt(1100)
+		b.current.Time = 700
+		// Blob base fee will be 2
+		excess := uint64(2314058)
+		b.current.ExcessBlobGas = &excess
+	} else {
+		return errors.New("invalid fork")
+	}
+	return nil
 }
 
-func (b *backendMock) deactivateLondon() {
-	b.current.Number = big.NewInt(900)
-}
 func (b *backendMock) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
 	return big.NewInt(42), nil
 }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Updates op-geth with the latest version of transaction_args.go from upstream geth.

**Tests**

Also brings in the updated unit tests.
