### PR TITLE
ci: update image to default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
         type: boolean
         default: false
     machine:
-      image: ubuntu-2204:2022.07.1
+      image: default
       resource_class: xlarge
     steps:
       - gcp-cli/install


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Handle deprecated build image on circle https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/50177 

