### PR TITLE
🧹  chore: bump minimal go version writing on docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ archives are published at https://geth.ethereum.org/downloads/.
 
 For prerequisites and detailed build instructions please read the [Installation Instructions](https://geth.ethereum.org/docs/getting-started/installing-geth).
 
-Building `geth` requires both a Go (version 1.19 or later) and a C compiler. You can install
+Building `geth` requires both a Go (version 1.21 or later) and a C compiler. You can install
 them using your favourite package manager. Once the dependencies are installed, run
 
 ```shell


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Since #230, optimism's `go.mod` depends on toolchain. Since the toolchain has been applied since [go version 1.21](https://go.dev/doc/toolchain), the programmer must maintain go version at least 1.21 or higher to build optimism.
However, `README.md` indicates that the minimum version is 1.19, which can be confusing. This PR should be resolve it.

**Additional context**

I have not checked whether the same problem exists in other documents in the repository.
