### PR TITLE
ethapi/receipt: Use hexutil for JSON marshalling

### DIFF
--- a/core/types/gen_receipt_json.go
+++ b/core/types/gen_receipt_json.go
@@ -34,12 +34,12 @@ func (r Receipt) MarshalJSON() ([]byte, error) {
 		BlockNumber           *hexutil.Big    `json:"blockNumber,omitempty"`
 		TransactionIndex      hexutil.Uint    `json:"transactionIndex"`
 		L1GasPrice            *hexutil.Big    `json:"l1GasPrice,omitempty"`
-		L1BlobBaseFee         *big.Int        `json:"l1BlobBaseFee,omitempty"`
+		L1BlobBaseFee         *hexutil.Big    `json:"l1BlobBaseFee,omitempty"`
 		L1GasUsed             *hexutil.Big    `json:"l1GasUsed,omitempty"`
 		L1Fee                 *hexutil.Big    `json:"l1Fee,omitempty"`
 		FeeScalar             *big.Float      `json:"l1FeeScalar,omitempty"`
-		L1BaseFeeScalar       *uint32         `json:"l1BaseFeeScalar,omitempty"`
-		L1BlobBaseFeeScalar   *uint32         `json:"l1BlobBaseFeeScalar,omitempty"`
+		L1BaseFeeScalar       *hexutil.Uint64 `json:"l1BaseFeeScalar,omitempty"`
+		L1BlobBaseFeeScalar   *hexutil.Uint64 `json:"l1BlobBaseFeeScalar,omitempty"`
 	}
 	var enc Receipt
 	enc.Type = hexutil.Uint64(r.Type)
@@ -60,12 +60,12 @@ func (r Receipt) MarshalJSON() ([]byte, error) {
 	enc.BlockNumber = (*hexutil.Big)(r.BlockNumber)
 	enc.TransactionIndex = hexutil.Uint(r.TransactionIndex)
 	enc.L1GasPrice = (*hexutil.Big)(r.L1GasPrice)
-	enc.L1BlobBaseFee = r.L1BlobBaseFee
+	enc.L1BlobBaseFee = (*hexutil.Big)(r.L1BlobBaseFee)
 	enc.L1GasUsed = (*hexutil.Big)(r.L1GasUsed)
 	enc.L1Fee = (*hexutil.Big)(r.L1Fee)
 	enc.FeeScalar = r.FeeScalar
-	enc.L1BaseFeeScalar = r.L1BaseFeeScalar
-	enc.L1BlobBaseFeeScalar = r.L1BlobBaseFeeScalar
+	enc.L1BaseFeeScalar = (*hexutil.Uint64)(r.L1BaseFeeScalar)
+	enc.L1BlobBaseFeeScalar = (*hexutil.Uint64)(r.L1BlobBaseFeeScalar)
 	return json.Marshal(&enc)
 }
 
@@ -90,12 +90,12 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 		BlockNumber           *hexutil.Big    `json:"blockNumber,omitempty"`
 		TransactionIndex      *hexutil.Uint   `json:"transactionIndex"`
 		L1GasPrice            *hexutil.Big    `json:"l1GasPrice,omitempty"`
-		L1BlobBaseFee         *big.Int        `json:"l1BlobBaseFee,omitempty"`
+		L1BlobBaseFee         *hexutil.Big    `json:"l1BlobBaseFee,omitempty"`
 		L1GasUsed             *hexutil.Big    `json:"l1GasUsed,omitempty"`
 		L1Fee                 *hexutil.Big    `json:"l1Fee,omitempty"`
 		FeeScalar             *big.Float      `json:"l1FeeScalar,omitempty"`
