### PR TITLE
fork.yaml: remove duplicate file reference which breaks forkdiff

### DIFF
--- a/fork.yaml
+++ b/fork.yaml
@@ -182,7 +182,6 @@ def:
         - title: Historical data for Snap-sync
           description: Snap-sync has access to trusted Deposit Transaction Nonce Data.
           globs:
-            - "eth/handler.go"
             - "eth/downloader/downloader.go"
             - "eth/downloader/receiptreference.go"
         - title: Discv5 node discovery


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Forkdiff requires each file to be referenced only once. This PR removes the duplicate entry that is causing it to fail.
