### PR TITLE
fix: store and log correct OPVersion

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -837,10 +837,10 @@ func makeWorkdir(wdflag string) string {
 }
 
 func isUnstableBuild(env build.Environment) bool {
-	if env.Tag != "" {
-		return false
+	if env.Tag == "untagged" || env.Tag == "" {
+		return true
 	}
-	return true
+	return false
 }
 
 type debPackage struct {

--- a/params/version.go
+++ b/params/version.go
@@ -35,7 +35,7 @@ var (
 	OPVersionMajor = 0          // Major version component of the current release
 	OPVersionMinor = 1          // Minor version component of the current release
 	OPVersionPatch = 0          // Patch version component of the current release
-	OPVersionMeta  = "unstable" // Version metadata to append to the version string
+	OPVersionMeta  = "untagged" // Version metadata to append to the version string
 )
 
 // This is set at build-time by the linker when the build is done by build/ci.go.
@@ -60,16 +60,18 @@ var _ = func() (_ string) {
 
 // Version holds the textual version string.
 var Version = func() string {
+	if OPVersionMeta == "untagged" {
+		return OPVersionMeta
+	}
 	return fmt.Sprintf("%d.%d.%d", OPVersionMajor, OPVersionMinor, OPVersionPatch)
 }()
 
 // VersionWithMeta holds the textual version string including the metadata.
 var VersionWithMeta = func() string {
-	v := Version
-	if OPVersionMeta != "" {
-		v += "-" + OPVersionMeta
+	if OPVersionMeta != "untagged" {
+		return Version + "-" + OPVersionMeta
 	}
-	return v
+	return Version
 }()
 
 // GethVersion holds the textual geth version string.


### PR DESCRIPTION
**Description**

Ensure `OPVersion` is set correctly during `make geth` and during `docker build`. This was broken when checking out a specific, non-HEAD commit, which creates a "detached head" scenario. Also when a commit did not have an associated tag, the `OPVersion` was set to `0.1.0-unstable`, which has now been changed to set `OPVersion` to `untagged`.

**Tests**

Manually tested the following scenarios

1. Detached head
```
git checkout 6aa2348118138a4f7021208ffaf8582d73169ba1
git tag --points-at 6aa2348118138a4f7021208ffaf8582d73169ba1
  > v1.101311.0-rc.1
```
Ran `make geth` and got the following output (verified `-ldflags` were set correctly):
```
go run build/ci.go install ./cmd/geth
>>> /usr/local/go/bin/go build -ldflags "-X github.com/ethereum/go-ethereum/internal/version.gitCommit=6aa2348118138a4f7021208ffaf8582d73169ba1 -X github.com/ethereum/go-ethereum/internal/version.gitDate=20240404 -X github.com/ethereum/go-ethereum/params.gitTag=v1.101311.0-rc.1 -s" -tags urfave_cli_no_docs,ckzg -trimpath -v -o /Users/samuel/repos/op-geth/build/bin/geth ./cmd/geth
```
Created a docker image and checked its printed version
```
docker buildx build -f Dockerfile . -t op-geth   
docker run op-geth -- version    
```
Got the following output (verified Version was set correctly)
```
Geth
Version: 1.101311.0-rc.1
Git Commit: 6aa2348118138a4f7021208ffaf8582d73169ba1
Git Commit Date: 20240404
Upstream Version: 1.13.11-stable
Architecture: arm64
Go Version: go1.21.9
Operating System: linux
GOPATH=
GOROOT=
```
Started the container and verified the logged version looked correct:
```
INFO [04-11|20:20:57.483] Starting peer-to-peer node               instance=Geth/v1.101311.0-rc.1-6aa23481-20240404/linux-arm64/go1.21.9
```

2. Untagged commit
```
git checkout optimism // on commit db7c618bff4b1b66e9b515a029a060026ea3c0d6
```
Ran `make geth` and got the following output (verified `-ldflags` were set correctly):
```
go run build/ci.go install ./cmd/geth
>>> /usr/local/go/bin/go build -ldflags "-X github.com/ethereum/go-ethereum/internal/version.gitCommit=db7c618bff4b1b66e9b515a029a060026ea3c0d6 -X github.com/ethereum/go-ethereum/internal/version.gitDate=20240409 -s" -tags urfave_cli_no_docs,ckzg -trimpath -v -o /Users/samuel/repos/op-geth/build/bin/geth ./cmd/geth
```
Created a docker image and checked its printed version
```
docker buildx build -f Dockerfile . -t op-geth   
docker run op-geth -- version    
```
Got the following output (verified Version was set correctly)
```
Geth
Version: untagged
Git Commit: db7c618bff4b1b66e9b515a029a060026ea3c0d6
Git Commit Date: 20240409
Upstream Version: 1.13.11-stable
Architecture: arm64
Go Version: go1.21.9
Operating System: linux
GOPATH=
GOROOT=
```
Started the container and verified the logged version looked correct (couldn't get rid of "v" before "untagged" without creating another diff with geth [here](https://github.com/ethereum-optimism/op-geth/blob/optimism/node/config.go#L308):
```
INFO [04-11|20:24:43.806] Starting peer-to-peer node               instance=Geth/vuntagged-db7c618b-20240409/linux-arm64/go1.21.9
```

**Additional context**

I do not have access to Circle CI so right now I am unable to verify that the `$CIRCLE_TAG` env var is set to the appropriate value [here](https://github.com/ethereum-optimism/op-geth/blob/optimism/.circleci/config.yml#L98).

**Metadata**

- Fixes https://github.com/ethereum-optimism/client-pod/issues/664
