### PR TITLE
Pass the original precompile to the override function.

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -55,7 +55,7 @@ func (evm *EVM) precompile(addr common.Address) (PrecompiledContract, bool) {
 	p, ok := precompiles[addr]
 	// Restrict overrides to known precompiles
 	if ok && evm.chainConfig.IsOptimism() && evm.Config.OptimismPrecompileOverrides != nil {
-		override, ok := evm.Config.OptimismPrecompileOverrides(evm.chainRules, addr)
+		override, ok := evm.Config.OptimismPrecompileOverrides(evm.chainRules, p, addr)
 		if ok {
 			return override, ok
 		}

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -25,7 +25,7 @@ import (
 )
 
 // PrecompileOverrides is a function that can be used to override the default precompiled contracts
-type PrecompileOverrides func(params.Rules, common.Address) (PrecompiledContract, bool)
+type PrecompileOverrides func(params.Rules, PrecompiledContract, common.Address) (PrecompiledContract, bool)
 
 // Config are the configuration options for the Interpreter
 type Config struct {


### PR DESCRIPTION
**Description**

Pass the original precompile to the override function. Will allow the override to optionally delegate some functions to the original precompile instead of having to fully replace it.


**Metadata**

- https://github.com/ethereum-optimism/client-pod/issues/628
