### PR TITLE
fix(forkdiff): update sub definitions to fix hydration

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -1,17 +1,19 @@
 name: Build and publish forkdiff github-pages
 permissions:
   contents: write
+
 on:
   push:
     branches:
       - optimism
+
 jobs:
   deploy:
     concurrency: ci-${{ github.ref }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1000  # make sure to fetch the old commit we diff against
 
@@ -23,7 +25,7 @@ jobs:
       - name: Build pages
         run: |
           mkdir -p tmp/pages
-          mv index.html tmp/pages/index.html
+          mv index.html tmp/pages/index.html || { echo "Error: Failed to move index.html to tmp/pages/"; exit 1; }
           touch tmp/pages/.nojekyll
           if [ "$GITHUB_REPOSITORY" == "ethereum-optimism/op-geth" ]; then
               echo "op-geth.optimism.io" > tmp/pages/CNAME

--- a/fork.yaml
+++ b/fork.yaml
@@ -1,6 +1,6 @@
 title: "op-geth - go-ethereum fork diff overview"
 footer: |
-  Fork-diff overview of [`op-geth`](https://github.com/ethereum-optimism/op-geth), a fork of [`go-ethereum`](https://github.com/ethereum/go-ethereum).
+  Fork-diff overview of [`op-geth`](https://github.com/ethereum-optimism/op-geth), a fork of [`go-ethereum, v1.13.8`](https://github.com/ethereum/go-ethereum).
   and execution-engine of the [OP-stack](https://github.com/ethereum-optimism/optimism).
 base:
   name: go-ethereum
@@ -25,6 +25,8 @@ def:
 
     - [L2 Execution Engine spec](https://github.com/ethereum-optimism/optimism/blob/develop/specs/exec-engine.md)
     - [Deposit Transaction spec](https://github.com/ethereum-optimism/optimism/blob/develop/specs/deposits.md)
+
+    Last updated: Tue Feb 13 19:58:26 UTC 2024
   sub:
     - title: "Core modifications"
       sub:
@@ -119,7 +121,7 @@ def:
           description: |
             The rollup functionality is enabled with the `optimism` field in the chain config.
             The EIP-1559 parameters are configurable to adjust for faster more frequent and smaller blocks.
-            The parameters can be overriden for testing.
+            The parameters can be overridden for testing.
           globs:
             - "params/config.go"
             - "params/protocol_params.go"
@@ -166,7 +168,6 @@ def:
             - "eth/ethconfig/config.go"
         - title: Tx gossip disable option
           globs:
-            - "eth/handler.go"
             - "eth/handler_eth.go"
         - title: Warn on missing hardfork data
           globs:
@@ -182,7 +183,6 @@ def:
         - title: Historical data for Snap-sync
           description: Snap-sync has access to trusted Deposit Transaction Nonce Data.
           globs:
-            - "eth/handler.go"
             - "eth/downloader/downloader.go"
             - "eth/downloader/receiptreference.go"
         - title: Discv5 node discovery


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This updates your `fork.yaml` file so that forkdiff binary can successfully build the report page.

Under the existing `fork.yaml` file, it fails to build and gives the following error:

```console
$ forkdiff
failed to hydrate patch stats 
error: sub definition 2 failed to hydrate: sub definition 6 failed to hydrate: file "eth/handler.go" was matched by glob 0 ("eth/handler.go") but is not remaining11:36:53 Tue Feb 13 2024 janitor macbook
```
**Tests**

I ran forkdiff with the updated changes and was able to successfully build the report page.

**Additional context**

There is no validation of the file, `fork.yaml`. Additionally, there exists no timestamp or versioning information in the generated report page. 

I added two hard coded values:
	1. the version of the corresponding git hash for go-ethereum, v1.13.8
	2. a 'Last Updated' value, using TZ=UTC


~~~diff
```yaml
# fork.yaml
footer: |
!  a fork of [`go-ethereum, v1.13.8`](https://github.com/ethereum/go-ethereum).
     description: |

+     Last updated: Tue Feb 13 19:58:26 UTC 2024
  sub:
```
~~~


## Considerations

`fork.yaml` should be validated at build, additionally I found no configuration specification for detailing diffing policy or setup.

For reference, this is one configuration

```cfg
git config --global merge.renameLimit 999999
git config --global diff.renameLimit 33440
git config --global diff.algorithm patience
```

This is beyond the scope of this PR, I just thought to mention it, as it makes maintainer job easier. 
