### PR TITLE
core/vm: Allow precompiles to be overriden

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -54,7 +54,7 @@ func (evm *EVM) precompile(addr common.Address) (PrecompiledContract, bool) {
 	}
 	p, ok := precompiles[addr]
 	// Restrict overrides to known precompiles
-	if evm.chainConfig.IsOptimism() && evm.Config.OptimismPrecompileOverrides != nil {
+	if ok && evm.chainConfig.IsOptimism() && evm.Config.OptimismPrecompileOverrides != nil {
 		override, ok := evm.Config.OptimismPrecompileOverrides(evm.chainRules, addr)
 		if ok {
 			return override, ok

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -53,6 +53,13 @@ func (evm *EVM) precompile(addr common.Address) (PrecompiledContract, bool) {
 		precompiles = PrecompiledContractsHomestead
 	}
 	p, ok := precompiles[addr]
+	// Restrict overrides to known precompiles
+	if evm.chainConfig.IsOptimism() && evm.Config.OptimismPrecompileOverrides != nil {
+		override, ok := evm.Config.OptimismPrecompileOverrides(evm.chainRules, addr)
+		if ok {
+			return override, ok
+		}
+	}
 	return p, ok
 }
 

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -21,14 +21,19 @@ import (
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
 )
+
+// PrecompileOverrides is a function that can be used to override the default precompiled contracts
+type PrecompileOverrides func(params.Rules, common.Address) (PrecompiledContract, bool)
 
 // Config are the configuration options for the Interpreter
 type Config struct {
-	Tracer                  EVMLogger // Opcode logger
-	NoBaseFee               bool      // Forces the EIP-1559 baseFee to 0 (needed for 0 price calls)
-	EnablePreimageRecording bool      // Enables recording of SHA3/keccak preimages
-	ExtraEips               []int     // Additional EIPS that are to be enabled
+	Tracer                      EVMLogger           // Opcode logger
+	NoBaseFee                   bool                // Forces the EIP-1559 baseFee to 0 (needed for 0 price calls)
+	EnablePreimageRecording     bool                // Enables recording of SHA3/keccak preimages
+	ExtraEips                   []int               // Additional EIPS that are to be enabled
+	OptimismPrecompileOverrides PrecompileOverrides // Precompile overrides for Optimism
 }
 
 // ScopeContext contains the things that are per-call, such as stack and memory,


### PR DESCRIPTION
Add a config option to override precompiles for Optimism execution.

The usecase for this change is to allow expensive precompiles, such as KZG point evaluation, to be replaced with a version that is more suitable for a given runtime.

For example, in the case of the fault proof program, executing the KZG point evaluation in MIPS32 requires over 15 billion steps. We'd like to offload this expensive execution to the op-program host, where it's much cheaper to execute.

**This change modifies behavior only when `vm.Config.OptimismPrecompileOverrides` is set**.