### PR TITLE
support estimate gas for blob tx

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -665,6 +665,12 @@ func toCallArg(msg ethereum.CallMsg) interface{} {
 	if msg.AccessList != nil {
 		arg["accessList"] = msg.AccessList
 	}
+	if msg.BlobGasFeeCap != nil {
+		arg["maxFeePerBlobGas"] = (*hexutil.Big)(msg.BlobGasFeeCap)
+	}
+	if msg.BlobHashes != nil {
+		arg["blobVersionedHashes"] = msg.BlobHashes
+	}
 	return arg
 }
 

--- a/interfaces.go
+++ b/interfaces.go
@@ -152,6 +152,10 @@ type CallMsg struct {
 	Data      []byte          // input data, usually an ABI-encoded contract method invocation
 
 	AccessList types.AccessList // EIP-2930 access list.
+
+	// For BlobTxType
+	BlobGasFeeCap *big.Int
+	BlobHashes    []common.Hash
 }
 
 // A ContractCaller provides contract calls, essentially transactions that are executed by

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -121,6 +121,8 @@ func (args *TransactionArgs) setDefaults(ctx context.Context, b Backend) error {
 			Value:                args.Value,
 			Data:                 (*hexutil.Bytes)(&data),
 			AccessList:           args.AccessList,
+			BlobFeeCap:           args.BlobFeeCap,
+			BlobHashes:           args.BlobHashes,
 		}
 		latestBlockNr := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
 		estimated, err := DoEstimateGas(ctx, b, callArgs, latestBlockNr, nil, b.RPCGasCap())


### PR DESCRIPTION
Changes for `TransactionArgs` are pulled from [this pr](https://github.com/ethereum/go-ethereum/pull/29085).

Currently when batcher [estimates gas](https://github.com/ethereum-optimism/optimism/blob/3e4430ee40ab72edb51ed11e5fa277ee7ae01746/op-service/txmgr/txmgr.go#L266), it doesn't pass parameters for blobs.

I'm going to create a pr for that after this one is merged since it refers to the `CallMsg` type from op-geth.