### PR TITLE
core,params: Don't rewind chain on pre-genesis time changes

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -459,11 +459,16 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 
 	// Rewind the chain in case of an incompatible config upgrade.
 	if compat, ok := genesisErr.(*params.ConfigCompatError); ok {
-		log.Warn("Rewinding chain to upgrade configuration", "err", compat)
-		if compat.RewindToTime > 0 {
-			bc.SetHeadWithTimestamp(compat.RewindToTime)
+		if compat.NewTime != nil && compat.StoredTime != nil &&
+			genesis.Timestamp > *compat.NewTime && genesis.Timestamp > *compat.StoredTime {
+			log.Warn("Ignoring chain rewind because of pre-genesis timestamp changes", "err", compat)
 		} else {
-			bc.SetHead(compat.RewindToBlock)
+			log.Warn("Rewinding chain to upgrade configuration", "err", compat)
+			if compat.NewTime != nil {
+				bc.SetHeadWithTimestamp(compat.RewindToTime)
+			} else {
+				bc.SetHead(compat.RewindToBlock)
+			}
 		}
 		rawdb.WriteChainConfig(db, genesisHash, chainConfig)
 	}

--- a/params/config.go
+++ b/params/config.go
@@ -956,7 +956,8 @@ func newTimestampCompatError(what string, storedtime, newtime *uint64) *ConfigCo
 		NewTime:      newtime,
 		RewindToTime: 0,
 	}
-	if rew != nil {
+	if rew != nil && *rew > 0 {
+		// if *rew == 0 this would cause an underflow
 		err.RewindToTime = *rew - 1
 	}
 	return err


### PR DESCRIPTION
**Description**

* Fixes an underflow bug when calculating the timestamp to rewind a chain to.
* Ignores chain rewinds if the timestamp changes are pre-genesis.

**Tests**

Will test on a devnet.

**Additional context**

We had a chain rewind on our internal `sepolia-devnet-0` on Jan 29 because the Canyon activation time changed from `0` to `1698436800` (`Fri Oct 27 20:00:00 UTC 2023`) when we set Base's Canyon activation time as the canonical time in the superchain-registry but didn't overwrite it to 0 again.

This change allows us to overwrite the Canyon activation time on `sepolia-devnet-0` back to `0` without causing another chain rewind.

We might want to upstream (parts of) this.

**Metadata**

- Fixes https://github.com/ethereum-optimism/client-pod/issues/624