-		L1BaseFeeScalar       *uint32         `json:"l1BaseFeeScalar,omitempty"`
-		L1BlobBaseFeeScalar   *uint32         `json:"l1BlobBaseFeeScalar,omitempty"`
+		L1BaseFeeScalar       *hexutil.Uint64 `json:"l1BaseFeeScalar,omitempty"`
+		L1BlobBaseFeeScalar   *hexutil.Uint64 `json:"l1BlobBaseFeeScalar,omitempty"`
 	}
 	var dec Receipt
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -161,7 +161,7 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 		r.L1GasPrice = (*big.Int)(dec.L1GasPrice)
 	}
 	if dec.L1BlobBaseFee != nil {
-		r.L1BlobBaseFee = dec.L1BlobBaseFee
+		r.L1BlobBaseFee = (*big.Int)(dec.L1BlobBaseFee)
 	}
 	if dec.L1GasUsed != nil {
 		r.L1GasUsed = (*big.Int)(dec.L1GasUsed)
@@ -173,10 +173,10 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 		r.FeeScalar = dec.FeeScalar
 	}
 	if dec.L1BaseFeeScalar != nil {
-		r.L1BaseFeeScalar = dec.L1BaseFeeScalar
+		r.L1BaseFeeScalar = (*uint64)(dec.L1BaseFeeScalar)
 	}
 	if dec.L1BlobBaseFeeScalar != nil {
-		r.L1BlobBaseFeeScalar = dec.L1BlobBaseFeeScalar
+		r.L1BlobBaseFeeScalar = (*uint64)(dec.L1BlobBaseFeeScalar)
 	}
 	return nil
 }

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -90,8 +90,8 @@ type Receipt struct {
 	L1GasUsed           *big.Int   `json:"l1GasUsed,omitempty"`           // Present from pre-bedrock
 	L1Fee               *big.Int   `json:"l1Fee,omitempty"`               // Present from pre-bedrock
 	FeeScalar           *big.Float `json:"l1FeeScalar,omitempty"`         // Present from pre-bedrock to Ecotone. Nil after Ecotone
-	L1BaseFeeScalar     *uint32    `json:"l1BaseFeeScalar,omitempty"`     // Always nil prior to the Ecotone hardfork
-	L1BlobBaseFeeScalar *uint32    `json:"l1BlobBaseFeeScalar,omitempty"` // Always nil prior to the Ecotone hardfork
+	L1BaseFeeScalar     *uint64    `json:"l1BaseFeeScalar,omitempty"`     // Always nil prior to the Ecotone hardfork
+	L1BlobBaseFeeScalar *uint64    `json:"l1BlobBaseFeeScalar,omitempty"` // Always nil prior to the Ecotone hardfork
 }
 
 type receiptMarshaling struct {
@@ -108,9 +108,12 @@ type receiptMarshaling struct {
 
 	// Optimism
 	L1GasPrice            *hexutil.Big
+	L1BlobBaseFee         *hexutil.Big
 	L1GasUsed             *hexutil.Big
 	L1Fee                 *hexutil.Big
 	FeeScalar             *big.Float
+	L1BaseFeeScalar       *hexutil.Uint64
+	L1BlobBaseFeeScalar   *hexutil.Uint64
 	DepositNonce          *hexutil.Uint64
 	DepositReceiptVersion *hexutil.Uint64
 }
@@ -585,9 +588,17 @@ func (rs Receipts) DeriveFields(config *params.ChainConfig, hash common.Hash, nu
 			rs[i].L1BlobBaseFee = gasParams.l1BlobBaseFee
 			rs[i].L1Fee, rs[i].L1GasUsed = gasParams.costFunc(txs[i].RollupCostData())
 			rs[i].FeeScalar = gasParams.feeScalar
-			rs[i].L1BaseFeeScalar = gasParams.l1BaseFeeScalar
-			rs[i].L1BlobBaseFeeScalar = gasParams.l1BlobBaseFeeScalar
+			rs[i].L1BaseFeeScalar = u32ptrTou64ptr(gasParams.l1BaseFeeScalar)
+			rs[i].L1BlobBaseFeeScalar = u32ptrTou64ptr(gasParams.l1BlobBaseFeeScalar)
 		}
 	}
 	return nil
+}
+
+func u32ptrTou64ptr(a *uint32) *uint64 {
+	if a == nil {
+		return nil
+	}
+	b := uint64(*a)
+	return &b
 }

--- a/core/types/receipt_test.go
+++ b/core/types/receipt_test.go
@@ -698,7 +698,7 @@ func clearComputedFieldsOnLogs(logs []*Log) []*Log {
 	return l
 }
 
-func getOptimismEcotoneTxReceipts(l1AttributesPayload []byte, l1GasPrice, l1BlobGasPrice, l1GasUsed, l1Fee *big.Int, baseFeeScalar, blobBaseFeeScalar *uint32) ([]*Transaction, []*Receipt) {
+func getOptimismEcotoneTxReceipts(l1AttributesPayload []byte, l1GasPrice, l1BlobGasPrice, l1GasUsed, l1Fee *big.Int, baseFeeScalar, blobBaseFeeScalar *uint64) ([]*Transaction, []*Receipt) {
 	// Create a few transactions to have receipts for
 	txs := Transactions{
 		NewTx(&DepositTx{
@@ -868,9 +868,9 @@ func TestDeriveOptimismEcotoneTxReceipts(t *testing.T) {
 	// Ecotone style l1 attributes with baseFeeScalar=2, blobBaseFeeScalar=3, baseFee=1000*1e6, blobBaseFee=10*1e6
 	payload := common.Hex2Bytes("440a5e20000000020000000300000000000004d200000000000004d200000000000004d2000000000000000000000000000000000000000000000000000000003b9aca00000000000000000000000000000000000000000000000000000000000098968000000000000000000000000000000000000000000000000000000000000004d200000000000000000000000000000000000000000000000000000000000004d2")
 	// the parameters we use below are defined in rollup_test.go
-	baseFeeScalarUint32 := uint32(baseFeeScalar.Uint64())
-	blobBaseFeeScalarUint32 := uint32(blobBaseFeeScalar.Uint64())
-	txs, receipts := getOptimismEcotoneTxReceipts(payload, baseFee, blobBaseFee, ecotoneGas, ecotoneFee, &baseFeeScalarUint32, &blobBaseFeeScalarUint32)
+	baseFeeScalarUint64 := baseFeeScalar.Uint64()
+	blobBaseFeeScalarUint64 := blobBaseFeeScalar.Uint64()
+	txs, receipts := getOptimismEcotoneTxReceipts(payload, baseFee, blobBaseFee, ecotoneGas, ecotoneFee, &baseFeeScalarUint64, &blobBaseFeeScalarUint64)
 
 	// Re-derive receipts.
 	baseFee := big.NewInt(1000)


### PR DESCRIPTION
**Description**

This switches *big.Int to *hexutil.Big and *uint32 to *hexutil.Uint64 for marshalling the post-ecotone fields. Hexutil is what is expected on the read side.

I had to switch from uint32 to uint64 for the scalar fields in the JSON because there is no hexutil.Uint32. This conversion is safe & internally it still uses a uint32 type.

**Tests**

Tested locally