### PR TITLE
feat(interop): superchain messaging txpool policy

### DIFF
--- a/core/txpool/optimism_policy.go
+++ b/core/txpool/optimism_policy.go
@@ -1,0 +1,28 @@
+package txpool
+
+import (
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+type OptimismTxPolicyStatus uint
+
+const (
+	OptimismTxPolicyInvalid OptimismTxPolicyStatus = iota
+	OptimismTxPolicyValid
+)
+
+type OptimismTxPoolPolicy interface {
+	// Run validation logic on the transaction prior to pool submission
+	//
+	// TOOD: Look into taking in the entire batch such that validation
+	//       can be parallelized by the implementor if necessary
+	ValidateTx(tx *types.Transaction) (OptimismTxPolicyStatus, error)
+}
+
+var _ OptimismTxPoolPolicy = &NoOpTxPoolPolicy{}
+
+type NoOpTxPoolPolicy struct{}
+
+func (p *NoOpTxPoolPolicy) ValidateTx(tx *types.Transaction) (OptimismTxPolicyStatus, error) {
+	return OptimismTxPolicyValid, nil
+}

--- a/core/txpool/policies/superchain_messaging.go
+++ b/core/txpool/policies/superchain_messaging.go
@@ -1,0 +1,103 @@
+package policies
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+type messageSafetyLabel int
+
+const (
+	invalid messageSafetyLabel = iota
+	safe
+	finalized
+)
+
+var (
+	inboxExecuteMessageSignature = "executeMessage(address,bytes,(address,uint256,uint256,uint256,uint256))"
+	inboxExecuteMessageBytes4    = crypto.Keccak256([]byte(inboxExecuteMessageSignature))[:4]
+)
+
+type messageIdentifier struct {
+	Origin      common.Address
+	BlockNumber *big.Int
+	LogIndex    uint64
+	Timestamp   uint64
+	ChainId     *big.Int
+}
+
+// Manually parse out the tx data per abi encoding rules
+//
+//	TODO: introduce a solabi utility present in the monorepo for readability
+func unpackInboxExecutionMessageTxData(txData []byte) (*messageIdentifier, []byte, error) {
+
+	// Function Selector
+	if len(txData) <= 4 {
+		return nil, nil, fmt.Errorf("invalid calldata: function selector")
+	} else if !bytes.Equal(txData[:4], inboxExecuteMessageBytes4) {
+		return nil, nil, fmt.Errorf("invalid function selector")
+	}
+	txData = txData[4:]
+
+	// the argument calldata must include at least 8 words (including message byte length)
+	if len(txData) < 8*32 {
+		return nil, nil, fmt.Errorf("invalid calldata: executeMessage function args")
+	}
+
+	// Message Target
+	txData = txData[32:]
+
+	// Message Bytes Calldata Location -- The 7th word
+	msgDataLoc := common.BytesToHash(txData[:32])
+	if msgDataLoc != common.HexToHash("0xe0") { // 7*32-4 (removing function selector)
+		return nil, nil, fmt.Errorf("invalid calldata: msg bytes data loc: %x", msgDataLoc)
+	}
+	txData = txData[32:]
+
+	// Message Identifier
+	var uint64Padding [24]byte
+	var addressPadding [12]byte
+	msgId := messageIdentifier{}
+
+	msgId.Origin = common.BytesToAddress(txData[:32])
+	if !bytes.Equal(txData[:12], addressPadding[:]) {
+		return nil, nil, fmt.Errorf("origin address padding is non-zero")
+	}
+	txData = txData[32:]
+
+	msgId.BlockNumber = new(big.Int).SetBytes(txData[:32])
+	txData = txData[32:]
+
+	msgId.LogIndex = new(big.Int).SetBytes(txData[:32]).Uint64()
+	if !bytes.Equal(txData[:24], uint64Padding[:]) {
+		return nil, nil, fmt.Errorf("log index padding is non-zero")
+	}
+	txData = txData[32:]
+
+	msgId.Timestamp = new(big.Int).SetBytes(txData[:32]).Uint64()
+	if !bytes.Equal(txData[:24], uint64Padding[:]) {
+		return nil, nil, fmt.Errorf("timestamp padding is non-zero")
+	}
+	txData = txData[32:]
+
+	msgId.ChainId = new(big.Int).SetBytes(txData[:32])
+	txData = txData[32:]
+
+	// Message Bytes
+	byteLen := new(big.Int).SetBytes(txData[:32]).Uint64()
+	if !bytes.Equal(txData[:24], uint64Padding[:]) {
+		return nil, nil, fmt.Errorf("log index padding is non-zero")
+	}
+	paddedByteLength := byteLen + (32 - (byteLen % 32))
+	if uint64(len(txData)) != 32+paddedByteLength {
+		return nil, nil, fmt.Errorf("invalid calldata: too many bytes")
+	}
+	txData = txData[32:]
+
+	msgBytes := txData[:byteLen]
+	return &msgId, msgBytes, nil
+}

--- a/core/txpool/policies/superchain_messaging.go
+++ b/core/txpool/policies/superchain_messaging.go
@@ -30,11 +30,10 @@ type messageIdentifier struct {
 	ChainId     *big.Int
 }
 
-// Manually parse out the tx data per abi encoding rules
-//
-//	TODO: introduce a solabi utility present in the monorepo for readability
+// Manually parse the tx data according to the function signature. [TODO] introduce a soliabi
+// utility OR pass the entire calldata to the backend to centralize where deser logic happens
+// with minimal validation here (i.e min tx data byte length)
 func unpackInboxExecutionMessageTxData(txData []byte) (*messageIdentifier, []byte, error) {
-
 	// Function Selector
 	if len(txData) <= 4 {
 		return nil, nil, fmt.Errorf("invalid calldata: function selector")

--- a/core/txpool/policies/superchain_messaging_policy.go
+++ b/core/txpool/policies/superchain_messaging_policy.go
@@ -34,16 +34,16 @@ func (m *SuperchainMessagingPolicy) ValidateTx(tx *types.Transaction) (txpool.Op
 
 	msgId, msgBytes, err := unpackInboxExecutionMessageTxData(tx.Data())
 	if err != nil {
-		return txpool.OptimismTxPolicyUnknown, fmt.Errorf("unable to unpack executeMessage calldata: %w", err)
+		return txpool.OptimismTxPolicyInvalid, fmt.Errorf("unable to unpack executeMessage tx data: %w", err)
 	}
 	msgIdBytes, err := json.Marshal(msgId)
 	if err != nil {
-		return txpool.OptimismTxPolicyUnknown, fmt.Errorf("unable to marshal message identifier: %w", err)
+		return txpool.OptimismTxPolicyInvalid, fmt.Errorf("unable to marshal message identifier: %w", err)
 	}
 
 	var safetyLabel messageSafetyLabel
 	if err := m.backend.CallContext(context.TODO(), &safetyLabel, "superchain_messageSafety", msgIdBytes, msgBytes); err != nil {
-		return txpool.OptimismTxPolicyUnknown, fmt.Errorf("unable to query message safety: %w", err)
+		return txpool.OptimismTxPolicyInvalid, fmt.Errorf("failed to query message safety: %w", err)
 	}
 
 	if safetyLabel == finalized {

--- a/core/txpool/policies/superchain_messaging_policy.go
+++ b/core/txpool/policies/superchain_messaging_policy.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	inboxAddress = common.HexToAddress("0x420")
+	crossL2InboxAddress = common.HexToAddress("0x420")
 
 	_ txpool.OptimismTxPoolPolicy = &SuperchainMessagingPolicy{}
 )
@@ -30,7 +30,7 @@ func NewSuperchainMessagingPolicy(cfg *params.ChainConfig, chain txpool.BlockCha
 
 func (m *SuperchainMessagingPolicy) ValidateTx(tx *types.Transaction) (txpool.OptimismTxPolicyStatus, error) {
 	time := m.chain.CurrentBlock().Time
-	if !m.cfg.IsInterop(time) || tx.To() == nil || *tx.To() != inboxAddress {
+	if !m.cfg.IsInterop(time) || tx.To() == nil || *tx.To() != crossL2InboxAddress {
 		return txpool.OptimismTxPolicyValid, nil
 	}
 

--- a/core/txpool/policies/superchain_messaging_policy.go
+++ b/core/txpool/policies/superchain_messaging_policy.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
@@ -19,16 +19,17 @@ var (
 )
 
 type SuperchainMessagingPolicy struct {
-	log     log.Logger
+	cfg     *params.ChainConfig
+	chain   txpool.BlockChain
 	backend *rpc.Client
 }
 
-func NewSuperchainMessagingPolicy(log log.Logger, backend *rpc.Client) *SuperchainMessagingPolicy {
-	return &SuperchainMessagingPolicy{log, backend}
+func NewSuperchainMessagingPolicy(cfg *params.ChainConfig, chain txpool.BlockChain, backend *rpc.Client) *SuperchainMessagingPolicy {
+	return &SuperchainMessagingPolicy{cfg, chain, backend}
 }
 
 func (m *SuperchainMessagingPolicy) ValidateTx(tx *types.Transaction) (txpool.OptimismTxPolicyStatus, error) {
-	if tx.To() == nil || *tx.To() != inboxAddress {
+	if !m.cfg.IsInterop(m.chain.CurrentBlock().Time) || tx.To() == nil || *tx.To() != inboxAddress {
 		return txpool.OptimismTxPolicyValid, nil
 	}
 

--- a/core/txpool/policies/superchain_messaging_policy.go
+++ b/core/txpool/policies/superchain_messaging_policy.go
@@ -1,0 +1,54 @@
+package policies
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/txpool"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+var (
+	inboxAddress = common.HexToAddress("0x420")
+
+	_ txpool.OptimismTxPoolPolicy = &SuperchainMessagingPolicy{}
+)
+
+type SuperchainMessagingPolicy struct {
+	log     log.Logger
+	backend *rpc.Client
+}
+
+func NewSuperchainMessagingPolicy(log log.Logger, backend *rpc.Client) *SuperchainMessagingPolicy {
+	return &SuperchainMessagingPolicy{log, backend}
+}
+
+func (m *SuperchainMessagingPolicy) ValidateTx(tx *types.Transaction) (txpool.OptimismTxPolicyStatus, error) {
+	if tx.To() == nil || *tx.To() != inboxAddress {
+		return txpool.OptimismTxPolicyValid, nil
+	}
+
+	msgId, msgBytes, err := unpackInboxExecutionMessageTxData(tx.Data())
+	if err != nil {
+		return txpool.OptimismTxPolicyUnknown, fmt.Errorf("unable to unpack executeMessage calldata: %w", err)
+	}
+	msgIdBytes, err := json.Marshal(msgId)
+	if err != nil {
+		return txpool.OptimismTxPolicyUnknown, fmt.Errorf("unable to marshal message identifier: %w", err)
+	}
+
+	var safetyLabel messageSafetyLabel
+	if err := m.backend.CallContext(context.TODO(), &safetyLabel, "superchain_messageSafety", msgIdBytes, msgBytes); err != nil {
+		return txpool.OptimismTxPolicyUnknown, fmt.Errorf("unable to query message safety: %w", err)
+	}
+
+	if safetyLabel == finalized {
+		return txpool.OptimismTxPolicyValid, nil
+	}
+
+	return txpool.OptimismTxPolicyInvalid, nil
+}

--- a/core/txpool/policies/superchain_messaging_test.go
+++ b/core/txpool/policies/superchain_messaging_test.go
@@ -1,0 +1,53 @@
+package policies
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	BytesType, _   = abi.NewType("bytes", "", nil)
+	AddressType, _ = abi.NewType("address", "", nil)
+	MsgIdType, _   = abi.NewType("tuple", "", []abi.ArgumentMarshaling{
+		{Name: "origin", Type: "address"},
+		{Name: "blockNumber", Type: "uint256"},
+
+		// for simpliciy use uint64 since these go fields as parameterized
+		// this way. makes no difference to the abi encoding of the tuple
+		{Name: "logIndex", Type: "uint64"},
+		{Name: "timestamp", Type: "uint64"},
+
+		{Name: "chainId", Type: "uint256"},
+	})
+
+	ExecuteMessageMethod = abi.NewMethod(
+		"executeMessage", // name
+		"executeMessage", // raw name
+		abi.Function,     // fn type
+		"",               // mutability
+		false,            // isConst
+		false,            // isPayable
+		abi.Arguments{{Type: AddressType}, {Type: BytesType}, {Type: MsgIdType}}, // inputs
+		abi.Arguments{}, // ouputs
+	)
+)
+
+func TestInboxExecuteMessageUnpacking(t *testing.T) {
+	msgId := messageIdentifier{common.HexToAddress("0xa"), big.NewInt(10), 1, 1, big.NewInt(10)}
+	calldata, err := ExecuteMessageMethod.Inputs.Pack(common.Address{}, []byte{byte(1)}, msgId)
+	require.NoError(t, err)
+
+	id, msg, err := unpackInboxExecutionMessageTxData(append(inboxExecuteMessageBytes4, calldata...))
+	require.NoError(t, err)
+	require.Len(t, msg, 1)
+	require.Equal(t, msg[0], byte(1))
+	require.Equal(t, msgId.Origin, id.Origin)
+	require.Equal(t, msgId.BlockNumber.Uint64(), id.BlockNumber.Uint64())
+	require.Equal(t, msgId.LogIndex, id.LogIndex)
+	require.Equal(t, msgId.Timestamp, id.Timestamp)
+	require.Equal(t, msgId.ChainId.Uint64(), id.ChainId.Uint64())
+}

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -32,6 +32,18 @@ import (
 
 type L1CostFunc func(dataGas types.RollupCostData) *big.Int
 
+type OptimismTxPolicyStatus uint
+
+const (
+	OptimismTxPolicyUnknown OptimismTxPolicyStatus = iota
+	OptimismTxPolicyInvalid
+	OptimismTxPolicyValid
+)
+
+type OptimismTxPoolPolicy interface {
+	ValidateTx(tx *types.Transaction) (OptimismTxPolicyStatus, error)
+}
+
 // TxStatus is the current status of a transaction as seen by the pool.
 type TxStatus uint
 

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -32,18 +32,6 @@ import (
 
 type L1CostFunc func(dataGas types.RollupCostData) *big.Int
 
-type OptimismTxPolicyStatus uint
-
-const (
-	OptimismTxPolicyUnknown OptimismTxPolicyStatus = iota
-	OptimismTxPolicyInvalid
-	OptimismTxPolicyValid
-)
-
-type OptimismTxPoolPolicy interface {
-	ValidateTx(tx *types.Transaction) (OptimismTxPolicyStatus, error)
-}
-
 // TxStatus is the current status of a transaction as seen by the pool.
 type TxStatus uint
 
@@ -79,7 +67,8 @@ type BlockChain interface {
 // They exit the pool when they are included in the blockchain or evicted due to
 // resource constraints.
 type TxPool struct {
-	subpools []SubPool // List of subpools for specialized transaction handling
+	subpools       []SubPool // List of subpools for specialized transaction handling
+	optimismPolicy OptimismTxPoolPolicy
 
 	reservations map[common.Address]SubPool // Map with the account to pool reservations
 	reserveLock  sync.Mutex                 // Lock protecting the account reservations
@@ -90,16 +79,28 @@ type TxPool struct {
 
 // New creates a new transaction pool to gather, sort and filter inbound
 // transactions from the network.
-func New(gasTip *big.Int, chain BlockChain, subpools []SubPool) (*TxPool, error) {
+func New(gasTip *big.Int, chain BlockChain, subpools []SubPool, policies ...OptimismTxPoolPolicy) (*TxPool, error) {
+	// TODO: Using an vararg type param to keep the function signature backwards
+	// compatible for now. Only expecting one or no policy
+	if len(policies) > 1 {
+		return nil, errors.New("expected at most one tx pool policy")
+	}
+
+	var optimismPolicy OptimismTxPoolPolicy = &NoOpTxPoolPolicy{}
+	if len(policies) > 0 {
+		optimismPolicy = policies[0]
+	}
+
 	// Retrieve the current head so that all subpools and this main coordinator
 	// pool will have the same starting state, even if the chain moves forward
 	// during initialization.
 	head := chain.CurrentBlock()
 
 	pool := &TxPool{
-		subpools:     subpools,
-		reservations: make(map[common.Address]SubPool),
-		quit:         make(chan chan error),
+		subpools:       subpools,
+		optimismPolicy: optimismPolicy,
+		reservations:   make(map[common.Address]SubPool),
+		quit:           make(chan chan error),
 	}
 	for i, subpool := range subpools {
 		if err := subpool.Init(gasTip, head, pool.reserver(i, subpool)); err != nil {
@@ -285,10 +286,25 @@ func (p *TxPool) Add(txs []*types.Transaction, local bool, sync bool) []error {
 	// so we can piece back the returned errors into the original order.
 	txsets := make([][]*types.Transaction, len(p.subpools))
 	splits := make([]int, len(txs))
+	errs := make([]error, len(txs))
 
 	for i, tx := range txs {
 		// Mark this transaction belonging to no-subpool
 		splits[i] = -1
+
+		// Check against the tx policy
+		status, err := p.optimismPolicy.ValidateTx(tx)
+		if err != nil {
+			// a policy should only inspect specific transactions like the interop inbox,
+			// in which a failure mode would only grief these transactions
+			log.Trace("OptimismTxPolicy validation error", "hash", tx.Hash(), "err", err)
+			errs[i] = err
+			splits[i] = -2
+		} else if status == OptimismTxPolicyInvalid {
+			log.Trace("OptimismTxPolicy discarding invalid transaction", "hash", tx.Hash())
+			errs[i] = errors.New("failed optimism tx policy validation")
+			splits[i] = -2
+		}
 
 		// Try to find a subpool that accepts the transaction
 		for j, subpool := range p.subpools {
@@ -305,11 +321,14 @@ func (p *TxPool) Add(txs []*types.Transaction, local bool, sync bool) []error {
 	for i := 0; i < len(p.subpools); i++ {
 		errsets[i] = p.subpools[i].Add(txsets[i], local, sync)
 	}
-	errs := make([]error, len(txs))
 	for i, split := range splits {
 		// If the transaction was rejected by all subpools, mark it unsupported
 		if split == -1 {
 			errs[i] = core.ErrTxTypeNotSupported
+			continue
+		}
+		// If the transaction was rejected by the configured policy, skip
+		if split == -2 {
 			continue
 		}
 		// Find which subpool handled it and pull in the corresponding error

--- a/params/config.go
+++ b/params/config.go
@@ -403,6 +403,8 @@ type OptimismConfig struct {
 	EIP1559Elasticity        uint64 `json:"eip1559Elasticity"`
 	EIP1559Denominator       uint64 `json:"eip1559Denominator"`
 	EIP1559DenominatorCanyon uint64 `json:"eip1559DenominatorCanyon"`
+
+	SuperchainBackendRPC *string `json:"superchainBackend,omitempty"`
 }
 
 // String implements the stringer interface, returning the optimism fee config details.


### PR DESCRIPTION
Closes ethereum-optimism/optimism#10890

Introduces a general abstraction, `OptimismTxPoolPolicy` that layers over the transaction pool and applied 3rdparty validation logic prior to txpool submission.

The only implementation of this abstraction with the `txpool/policies` package is for interop, the `SuperchainMessagingPolicy`. This policy maintains a connection to the superchain backend, implemented in `ethereum-optimism/optimsim#9612` and checks for message safety of any executing interop message in the CrossL2Inbox predeploy address.

For now the policy only allows the for the passthrough of executing interop messages:
1. superchain backend doesn't mark the initiated message pointed to by the identifier as invalid
2. timestamp invariant holds
3. policy only allows for initiated messages that are finalized -- _for now_