### PR TITLE
ethapi: Set post Ecotone receipt fields

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1910,8 +1910,19 @@ func marshalReceipt(receipt *types.Receipt, blockHash common.Hash, blockNumber u
 		fields["l1GasPrice"] = (*hexutil.Big)(receipt.L1GasPrice)
 		fields["l1GasUsed"] = (*hexutil.Big)(receipt.L1GasUsed)
 		fields["l1Fee"] = (*hexutil.Big)(receipt.L1Fee)
-		if receipt.FeeScalar != nil { // removed in Ecotone
+		// Fields removed with Ecotone
+		if receipt.FeeScalar != nil {
 			fields["l1FeeScalar"] = receipt.FeeScalar.String()
+		}
+		// Fields added in Ecotone
+		if receipt.L1BlobBaseFee != nil {
+			fields["l1BlobBaseFee"] = (*hexutil.Big)(receipt.L1BlobBaseFee)
+		}
+		if receipt.L1BaseFeeScalar != nil {
+			fields["l1BaseFeeScalar"] = hexutil.Uint64(*receipt.L1BaseFeeScalar)
+		}
+		if receipt.L1BlobBaseFeeScalar != nil {
+			fields["l1BlobBaseFeeScalar"] = hexutil.Uint64(*receipt.L1BlobBaseFeeScalar)
 		}
 	}
 	if chainConfig.Optimism != nil && tx.IsDepositTx() && receipt.DepositNonce != nil {


### PR DESCRIPTION
**Description**

Wire in the new fields from #278 to the eth API server

**Tests**

Tested locally with the devnet & confirmed that the correct fields are returned pre & post ecotone.

