### PR TITLE
Add Ecotone Fee Information to JSON Receipts

### DIFF
--- a/core/types/gen_receipt_json.go
+++ b/core/types/gen_receipt_json.go
@@ -34,9 +34,12 @@ func (r Receipt) MarshalJSON() ([]byte, error) {
 		BlockNumber           *hexutil.Big    `json:"blockNumber,omitempty"`
 		TransactionIndex      hexutil.Uint    `json:"transactionIndex"`
 		L1GasPrice            *hexutil.Big    `json:"l1GasPrice,omitempty"`
+		L1BlobBaseFee         *big.Int        `json:"l1BlobBaseFee,omitempty"`
 		L1GasUsed             *hexutil.Big    `json:"l1GasUsed,omitempty"`
 		L1Fee                 *hexutil.Big    `json:"l1Fee,omitempty"`
 		FeeScalar             *big.Float      `json:"l1FeeScalar,omitempty"`
+		L1BaseFeeScalar       *big.Float      `json:"l1BaseFeeScalar,omitempty"`
+		L1BlobBaseFeeScalar   *big.Float      `json:"l1BlobBaseFeeScalar,omitempty"`
 	}
 	var enc Receipt
 	enc.Type = hexutil.Uint64(r.Type)
@@ -57,9 +60,12 @@ func (r Receipt) MarshalJSON() ([]byte, error) {
 	enc.BlockNumber = (*hexutil.Big)(r.BlockNumber)
 	enc.TransactionIndex = hexutil.Uint(r.TransactionIndex)
 	enc.L1GasPrice = (*hexutil.Big)(r.L1GasPrice)
+	enc.L1BlobBaseFee = r.L1BlobBaseFee
 	enc.L1GasUsed = (*hexutil.Big)(r.L1GasUsed)
 	enc.L1Fee = (*hexutil.Big)(r.L1Fee)
 	enc.FeeScalar = r.FeeScalar
+	enc.L1BaseFeeScalar = r.L1BaseFeeScalar
+	enc.L1BlobBaseFeeScalar = r.L1BlobBaseFeeScalar
 	return json.Marshal(&enc)
 }
 
@@ -84,9 +90,12 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 		BlockNumber           *hexutil.Big    `json:"blockNumber,omitempty"`
 		TransactionIndex      *hexutil.Uint   `json:"transactionIndex"`
 		L1GasPrice            *hexutil.Big    `json:"l1GasPrice,omitempty"`
+		L1BlobBaseFee         *big.Int        `json:"l1BlobBaseFee,omitempty"`
 		L1GasUsed             *hexutil.Big    `json:"l1GasUsed,omitempty"`
 		L1Fee                 *hexutil.Big    `json:"l1Fee,omitempty"`
 		FeeScalar             *big.Float      `json:"l1FeeScalar,omitempty"`
+		L1BaseFeeScalar       *big.Float      `json:"l1BaseFeeScalar,omitempty"`
+		L1BlobBaseFeeScalar   *big.Float      `json:"l1BlobBaseFeeScalar,omitempty"`
 	}
 	var dec Receipt
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -151,6 +160,9 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 	if dec.L1GasPrice != nil {
 		r.L1GasPrice = (*big.Int)(dec.L1GasPrice)
 	}
+	if dec.L1BlobBaseFee != nil {
+		r.L1BlobBaseFee = dec.L1BlobBaseFee
+	}
 	if dec.L1GasUsed != nil {
 		r.L1GasUsed = (*big.Int)(dec.L1GasUsed)
 	}
@@ -159,6 +171,12 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 	}
 	if dec.FeeScalar != nil {
 		r.FeeScalar = dec.FeeScalar
+	}
+	if dec.L1BaseFeeScalar != nil {
+		r.L1BaseFeeScalar = dec.L1BaseFeeScalar
+	}
+	if dec.L1BlobBaseFeeScalar != nil {
+		r.L1BlobBaseFeeScalar = dec.L1BlobBaseFeeScalar
 	}
 	return nil
 }

