### PR TITLE
add timer metrics to txpool.Reset and event.Feed.Send

### DIFF
--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math/big"
 	"sync"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
@@ -49,6 +50,8 @@ var (
 	// This is mostly a sanity metric to ensure there's no bug that would make
 	// some subpool hog all the reservations due to mis-accounting.
 	reservationsGaugeName = "txpool/reservations"
+	// resetTimerName is the prefix of a tx-pool reset duration metric.
+	resetTimerName = "txpool/reset"
 )
 
 // BlockChain defines the minimal set of methods needed to back a tx pool with
@@ -204,6 +207,10 @@ func (p *TxPool) loop(head *types.Header, chain BlockChain) {
 			case resetBusy <- struct{}{}:
 				// Busy marker injected, start a new subpool reset
 				go func(oldHead, newHead *types.Header) {
+					if metrics.Enabled {
+						start := time.Now()
+						defer metrics.GetOrRegisterTimer(resetTimerName, nil).UpdateSince(start)
+					}
 					for _, subpool := range p.subpools {
 						subpool.Reset(oldHead, newHead)
 					}


### PR DESCRIPTION
**Description**

Add metrics for the two things that seem to affect performance most:
- `event.Feed.Send`: all consumers are blocking. If there are more events firing than consumers can keep up with, things that to block due to back-pressure. We should meter these send delays.
- `txpool.Reset` on new-head: meter how long it takes to adapt the pool to a new state of balance/nonce values.

