### PR TITLE
tracer: Account for the L1 Fee in the prestate tracer

### DIFF
--- a/cmd/evm/internal/t8ntool/tracewriter.go
+++ b/cmd/evm/internal/t8ntool/tracewriter.go
@@ -22,6 +22,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/eth/tracers"
 	"github.com/ethereum/go-ethereum/log"
@@ -56,7 +57,9 @@ func (t *traceWriter) CaptureTxEnd(restGas uint64) {
 	}
 }
 
-func (t *traceWriter) CaptureTxStart(gasLimit uint64) { t.inner.CaptureTxStart(gasLimit) }
+func (t *traceWriter) CaptureTxStart(gasLimit uint64, l1Cost types.RollupCostData) {
+	t.inner.CaptureTxStart(gasLimit, l1Cost)
+}
 func (t *traceWriter) CaptureStart(env *vm.EVM, from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int) {
 	t.inner.CaptureStart(env, from, to, create, input, gas, value)
 }

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -436,7 +436,7 @@ func (st *StateTransition) innerTransitionDb() (*ExecutionResult, error) {
 	}
 
 	if tracer := st.evm.Config.Tracer; tracer != nil {
-		tracer.CaptureTxStart(st.initialGas)
+		tracer.CaptureTxStart(st.initialGas, st.msg.RollupCostData)
 		defer func() {
 			if st.msg.IsDepositTx {
 				tracer.CaptureTxEnd(0)

--- a/core/vm/logger.go
+++ b/core/vm/logger.go
@@ -20,6 +20,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 )
 
 // EVMLogger is used to collect execution traces from an EVM transaction
@@ -29,7 +30,7 @@ import (
 // if you need to retain them beyond the current call.
 type EVMLogger interface {
 	// Transaction level
-	CaptureTxStart(gasLimit uint64)
+	CaptureTxStart(gasLimit uint64, l1Cost types.RollupCostData)
 	CaptureTxEnd(restGas uint64)
 	// Top call frame
 	CaptureStart(env *EVM, from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int)

--- a/eth/tracers/js/goja.go
+++ b/eth/tracers/js/goja.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/eth/tracers"
@@ -222,7 +223,7 @@ func newJsTracer(code string, ctx *tracers.Context, cfg json.RawMessage) (tracer
 
 // CaptureTxStart implements the Tracer interface and is invoked at the beginning of
 // transaction processing.
-func (t *jsTracer) CaptureTxStart(gasLimit uint64) {
+func (t *jsTracer) CaptureTxStart(gasLimit uint64, l1Cost types.RollupCostData) {
 	t.gasLimit = gasLimit
 }
 

--- a/eth/tracers/js/tracer_test.go
+++ b/eth/tracers/js/tracer_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/eth/tracers"
 	"github.com/ethereum/go-ethereum/params"
@@ -73,7 +74,7 @@ func runTrace(tracer tracers.Tracer, vmctx *vmContext, chaincfg *params.ChainCon
 		contract.Code = contractCode
 	}
 
-	tracer.CaptureTxStart(gasLimit)
+	tracer.CaptureTxStart(gasLimit, types.RollupCostData{})
 	tracer.CaptureStart(env, contract.Caller(), contract.Address(), false, []byte{}, startGas, value)
 	ret, err := env.Interpreter().Run(contract, []byte{}, false)
 	tracer.CaptureEnd(ret, startGas-contract.Gas, err)

--- a/eth/tracers/logger/access_list_tracer.go
+++ b/eth/tracers/logger/access_list_tracer.go
@@ -168,7 +168,7 @@ func (*AccessListTracer) CaptureEnter(typ vm.OpCode, from common.Address, to com
 
 func (*AccessListTracer) CaptureExit(output []byte, gasUsed uint64, err error) {}
 
-func (*AccessListTracer) CaptureTxStart(gasLimit uint64) {}
+func (*AccessListTracer) CaptureTxStart(gasLimit uint64, l1Cost types.RollupCostData) {}
 
 func (*AccessListTracer) CaptureTxEnd(restGas uint64) {}
 

--- a/eth/tracers/logger/logger.go
+++ b/eth/tracers/logger/logger.go
@@ -262,7 +262,7 @@ func (l *StructLogger) Stop(err error) {
 	l.interrupt.Store(true)
 }
 
-func (l *StructLogger) CaptureTxStart(gasLimit uint64) {
+func (l *StructLogger) CaptureTxStart(gasLimit uint64, l1Cost types.RollupCostData) {
 	l.gasLimit = gasLimit
 }
 
@@ -395,7 +395,7 @@ func (t *mdLogger) CaptureEnter(typ vm.OpCode, from common.Address, to common.Ad
 
 func (t *mdLogger) CaptureExit(output []byte, gasUsed uint64, err error) {}
 
-func (*mdLogger) CaptureTxStart(gasLimit uint64) {}
+func (*mdLogger) CaptureTxStart(gasLimit uint64, l1Cost types.RollupCostData) {}
 
 func (*mdLogger) CaptureTxEnd(restGas uint64) {}
 

--- a/eth/tracers/logger/logger_json.go
+++ b/eth/tracers/logger/logger_json.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 )
 
@@ -97,6 +98,6 @@ func (l *JSONLogger) CaptureEnter(typ vm.OpCode, from common.Address, to common.
 
 func (l *JSONLogger) CaptureExit(output []byte, gasUsed uint64, err error) {}
 
-func (l *JSONLogger) CaptureTxStart(gasLimit uint64) {}
+func (l *JSONLogger) CaptureTxStart(gasLimit uint64, l1Cost types.RollupCostData) {}
 
 func (l *JSONLogger) CaptureTxEnd(restGas uint64) {}

--- a/eth/tracers/native/call.go
+++ b/eth/tracers/native/call.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/eth/tracers"
 	"github.com/ethereum/go-ethereum/log"
@@ -243,7 +244,7 @@ func (t *callTracer) CaptureExit(output []byte, gasUsed uint64, err error) {
 	t.callstack[size-1].Calls = append(t.callstack[size-1].Calls, call)
 }
 
-func (t *callTracer) CaptureTxStart(gasLimit uint64) {
+func (t *callTracer) CaptureTxStart(gasLimit uint64, l1Cost types.RollupCostData) {
 	t.gasLimit = gasLimit
 }
 

--- a/eth/tracers/native/call_flat.go
+++ b/eth/tracers/native/call_flat.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/eth/tracers"
 )
@@ -201,8 +202,8 @@ func (t *flatCallTracer) CaptureExit(output []byte, gasUsed uint64, err error) {
 	}
 }
 
-func (t *flatCallTracer) CaptureTxStart(gasLimit uint64) {
-	t.tracer.CaptureTxStart(gasLimit)
+func (t *flatCallTracer) CaptureTxStart(gasLimit uint64, l1Cost types.RollupCostData) {
+	t.tracer.CaptureTxStart(gasLimit, l1Cost)
 }
 
 func (t *flatCallTracer) CaptureTxEnd(restGas uint64) {

--- a/eth/tracers/native/mux.go
+++ b/eth/tracers/native/mux.go
@@ -21,6 +21,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/eth/tracers"
 )
@@ -101,9 +102,9 @@ func (t *muxTracer) CaptureExit(output []byte, gasUsed uint64, err error) {
 	}
 }
 
-func (t *muxTracer) CaptureTxStart(gasLimit uint64) {
+func (t *muxTracer) CaptureTxStart(gasLimit uint64, l1Cost types.RollupCostData) {
 	for _, t := range t.tracers {
-		t.CaptureTxStart(gasLimit)
+		t.CaptureTxStart(gasLimit, l1Cost)
 	}
 }
 

--- a/eth/tracers/native/noop.go
+++ b/eth/tracers/native/noop.go
@@ -21,6 +21,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/eth/tracers"
 )
@@ -63,7 +64,7 @@ func (t *noopTracer) CaptureEnter(typ vm.OpCode, from common.Address, to common.
 func (t *noopTracer) CaptureExit(output []byte, gasUsed uint64, err error) {
 }
 
-func (*noopTracer) CaptureTxStart(gasLimit uint64) {}
+func (*noopTracer) CaptureTxStart(gasLimit uint64, l1Cost types.RollupCostData) {}
 
 func (*noopTracer) CaptureTxEnd(restGas uint64) {}
 


### PR DESCRIPTION
**Description**

This undoes the L1 fee for the prestate tracer. To implement this change I had to modify the tracer API because I need access to the Message object to get the L1 cost. This object is only available at `CaptureTxStart`, but the VM & L1 Cost is not available until `CaptureStart` thus the modification of the Tracer API & extra fields in the Prestate Trace.

**Tests**

TODO

**Metadata**

- Fixes https://github.com/ethereum-optimism/op-geth/issues/226