--- a/core/types/gen_receipt_json.go
+++ b/core/types/gen_receipt_json.go
@@ -38,8 +38,8 @@ func (r Receipt) MarshalJSON() ([]byte, error) {
 		L1GasUsed             *hexutil.Big    `json:"l1GasUsed,omitempty"`
 		L1Fee                 *hexutil.Big    `json:"l1Fee,omitempty"`
 		FeeScalar             *big.Float      `json:"l1FeeScalar,omitempty"`
-		L1BaseFeeScalar       *big.Float      `json:"l1BaseFeeScalar,omitempty"`
-		L1BlobBaseFeeScalar   *big.Float      `json:"l1BlobBaseFeeScalar,omitempty"`
+		L1BaseFeeScalar       *uint32         `json:"l1BaseFeeScalar,omitempty"`
+		L1BlobBaseFeeScalar   *uint32         `json:"l1BlobBaseFeeScalar,omitempty"`
 	}
 	var enc Receipt
 	enc.Type = hexutil.Uint64(r.Type)
@@ -94,8 +94,8 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 		L1GasUsed             *hexutil.Big    `json:"l1GasUsed,omitempty"`
 		L1Fee                 *hexutil.Big    `json:"l1Fee,omitempty"`
 		FeeScalar             *big.Float      `json:"l1FeeScalar,omitempty"`
