### PR TITLE
Fjord: Add FastLZ compression into L1CostFunc

### DIFF
--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -87,7 +87,7 @@ type Receipt struct {
 	// Optimism: extend receipts with L1 fee info
 	L1GasPrice          *big.Int   `json:"l1GasPrice,omitempty"`          // Present from pre-bedrock. L1 Basefee after Bedrock
 	L1BlobBaseFee       *big.Int   `json:"l1BlobBaseFee,omitempty"`       // Always nil prior to the Ecotone hardfork
-	L1GasUsed           *big.Int   `json:"l1GasUsed,omitempty"`           // Present from pre-bedrock
+	L1GasUsed           *big.Int   `json:"l1GasUsed,omitempty"`           // Present from pre-bedrock, deprecated as of Fjord
 	L1Fee               *big.Int   `json:"l1Fee,omitempty"`               // Present from pre-bedrock
 	FeeScalar           *big.Float `json:"l1FeeScalar,omitempty"`         // Present from pre-bedrock to Ecotone. Nil after Ecotone
 	L1BaseFeeScalar     *uint64    `json:"l1BaseFeeScalar,omitempty"`     // Always nil prior to the Ecotone hardfork

--- a/core/types/rollup_cost.go
+++ b/core/types/rollup_cost.go
@@ -75,7 +75,6 @@ var (
 	fjordDivisor   = big.NewInt(1_000_000_000_000)
 	sixteen        = big.NewInt(16)
 
-	// TODO(ytu): Add spec link once spec is merged
 	l1CostIntercept  = big.NewInt(-27_321_890)
 	l1CostFastlzCoef = big.NewInt(1_031_462)
 	l1CostTxSizeCoef = big.NewInt(-88_664)
@@ -86,8 +85,8 @@ var (
 // RollupCostData is a transaction structure that caches data for quickly computing the data
 // availablility costs for the transaction.
 type RollupCostData struct {
-	zeroes, ones   uint64
-	compressedSize uint64
+	zeroes, ones uint64
+	fastlzSize   uint64
 }
 
 type StateGetter interface {
@@ -110,7 +109,7 @@ func NewRollupCostData(data []byte) (out RollupCostData) {
 			out.ones++
 		}
 	}
-	out.compressedSize = uint64(FlzCompressLen(data))
+	out.fastlzSize = uint64(FlzCompressLen(data))
 	return out
 }
 
@@ -346,7 +345,7 @@ func newL1CostFuncFjord(l1BaseFee, l1BlobBaseFee, l1BaseFeeScalar, l1BlobBaseFee
 		blobCostPerByte := new(big.Int).Mul(l1BlobBaseFee, l1BlobBaseFeeScalar)
 		l1FeeScaled := new(big.Int).Add(calldataCostPerByte, blobCostPerByte)
 
-		fastlzTerm := new(big.Int).SetUint64(costData.compressedSize)
+		fastlzTerm := new(big.Int).SetUint64(costData.fastlzSize)
 		fastlzTerm.Mul(fastlzTerm, l1CostFastlzCoef)
 		txSizeTerm := new(big.Int).SetUint64(costData.zeroes + costData.ones)
 		txSizeTerm.Mul(txSizeTerm, l1CostTxSizeCoef)

--- a/core/types/rollup_cost.go
+++ b/core/types/rollup_cost.go
@@ -136,7 +136,7 @@ func NewL1CostFunc(config *params.ChainConfig, statedb StateGetter) L1CostFunc {
 			// function. We detect this scenario by checking if the Ecotone parameters are
 			// unset. Note here we rely on assumption that the scalar parameters are adjacent
 			// in the buffer and l1BaseFeeScalar comes first. We need to check this prior to
-			// other forks, as the first block of Fjord and Ecotone could be the  same block.
+			// other forks, as the first block of Fjord and Ecotone could be the same block.
 			firstEcotoneBlock := l1BlobBaseFee.BitLen() == 0 &&
 				bytes.Equal(emptyScalars, l1FeeScalars[scalarSectionStart:scalarSectionStart+8])
 			if firstEcotoneBlock {

--- a/core/types/rollup_cost.go
+++ b/core/types/rollup_cost.go
@@ -78,7 +78,7 @@ var (
 	L1CostIntercept  = big.NewInt(-42_585_600)
 	L1CostFastlzCoef = big.NewInt(836_500)
 
-	MinTransactionSize       = big.NewInt(71)
+	MinTransactionSize       = big.NewInt(100)
 	MinTransactionSizeScaled = new(big.Int).Mul(MinTransactionSize, big.NewInt(1e6))
 
 	emptyScalars = make([]byte, 8)

--- a/core/types/rollup_cost.go
+++ b/core/types/rollup_cost.go
@@ -75,16 +75,17 @@ var (
 	fjordDivisor   = big.NewInt(1_000_000_000_000)
 	sixteen        = big.NewInt(16)
 
-	l1CostIntercept  = big.NewInt(-42_585_600)
-	l1CostFastlzCoef = big.NewInt(836_500)
+	L1CostIntercept  = big.NewInt(-42_585_600)
+	L1CostFastlzCoef = big.NewInt(836_500)
 
-	minTransactionSize = big.NewInt(71 * 1e6)
+	MinTransactionSize       = big.NewInt(71)
+	MinTransactionSizeScaled = new(big.Int).Mul(MinTransactionSize, big.NewInt(1e6))
 
 	emptyScalars = make([]byte, 8)
 )
 
 // RollupCostData is a transaction structure that caches data for quickly computing the data
-// availablility costs for the transaction.
+// availability costs for the transaction.
 type RollupCostData struct {
 	zeroes, ones uint64
 	fastlzSize   uint64
@@ -365,11 +366,11 @@ func newL1CostFuncFjord(l1BaseFee, l1BlobBaseFee, l1BaseFeeScalar, l1BlobBaseFee
 		l1FeeScaled := new(big.Int).Add(calldataCostPerByte, blobCostPerByte)
 
 		fastlzSize := new(big.Int).SetUint64(costData.fastlzSize)
-		fastlzSize.Mul(fastlzSize, l1CostFastlzCoef)
-		fastlzSize.Add(fastlzSize, l1CostIntercept)
+		fastlzSize.Mul(fastlzSize, L1CostFastlzCoef)
+		fastlzSize.Add(fastlzSize, L1CostIntercept)
 
-		if fastlzSize.Cmp(minTransactionSize) < 0 {
-			fastlzSize.Set(minTransactionSize)
+		if fastlzSize.Cmp(MinTransactionSizeScaled) < 0 {
+			fastlzSize.Set(MinTransactionSizeScaled)
 		}
 
 		l1CostSigned := new(big.Int).Set(fastlzSize)

--- a/core/types/rollup_cost.go
+++ b/core/types/rollup_cost.go
@@ -352,7 +352,7 @@ func l1CostHelper(gasWithOverhead, l1BaseFee, scalar *big.Int) *big.Int {
 // newL1CostFuncFjord returns an l1 cost function suitable for the Fjord upgrade
 func newL1CostFuncFjord(l1BaseFee, l1BlobBaseFee, l1BaseFeeScalar, l1BlobBaseFeeScalar *big.Int) l1CostFunc {
 	return func(costData RollupCostData) (fee, calldataGasUsed *big.Int) {
-		calldataGasUsed = bedrockCalldataGasUsed(costData)
+		calldataGasUsed = new(big.Int).SetUint64(costData.fastlzSize * params.TxDataNonZeroGasEIP2028)
 		// Fjord L1 cost function:
 		//
 		//l1FeeScaled = baseFeeScalar*l1BaseFee*16 + blobFeeScalar*l1BlobBaseFee

--- a/core/types/rollup_cost_test.go
+++ b/core/types/rollup_cost_test.go
@@ -286,6 +286,18 @@ func TestNewL1CostFunc(t *testing.T) {
 	fee = costFunc(emptyTx.RollupCostData(), time)
 	require.NotNil(t, fee)
 	require.Equal(t, regolithFee, fee)
+
+	// emptyTx fee w/ fjord config, but simulate first ecotone block by blowing away the ecotone
+	// params. Should result in regolith fee.
+	config.EcotoneTime = &time
+	config.FjordTime = &time
+	statedb.baseFeeScalar = 0
+	statedb.blobBaseFeeScalar = 0
+	statedb.blobBaseFee = new(big.Int)
+	costFunc = NewL1CostFunc(config, statedb)
+	fee = costFunc(emptyTx.RollupCostData(), time)
+	require.NotNil(t, fee)
+	require.Equal(t, regolithFee, fee)
 }
 
 func TestFlzCompressLen(t *testing.T) {

--- a/core/types/rollup_cost_test.go
+++ b/core/types/rollup_cost_test.go
@@ -73,6 +73,24 @@ func TestFjordL1CostFunc(t *testing.T) {
 	require.Equal(t, fjordFee, c0)
 }
 
+// TestFjordL1CostSolidityParity tests that the cost function for the fjord upgrade matches a Solidity
+// test to ensure the outputs are the same.
+func TestFjordL1CostSolidityParity(t *testing.T) {
+	costFunc := newL1CostFuncFjord(
+		big.NewInt(2*1e6),
+		big.NewInt(3*1e6),
+		big.NewInt(20),
+		big.NewInt(15),
+	)
+
+	c0, g0 := costFunc(RollupCostData{
+		fastlzSize: 235,
+	})
+
+	require.Equal(t, big.NewInt(3760), g0)
+	require.Equal(t, big.NewInt(105484), c0)
+}
+
 func TestExtractBedrockGasParams(t *testing.T) {
 	regolithTime := uint64(1)
 	config := &params.ChainConfig{

--- a/core/types/rollup_cost_test.go
+++ b/core/types/rollup_cost_test.go
@@ -27,7 +27,8 @@ var (
 	bedrockFee  = big.NewInt(11326000000000)
 	regolithFee = big.NewInt(3710000000000)
 	ecotoneFee  = big.NewInt(960900) // (480/16)*(2*16*1000 + 3*10) == 960900
-	fjordFee    = big.NewInt(63852)  // (-27321890 + 1031462*31 - 88664*30) * (2*16*1000 + 3*10) / 1e6 == 63852
+	// the emptyTx is out of bounds for the linear regression so it uses the minimum size
+	fjordFee = big.NewInt(2274130) // 71_000_000 * (2 * 1000 * 1e6 * 16 + 3 * 10 * 1e6) / 1e12
 
 	bedrockGas  = big.NewInt(1618)
 	regolithGas = big.NewInt(530) // 530  = 1618 - (16*68)
@@ -66,7 +67,6 @@ func TestFjordL1CostFunc(t *testing.T) {
 		blobBaseFeeScalar,
 		l1CostIntercept,
 		l1CostFastlzCoef,
-		l1CostTxSizeCoef,
 	)
 
 	c0, g0 := costFunc(emptyTx.RollupCostData())

--- a/core/types/rollup_cost_test.go
+++ b/core/types/rollup_cost_test.go
@@ -33,7 +33,7 @@ var (
 	bedrockGas  = big.NewInt(1618)
 	regolithGas = big.NewInt(530) // 530  = 1618 - (16*68)
 	ecotoneGas  = big.NewInt(480)
-	fjordGas    = ecotoneGas
+	fjordGas    = big.NewInt(496) // fastlz size of the txn
 )
 
 func TestBedrockL1CostFunc(t *testing.T) {

--- a/core/types/rollup_cost_test.go
+++ b/core/types/rollup_cost_test.go
@@ -33,7 +33,7 @@ var (
 	bedrockGas  = big.NewInt(1618)
 	regolithGas = big.NewInt(530) // 530  = 1618 - (16*68)
 	ecotoneGas  = big.NewInt(480)
-	fjordGas    = big.NewInt(496) // fastlz size of the txn
+	fjordGas    = big.NewInt(1600) // fastlz size of minimum txn, 100_000_000 * 16 / 1e6
 )
 
 func TestBedrockL1CostFunc(t *testing.T) {
@@ -87,7 +87,7 @@ func TestFjordL1CostSolidityParity(t *testing.T) {
 		fastlzSize: 235,
 	})
 
-	require.Equal(t, big.NewInt(3760), g0)
+	require.Equal(t, big.NewInt(2463), g0)
 	require.Equal(t, big.NewInt(105484), c0)
 }
 

--- a/core/types/rollup_cost_test.go
+++ b/core/types/rollup_cost_test.go
@@ -28,7 +28,7 @@ var (
 	regolithFee = big.NewInt(3710000000000)
 	ecotoneFee  = big.NewInt(960900) // (480/16)*(2*16*1000 + 3*10) == 960900
 	// the emptyTx is out of bounds for the linear regression so it uses the minimum size
-	fjordFee = big.NewInt(2274130) // 71_000_000 * (2 * 1000 * 1e6 * 16 + 3 * 10 * 1e6) / 1e12
+	fjordFee = big.NewInt(3203000) // 100_000_000 * (2 * 1000 * 1e6 * 16 + 3 * 10 * 1e6) / 1e12
 
 	bedrockGas  = big.NewInt(1618)
 	regolithGas = big.NewInt(530) // 530  = 1618 - (16*68)

--- a/core/types/rollup_cost_test.go
+++ b/core/types/rollup_cost_test.go
@@ -60,14 +60,12 @@ func TestEcotoneL1CostFunc(t *testing.T) {
 }
 
 func TestFjordL1CostFuncMinimumBounds(t *testing.T) {
-	costFunc := newL1CostFuncFjord(
+	costFunc := NewL1CostFuncFjord(
 		baseFee,
 		blobBaseFee,
 		baseFeeScalar,
 		blobBaseFeeScalar,
 	)
-
-	c0, g0 := costFunc(emptyTx.RollupCostData())
 
 	// Minimum size transactions:
 	// -42.5856 + 0.8365*110 = 49.4294
@@ -75,7 +73,7 @@ func TestFjordL1CostFuncMinimumBounds(t *testing.T) {
 	// -42.5856 + 0.8365*170 = 99.6194
 	for _, fastLzsize := range []uint64{100, 150, 170} {
 		c, g := costFunc(RollupCostData{
-			fastlzSize: fastLzsize,
+			FastLzSize: fastLzsize,
 		})
 
 		require.Equal(t, minimumFjordGas, g)
@@ -87,19 +85,19 @@ func TestFjordL1CostFuncMinimumBounds(t *testing.T) {
 	// -42.5856 + 0.8365*175 = 108.8019
 	// -42.5856 + 0.8365*200 = 124.7144
 	for _, fastLzsize := range []uint64{171, 175, 200} {
-		c0, g0 = costFunc(RollupCostData{
-			fastlzSize: fastLzsize,
+		c, g := costFunc(RollupCostData{
+			FastLzSize: fastLzsize,
 		})
 
-		require.Greater(t, g0.Uint64(), minimumFjordGas.Uint64())
-		require.Greater(t, c0.Uint64(), fjordFee.Uint64())
+		require.Greater(t, g.Uint64(), minimumFjordGas.Uint64())
+		require.Greater(t, c.Uint64(), fjordFee.Uint64())
 	}
 }
 
 // TestFjordL1CostSolidityParity tests that the cost function for the fjord upgrade matches a Solidity
 // test to ensure the outputs are the same.
 func TestFjordL1CostSolidityParity(t *testing.T) {
-	costFunc := newL1CostFuncFjord(
+	costFunc := NewL1CostFuncFjord(
 		big.NewInt(2*1e6),
 		big.NewInt(3*1e6),
 		big.NewInt(20),
@@ -107,7 +105,7 @@ func TestFjordL1CostSolidityParity(t *testing.T) {
 	)
 
 	c0, g0 := costFunc(RollupCostData{
-		fastlzSize: 235,
+		FastLzSize: 235,
 	})
 
 	require.Equal(t, big.NewInt(2463), g0)

--- a/core/types/rollup_cost_test.go
+++ b/core/types/rollup_cost_test.go
@@ -1,13 +1,16 @@
 package types
 
 import (
+	"bytes"
 	"encoding/binary"
+	"encoding/hex"
 	"math/big"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params"
-	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -24,10 +27,12 @@ var (
 	bedrockFee  = big.NewInt(11326000000000)
 	regolithFee = big.NewInt(3710000000000)
 	ecotoneFee  = big.NewInt(960900) // (480/16)*(2*16*1000 + 3*10) == 960900
+	fjordFee    = big.NewInt(63852)  // (-27321890 + 1031462*31 - 88664*30) * (2*16*1000 + 3*10) / 1e6 == 63852
 
 	bedrockGas  = big.NewInt(1618)
 	regolithGas = big.NewInt(530) // 530  = 1618 - (16*68)
 	ecotoneGas  = big.NewInt(480)
+	fjordGas    = ecotoneGas
 )
 
 func TestBedrockL1CostFunc(t *testing.T) {
@@ -46,9 +51,28 @@ func TestBedrockL1CostFunc(t *testing.T) {
 
 func TestEcotoneL1CostFunc(t *testing.T) {
 	costFunc := newL1CostFuncEcotone(baseFee, blobBaseFee, baseFeeScalar, blobBaseFeeScalar)
-	c, g := costFunc(emptyTx.RollupCostData())
-	require.Equal(t, ecotoneGas, g)
-	require.Equal(t, ecotoneFee, c)
+
+	c0, g0 := costFunc(emptyTx.RollupCostData())
+
+	require.Equal(t, ecotoneGas, g0)
+	require.Equal(t, ecotoneFee, c0)
+}
+
+func TestFjordL1CostFunc(t *testing.T) {
+	costFunc := newL1CostFuncFjord(
+		baseFee,
+		blobBaseFee,
+		baseFeeScalar,
+		blobBaseFeeScalar,
+		l1CostIntercept,
+		l1CostFastlzCoef,
+		l1CostTxSizeCoef,
+	)
+
+	c0, g0 := costFunc(emptyTx.RollupCostData())
+
+	require.Equal(t, fjordGas, g0)
+	require.Equal(t, fjordFee, c0)
 }
 
 func TestExtractBedrockGasParams(t *testing.T) {
@@ -93,13 +117,18 @@ func TestExtractEcotoneGasParams(t *testing.T) {
 		RegolithTime: &zeroTime,
 		EcotoneTime:  &zeroTime,
 	}
-	require.True(t, config.IsOptimismEcotone(0))
+	require.True(t, config.IsOptimismEcotone(zeroTime))
 
-	data := getEcotoneL1Attributes(baseFee, blobBaseFee, baseFeeScalar, blobBaseFeeScalar)
+	data := getEcotoneL1Attributes(
+		baseFee,
+		blobBaseFee,
+		baseFeeScalar,
+		blobBaseFeeScalar,
+	)
 
-	gasparams, err := extractL1GasParams(config, 0, data)
-	costFunc := gasparams.costFunc
+	gasparams, err := extractL1GasParams(config, zeroTime, data)
 	require.NoError(t, err)
+	costFunc := gasparams.costFunc
 
 	c, g := costFunc(emptyTx.RollupCostData())
 
@@ -126,10 +155,11 @@ func TestFirstBlockEcotoneGasParams(t *testing.T) {
 
 	data := getBedrockL1Attributes(baseFee, overhead, scalar)
 
-	gasparams, err := extractL1GasParams(config, 0, data)
-	oldCostFunc := gasparams.costFunc
+	gasparams, err := extractL1GasParams(config, zeroTime, data)
 	require.NoError(t, err)
-	c, _ := oldCostFunc(emptyTx.RollupCostData())
+	oldCostFunc := gasparams.costFunc
+	c, g := oldCostFunc(emptyTx.RollupCostData())
+	require.Equal(t, regolithGas, g)
 	require.Equal(t, regolithFee, c)
 }
 
@@ -152,19 +182,19 @@ func getBedrockL1Attributes(baseFee, overhead, scalar *big.Int) []byte {
 func getEcotoneL1Attributes(baseFee, blobBaseFee, baseFeeScalar, blobBaseFeeScalar *big.Int) []byte {
 	ignored := big.NewInt(1234)
 	data := []byte{}
-	uint256 := make([]byte, 32)
-	uint64 := make([]byte, 8)
-	uint32 := make([]byte, 4)
+	uint256Slice := make([]byte, 32)
+	uint64Slice := make([]byte, 8)
+	uint32Slice := make([]byte, 4)
 	data = append(data, EcotoneL1AttributesSelector...)
-	data = append(data, baseFeeScalar.FillBytes(uint32)...)
-	data = append(data, blobBaseFeeScalar.FillBytes(uint32)...)
-	data = append(data, ignored.FillBytes(uint64)...)
-	data = append(data, ignored.FillBytes(uint64)...)
-	data = append(data, ignored.FillBytes(uint64)...)
-	data = append(data, baseFee.FillBytes(uint256)...)
-	data = append(data, blobBaseFee.FillBytes(uint256)...)
-	data = append(data, ignored.FillBytes(uint256)...)
-	data = append(data, ignored.FillBytes(uint256)...)
+	data = append(data, baseFeeScalar.FillBytes(uint32Slice)...)
+	data = append(data, blobBaseFeeScalar.FillBytes(uint32Slice)...)
+	data = append(data, ignored.FillBytes(uint64Slice)...)
+	data = append(data, ignored.FillBytes(uint64Slice)...)
+	data = append(data, ignored.FillBytes(uint64Slice)...)
+	data = append(data, baseFee.FillBytes(uint256Slice)...)
+	data = append(data, blobBaseFee.FillBytes(uint256Slice)...)
+	data = append(data, ignored.FillBytes(uint256Slice)...)
+	data = append(data, ignored.FillBytes(uint256Slice)...)
 	return data
 }
 
@@ -185,6 +215,7 @@ func (sg *testStateGetter) GetState(addr common.Address, slot common.Hash) commo
 	case L1BlobBaseFeeSlot:
 		sg.blobBaseFee.FillBytes(buf[:])
 	case L1FeeScalarsSlot:
+		// fetch Ecotone fee sclars
 		offset := scalarSectionStart
 		binary.BigEndian.PutUint32(buf[offset:offset+4], sg.baseFeeScalar)
 		binary.BigEndian.PutUint32(buf[offset+4:offset+8], sg.blobBaseFeeScalar)
@@ -197,7 +228,8 @@ func (sg *testStateGetter) GetState(addr common.Address, slot common.Hash) commo
 // TestNewL1CostFunc tests that the appropriate cost function is selected based on the
 // configuration and statedb values.
 func TestNewL1CostFunc(t *testing.T) {
-	time := uint64(1)
+	time := uint64(10)
+	timeInFuture := uint64(20)
 	config := &params.ChainConfig{
 		Optimism: params.OptimismTestConfig.Optimism,
 	}
@@ -237,8 +269,16 @@ func TestNewL1CostFunc(t *testing.T) {
 	require.NotNil(t, fee)
 	require.Equal(t, ecotoneFee, fee)
 
+	// emptyTx fee w/ fjord config should be the fjord fee
+	config.FjordTime = &time
+	costFunc = NewL1CostFunc(config, statedb)
+	fee = costFunc(emptyTx.RollupCostData(), time)
+	require.NotNil(t, fee)
+	require.Equal(t, fjordFee, fee)
+
 	// emptyTx fee w/ ecotone config, but simulate first ecotone block by blowing away the ecotone
 	// params. Should result in regolith fee.
+	config.FjordTime = &timeInFuture
 	statedb.baseFeeScalar = 0
 	statedb.blobBaseFeeScalar = 0
 	statedb.blobBaseFee = new(big.Int)
@@ -246,4 +286,45 @@ func TestNewL1CostFunc(t *testing.T) {
 	fee = costFunc(emptyTx.RollupCostData(), time)
 	require.NotNil(t, fee)
 	require.Equal(t, regolithFee, fee)
+}
+
+func TestFlzCompressLen(t *testing.T) {
+	var (
+		emptyTxBytes, _   = emptyTx.MarshalBinary()
+		contractCallTxStr = "02f901550a758302df1483be21b88304743f94f8" +
+			"0e51afb613d764fa61751affd3313c190a86bb870151bd62fd12adb8" +
+			"e41ef24f3f0000000000000000000000000000000000000000000000" +
+			"00000000000000006e000000000000000000000000af88d065e77c8c" +
+			"c2239327c5edb3a432268e5831000000000000000000000000000000" +
+			"000000000000000000000000000003c1e50000000000000000000000" +
+			"00000000000000000000000000000000000000000000000000000000" +
+			"000000000000000000000000000000000000000000000000a0000000" +
+			"00000000000000000000000000000000000000000000000000000000" +
+			"148c89ed219d02f1a5be012c689b4f5b731827bebe00000000000000" +
+			"0000000000c001a033fd89cb37c31b2cba46b6466e040c61fc9b2a36" +
+			"75a7f5f493ebd5ad77c497f8a07cdf65680e238392693019b4092f61" +
+			"0222e71b7cec06449cb922b93b6a12744e"
+		contractCallTx, _ = hex.DecodeString(contractCallTxStr)
+	)
+
+	testCases := []struct {
+		input       []byte
+		expectedLen uint32
+	}{
+		// empty input
+		{[]byte{}, 0},
+		// all 1 inputs
+		{bytes.Repeat([]byte{1}, 1000), 21},
+		// all 0 inputs
+		{make([]byte, 1000), 21},
+		// empty tx input
+		{emptyTxBytes, 31},
+		// contract call tx: https://optimistic.etherscan.io/tx/0x8eb9dd4eb6d33f4dc25fb015919e4b1e9f7542f9b0322bf6622e268cd116b594
+		{contractCallTx, 202},
+	}
+
+	for _, tc := range testCases {
+		output := FlzCompressLen(tc.input)
+		require.Equal(t, tc.expectedLen, output)
+	}
 }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
We found that the FastLZ algorithm is a pretty good estimate for the actual results we'd see from zlib compressing the batches we write to L1 (albeit with a different `scalar` as the compression ratios aren't quite as good). See https://github.com/roberto-bayardo/compression-analysis and [this sheet](https://docs.google.com/spreadsheets/d/1vZNAtyGnMR4iGE84wV0RZ7BpohSKUCd9Lsdg0wrNk8c/edit#gid=0).

This PR introduces a `flzCompress` call into the `DataGas` part of the `L1CostFunc`. Companion `optimism` PR is here: https://github.com/ethereum-optimism/optimism/pull/9618

**Tests**

TODO

**Additional context**

The current naive L1Cost approach:
```
l1fee = ((0s in calldata) * 4 + (1s in calldata) * 16 + 188) * l1BaseFee * 0.684
```
works pretty well on average, but penalizes very compressible txs ([e.g.](https://basescan.org/tx/0x041c111f2dea51404d713ef70a31e481bd4bf637544ab2e5e5ac2c7fb1cb1614)), and undercharges incompressible txs ([e.g.](https://basescan.org/tx/0x0330a3787711c951c18df58cb7c60c2f9ac241d05bd1bafa7a9dae317a65b3ce)). This change makes the `L1CostFunc` much fairer compared to real-world L1 costs.