-		L1BaseFeeScalar       *big.Float      `json:"l1BaseFeeScalar,omitempty"`
-		L1BlobBaseFeeScalar   *big.Float      `json:"l1BlobBaseFeeScalar,omitempty"`
+		L1BaseFeeScalar       *uint32         `json:"l1BaseFeeScalar,omitempty"`
+		L1BlobBaseFeeScalar   *uint32         `json:"l1BlobBaseFeeScalar,omitempty"`
 	}
 	var dec Receipt
 	if err := json.Unmarshal(input, &dec); err != nil {

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -90,8 +90,8 @@ type Receipt struct {
 	L1GasUsed           *big.Int   `json:"l1GasUsed,omitempty"`           // Present from pre-bedrock
 	L1Fee               *big.Int   `json:"l1Fee,omitempty"`               // Present from pre-bedrock
 	FeeScalar           *big.Float `json:"l1FeeScalar,omitempty"`         // Present from pre-bedrock to Ecotone. Nil after Ecotone
-	L1BaseFeeScalar     *big.Float `json:"l1BaseFeeScalar,omitempty"`     // Always nil prior to the Ecotone hardfork
-	L1BlobBaseFeeScalar *big.Float `json:"l1BlobBaseFeeScalar,omitempty"` // Always nil prior to the Ecotone hardfork
+	L1BaseFeeScalar     *uint32    `json:"l1BaseFeeScalar,omitempty"`     // Always nil prior to the Ecotone hardfork
+	L1BlobBaseFeeScalar *uint32    `json:"l1BlobBaseFeeScalar,omitempty"` // Always nil prior to the Ecotone hardfork
 }
 
 type receiptMarshaling struct {

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -84,11 +84,14 @@ type Receipt struct {
 	BlockNumber      *big.Int    `json:"blockNumber,omitempty"`
 	TransactionIndex uint        `json:"transactionIndex"`
 
-	// OVM legacy: extend receipts with their L1 price (if a rollup tx)
-	L1GasPrice *big.Int   `json:"l1GasPrice,omitempty"`
-	L1GasUsed  *big.Int   `json:"l1GasUsed,omitempty"`
-	L1Fee      *big.Int   `json:"l1Fee,omitempty"`
-	FeeScalar  *big.Float `json:"l1FeeScalar,omitempty"` // always nil after Ecotone hardfork
+	// Optimism: extend receipts with L1 fee info
+	L1GasPrice          *big.Int   `json:"l1GasPrice,omitempty"`          // Present from pre-bedrock. L1 Basefee after Bedrock
+	L1BlobBaseFee       *big.Int   `json:"l1BlobBaseFee,omitempty"`       // Always nil prior to the Ecotone hardfork
+	L1GasUsed           *big.Int   `json:"l1GasUsed,omitempty"`           // Present from pre-bedrock
+	L1Fee               *big.Int   `json:"l1Fee,omitempty"`               // Present from pre-bedrock
+	FeeScalar           *big.Float `json:"l1FeeScalar,omitempty"`         // Present from pre-bedrock to Ecotone. Nil after Ecotone
+	L1BaseFeeScalar     *big.Float `json:"l1BaseFeeScalar,omitempty"`     // Always nil prior to the Ecotone hardfork
+	L1BlobBaseFeeScalar *big.Float `json:"l1BlobBaseFeeScalar,omitempty"` // Always nil prior to the Ecotone hardfork
 }
 
 type receiptMarshaling struct {
@@ -570,7 +573,7 @@ func (rs Receipts) DeriveFields(config *params.ChainConfig, hash common.Hash, nu
 		}
 	}
 	if config.Optimism != nil && len(txs) >= 2 && config.IsBedrock(new(big.Int).SetUint64(number)) { // need at least an info tx and a non-info tx
-		l1BaseFee, costFunc, feeScalar, err := extractL1GasParams(config, time, txs[0].Data())
+		gasParams, err := extractL1GasParams(config, time, txs[0].Data())
 		if err != nil {
 			return err
 		}
@@ -578,9 +581,12 @@ func (rs Receipts) DeriveFields(config *params.ChainConfig, hash common.Hash, nu
 			if txs[i].IsDepositTx() {
 				continue
 			}
-			rs[i].L1GasPrice = l1BaseFee
-			rs[i].L1Fee, rs[i].L1GasUsed = costFunc(txs[i].RollupCostData())
-			rs[i].FeeScalar = feeScalar
+			rs[i].L1GasPrice = gasParams.l1BaseFee
+			rs[i].L1BlobBaseFee = gasParams.l1BlobBaseFee
+			rs[i].L1Fee, rs[i].L1GasUsed = gasParams.costFunc(txs[i].RollupCostData())
+			rs[i].FeeScalar = gasParams.feeScalar
+			rs[i].L1BaseFeeScalar = gasParams.l1BaseFeeScalar
+			rs[i].L1BlobBaseFeeScalar = gasParams.l1BlobBaseFeeScalar
 		}
 	}
 	return nil

--- a/core/types/receipt_test.go
+++ b/core/types/receipt_test.go
@@ -867,7 +867,7 @@ func TestDeriveOptimismBedrockTxReceipts(t *testing.T) {
 func TestDeriveOptimismEcotoneTxReceipts(t *testing.T) {
 	// Ecotone style l1 attributes with baseFeeScalar=2, blobBaseFeeScalar=3, baseFee=1000*1e6, blobBaseFee=10*1e6
 	payload := common.Hex2Bytes("440a5e20000000020000000300000000000004d200000000000004d200000000000004d2000000000000000000000000000000000000000000000000000000003b9aca00000000000000000000000000000000000000000000000000000000000098968000000000000000000000000000000000000000000000000000000000000004d200000000000000000000000000000000000000000000000000000000000004d2")
-	// the parameters we use below are defined in rollup_test.go. Scale the fee scalars by 1e6 to account for the float format.
+	// the parameters we use below are defined in rollup_test.go
 	baseFeeScalarUint32 := uint32(baseFeeScalar.Uint64())
 	blobBaseFeeScalarUint32 := uint32(blobBaseFeeScalar.Uint64())
 	txs, receipts := getOptimismEcotoneTxReceipts(payload, baseFee, blobBaseFee, ecotoneGas, ecotoneFee, &baseFeeScalarUint32, &blobBaseFeeScalarUint32)

--- a/core/types/receipt_test.go
+++ b/core/types/receipt_test.go
@@ -698,7 +698,7 @@ func clearComputedFieldsOnLogs(logs []*Log) []*Log {
 	return l
 }
 
-func getOptimismEcotoneTxReceipts(l1AttributesPayload []byte, l1GasPrice, l1BlobGasPrice, l1GasUsed, l1Fee *big.Int, baseFeeScalar, blobBaseFeeScalar *big.Float) ([]*Transaction, []*Receipt) {
+func getOptimismEcotoneTxReceipts(l1AttributesPayload []byte, l1GasPrice, l1BlobGasPrice, l1GasUsed, l1Fee *big.Int, baseFeeScalar, blobBaseFeeScalar *uint32) ([]*Transaction, []*Receipt) {
 	// Create a few transactions to have receipts for
 	txs := Transactions{
 		NewTx(&DepositTx{
@@ -868,7 +868,9 @@ func TestDeriveOptimismEcotoneTxReceipts(t *testing.T) {
 	// Ecotone style l1 attributes with baseFeeScalar=2, blobBaseFeeScalar=3, baseFee=1000*1e6, blobBaseFee=10*1e6
 	payload := common.Hex2Bytes("440a5e20000000020000000300000000000004d200000000000004d200000000000004d2000000000000000000000000000000000000000000000000000000003b9aca00000000000000000000000000000000000000000000000000000000000098968000000000000000000000000000000000000000000000000000000000000004d200000000000000000000000000000000000000000000000000000000000004d2")
 	// the parameters we use below are defined in rollup_test.go. Scale the fee scalars by 1e6 to account for the float format.
-	txs, receipts := getOptimismEcotoneTxReceipts(payload, baseFee, blobBaseFee, ecotoneGas, ecotoneFee, big.NewFloat(2e-6), big.NewFloat(3e-6))
+	baseFeeScalarUint32 := uint32(baseFeeScalar.Uint64())
+	blobBaseFeeScalarUint32 := uint32(blobBaseFeeScalar.Uint64())
+	txs, receipts := getOptimismEcotoneTxReceipts(payload, baseFee, blobBaseFee, ecotoneGas, ecotoneFee, &baseFeeScalarUint32, &blobBaseFeeScalarUint32)
 
 	// Re-derive receipts.
 	baseFee := big.NewInt(1000)

--- a/core/types/receipt_test.go
+++ b/core/types/receipt_test.go
@@ -698,10 +698,77 @@ func clearComputedFieldsOnLogs(logs []*Log) []*Log {
 	return l
 }
 
-func getOptimismTxReceipts(
-	t *testing.T, l1AttributesPayload []byte,
-	l1GasPrice, l1GasUsed *big.Int, feeScalar *big.Float, l1Fee *big.Int) ([]*Transaction, []*Receipt) {
-	//to4 := common.HexToAddress("0x4")
+func getOptimismEcotoneTxReceipts(l1AttributesPayload []byte, l1GasPrice, l1BlobGasPrice, l1GasUsed, l1Fee *big.Int, baseFeeScalar, blobBaseFeeScalar *big.Float) ([]*Transaction, []*Receipt) {
+	// Create a few transactions to have receipts for
+	txs := Transactions{
+		NewTx(&DepositTx{
+			To:    nil, // contract creation
+			Value: big.NewInt(6),
+			Gas:   50,
+			Data:  l1AttributesPayload,
+		}),
+		emptyTx,
+	}
+
+	// Create the corresponding receipts
+	receipts := Receipts{
+		&Receipt{
+			Type:              DepositTxType,
+			PostState:         common.Hash{5}.Bytes(),
+			CumulativeGasUsed: 50 + 15,
+			Logs: []*Log{
+				{
+					Address: common.BytesToAddress([]byte{0x33}),
+					// derived fields:
+					BlockNumber: blockNumber.Uint64(),
+					TxHash:      txs[0].Hash(),
+					TxIndex:     0,
+					BlockHash:   blockHash,
+					Index:       0,
+				},
+				{
+					Address: common.BytesToAddress([]byte{0x03, 0x33}),
+					// derived fields:
+					BlockNumber: blockNumber.Uint64(),
+					TxHash:      txs[0].Hash(),
+					TxIndex:     0,
+					BlockHash:   blockHash,
+					Index:       1,
+				},
+			},
+			TxHash:            txs[0].Hash(),
+			ContractAddress:   common.HexToAddress("0x3bb898b4bbe24f68a4e9be46cfe72d1787fd74f4"),
+			GasUsed:           65,
+			EffectiveGasPrice: big.NewInt(0),
+			BlockHash:         blockHash,
+			BlockNumber:       blockNumber,
+			TransactionIndex:  0,
+			DepositNonce:      &depNonce1,
+		},
+		&Receipt{
+			Type:              LegacyTxType,
+			EffectiveGasPrice: big.NewInt(0),
+			PostState:         common.Hash{4}.Bytes(),
+			CumulativeGasUsed: 10,
+			Logs:              []*Log{},
+			// derived fields:
+			TxHash:              txs[1].Hash(),
+			GasUsed:             18446744073709551561,
+			BlockHash:           blockHash,
+			BlockNumber:         blockNumber,
+			TransactionIndex:    1,
+			L1GasPrice:          l1GasPrice,
+			L1BlobBaseFee:       l1BlobGasPrice,
+			L1GasUsed:           l1GasUsed,
+			L1Fee:               l1Fee,
+			L1BaseFeeScalar:     baseFeeScalar,
+			L1BlobBaseFeeScalar: blobBaseFeeScalar,
+		},
+	}
+	return txs, receipts
+}
+
+func getOptimismTxReceipts(l1AttributesPayload []byte, l1GasPrice, l1GasUsed, l1Fee *big.Int, feeScalar *big.Float) ([]*Transaction, []*Receipt) {
 	// Create a few transactions to have receipts for
 	txs := Transactions{
 		NewTx(&DepositTx{
@@ -777,7 +844,7 @@ func TestDeriveOptimismBedrockTxReceipts(t *testing.T) {
 	l1GasUsed := bedrockGas
 	feeScalar := big.NewFloat(float64(scalar.Uint64() / 1e6))
 	l1Fee := bedrockFee
-	txs, receipts := getOptimismTxReceipts(t, payload, l1GasPrice, l1GasUsed, feeScalar, l1Fee)
+	txs, receipts := getOptimismTxReceipts(payload, l1GasPrice, l1GasUsed, l1Fee, feeScalar)
 
 	// Re-derive receipts.
 	baseFee := big.NewInt(1000)
@@ -800,11 +867,8 @@ func TestDeriveOptimismBedrockTxReceipts(t *testing.T) {
 func TestDeriveOptimismEcotoneTxReceipts(t *testing.T) {
 	// Ecotone style l1 attributes with baseFeeScalar=2, blobBaseFeeScalar=3, baseFee=1000*1e6, blobBaseFee=10*1e6
 	payload := common.Hex2Bytes("440a5e20000000020000000300000000000004d200000000000004d200000000000004d2000000000000000000000000000000000000000000000000000000003b9aca00000000000000000000000000000000000000000000000000000000000098968000000000000000000000000000000000000000000000000000000000000004d200000000000000000000000000000000000000000000000000000000000004d2")
-	// the parameters we use below are defined in rollup_test.go
-	l1GasPrice := baseFee
-	l1GasUsed := ecotoneGas
-	l1Fee := ecotoneFee
-	txs, receipts := getOptimismTxReceipts(t, payload, l1GasPrice, l1GasUsed, nil /*feeScalar*/, l1Fee)
+	// the parameters we use below are defined in rollup_test.go. Scale the fee scalars by 1e6 to account for the float format.
+	txs, receipts := getOptimismEcotoneTxReceipts(payload, baseFee, blobBaseFee, ecotoneGas, ecotoneFee, big.NewFloat(2e-6), big.NewFloat(3e-6))
 
 	// Re-derive receipts.
 	baseFee := big.NewInt(1000)

--- a/core/types/rollup_cost.go
+++ b/core/types/rollup_cost.go
@@ -218,37 +218,58 @@ func newL1CostFuncEcotone(l1BaseFee, l1BlobBaseFee, l1BaseFeeScalar, l1BlobBaseF
 	}
 }
 
-// extractL1GasParams extracts the gas parameters necessary to compute gas costs from L1 block info
-func extractL1GasParams(config *params.ChainConfig, time uint64, data []byte) (l1BaseFee *big.Int, costFunc l1CostFunc, feeScalar *big.Float, err error) {
-	if config.IsEcotone(time) {
-		// edge case: for the very first Ecotone block we still need to use the Bedrock
-		// function. We detect this edge case by seeing if the function selector is the old one
-		if len(data) >= 4 && !bytes.Equal(data[0:4], BedrockL1AttributesSelector) {
-			l1BaseFee, costFunc, err = extractL1GasParamsEcotone(data)
-			return
-		}
-	}
+type gasParams struct {
+	isEcotoneFormat     bool
+	l1BaseFee           *big.Int
+	l1BlobBaseFee       *big.Int
+	costFunc            l1CostFunc
+	feeScalar           *big.Float // pre-ecotone
+	l1BaseFeeScalar     *big.Float // post-ecotone
+	l1BlobBaseFeeScalar *big.Float // post-ecotone
+}
 
+// intToScaledFloat returns scalar/10e6 as a float
+func intToScaledFloat(scalar *big.Int) *big.Float {
+	fscalar := new(big.Float).SetInt(scalar)
+	fdivisor := new(big.Float).SetUint64(1_000_000) // 10**6, i.e. 6 decimals
+	return new(big.Float).Quo(fscalar, fdivisor)
+}
+
+// extractL1GasParams extracts the gas parameters necessary to compute gas costs from L1 block info
+func extractL1GasParams(config *params.ChainConfig, time uint64, data []byte) (gasParams, error) {
+	// edge case: for the very first Ecotone block we still need to use the Bedrock
+	// function. We detect this edge case by seeing if the function selector is the old one
+	// If so, fall through to the pre-ecotone format
+	if config.IsEcotone(time) && len(data) >= 4 && !bytes.Equal(data[0:4], BedrockL1AttributesSelector) {
+		return extractL1GasParamsEcotone(data)
+	}
+	return extractL1GasParamsPreEcotone(config, time, data)
+}
+
+func extractL1GasParamsPreEcotone(config *params.ChainConfig, time uint64, data []byte) (gasParams, error) {
 	// data consists of func selector followed by 7 ABI-encoded parameters (32 bytes each)
 	if len(data) < 4+32*8 {
-		return nil, nil, nil, fmt.Errorf("expected at least %d L1 info bytes, got %d", 4+32*8, len(data))
+		return gasParams{}, fmt.Errorf("expected at least %d L1 info bytes, got %d", 4+32*8, len(data))
 	}
-	data = data[4:]                                      // trim function selector
-	l1BaseFee = new(big.Int).SetBytes(data[32*2 : 32*3]) // arg index 2
-	overhead := new(big.Int).SetBytes(data[32*6 : 32*7]) // arg index 6
-	scalar := new(big.Int).SetBytes(data[32*7 : 32*8])   // arg index 7
-	fscalar := new(big.Float).SetInt(scalar)             // legacy: format fee scalar as big Float
-	fdivisor := new(big.Float).SetUint64(1_000_000)      // 10**6, i.e. 6 decimals
-	feeScalar = new(big.Float).Quo(fscalar, fdivisor)
-	costFunc = newL1CostFuncBedrockHelper(l1BaseFee, overhead, scalar, config.IsRegolith(time))
-	return
+	data = data[4:]                                       // trim function selector
+	l1BaseFee := new(big.Int).SetBytes(data[32*2 : 32*3]) // arg index 2
+	overhead := new(big.Int).SetBytes(data[32*6 : 32*7])  // arg index 6
+	scalar := new(big.Int).SetBytes(data[32*7 : 32*8])    // arg index 7
+	feeScalar := intToScaledFloat(scalar)                 // legacy: format fee scalar as big Float
+	costFunc := newL1CostFuncBedrockHelper(l1BaseFee, overhead, scalar, config.IsRegolith(time))
+	return gasParams{
+		isEcotoneFormat: false,
+		l1BaseFee:       l1BaseFee,
+		costFunc:        costFunc,
+		feeScalar:       feeScalar,
+	}, nil
 }
 
 // extractEcotoneL1GasParams extracts the gas parameters necessary to compute gas from L1 attribute
 // info calldata after the Ecotone upgrade, but not for the very first Ecotone block.
-func extractL1GasParamsEcotone(data []byte) (l1BaseFee *big.Int, costFunc l1CostFunc, err error) {
+func extractL1GasParamsEcotone(data []byte) (gasParams, error) {
 	if len(data) != 164 {
-		return nil, nil, fmt.Errorf("expected 164 L1 info bytes, got %d", len(data))
+		return gasParams{}, fmt.Errorf("expected 164 L1 info bytes, got %d", len(data))
 	}
 	// data layout assumed for Ecotone:
 	// offset type varname
@@ -262,12 +283,19 @@ func extractL1GasParamsEcotone(data []byte) (l1BaseFee *big.Int, costFunc l1Cost
 	// 68    uint256 _blobBaseFee,
 	// 100    bytes32 _hash,
 	// 132   bytes32 _batcherHash,
-	l1BaseFee = new(big.Int).SetBytes(data[36:68])
+	l1BaseFee := new(big.Int).SetBytes(data[36:68])
 	l1BlobBaseFee := new(big.Int).SetBytes(data[68:100])
 	l1BaseFeeScalar := new(big.Int).SetBytes(data[4:8])
 	l1BlobBaseFeeScalar := new(big.Int).SetBytes(data[8:12])
-	costFunc = newL1CostFuncEcotone(l1BaseFee, l1BlobBaseFee, l1BaseFeeScalar, l1BlobBaseFeeScalar)
-	return
+	costFunc := newL1CostFuncEcotone(l1BaseFee, l1BlobBaseFee, l1BaseFeeScalar, l1BlobBaseFeeScalar)
+	return gasParams{
+		isEcotoneFormat:     true,
+		l1BaseFee:           l1BaseFee,
+		l1BlobBaseFee:       l1BlobBaseFee,
+		costFunc:            costFunc,
+		l1BaseFeeScalar:     intToScaledFloat(l1BaseFeeScalar),
+		l1BlobBaseFeeScalar: intToScaledFloat(l1BlobBaseFeeScalar),
+	}, nil
 }
 
 // L1Cost computes the the data availability fee for transactions in blocks prior to the Ecotone


### PR DESCRIPTION
**Description**

This commit adds the following fields the receipt:
- L1 Blob BaseFee
- L1 BaseFee Scalar
- L1 BlobBaseFee Scalar

The new fields are only present after Ecotone. The field `feeScalar` which is pre-ecotone is set to null now for receipts that occurred after Ecotone's activation.

I also refactored extractL1GasParams to return a struct rather than a list of value due to the large number of returned fields.

**Tests**

I modified the post-ecotone unit tests to check for these fields.

**Metadata**

- Fixes https://github.com/ethereum-optimism/client-pod/issues/640
