### PR TITLE
forkdiff update

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 1000  # make sure to fetch the old commit we diff against
 
       - name: Build forkdiff
-        uses: "docker://protolambda/forkdiff:latest"
+        uses: "docker://protolambda/forkdiff:0.1.0"
         with:
           args: -repo=/github/workspace -fork=/github/workspace/fork.yaml -out=/github/workspace/index.html
 

--- a/fork.yaml
+++ b/fork.yaml
@@ -226,7 +226,7 @@ def:
           globs:
             - "eth/tracers/api.go"
         - title: "Daisy Chain tests"
-          ignored:
+          ignore:
             - "internal/ethapi/transaction_args_test.go"
             - "ethclient/ethclient_test.go"
             - "eth/tracers/api_test.go"
@@ -261,7 +261,7 @@ def:
             - "accounts/usbwallet/hub.go"
     - title: "Testing"
       description: Additional or modified tests, not already captured by the above diff
-      ignored:
+      ignore:
         - "**/*_test.go"
 
 # ignored globally, does not count towards line count

--- a/fork.yaml
+++ b/fork.yaml
@@ -5,7 +5,7 @@ footer: |
 base:
   name: go-ethereum
   url: https://github.com/ethereum/go-ethereum
-  hash: c5ba367eb6232e3eddd7d6226bfd374449c63164 v1.13.15
+  hash: c5ba367eb6232e3eddd7d6226bfd374449c63164 # v1.13.15
 fork:
   name: op-geth
   url: https://github.com/ethereum-optimism/op-geth
@@ -56,7 +56,7 @@ def:
               globs:
                 - "core/vm/evm.go"
                 - "core/evm.go"
-                - "core/types/rollup_l1_cost.go"
+                - "core/types/rollup_cost.go"
                 - "core/state_processor.go"
                 - "core/state_prefetcher.go"
             - title: Transaction processing
@@ -111,7 +111,7 @@ def:
           description: |
             Transaction queueing and inclusion needs to account for the L1 cost component.
           globs:
-            - "core/txpool/*"
+            - "core/txpool/**/*"
             - "core/txpool/legacypool/*"
     - title: "Chain Configuration"
       sub:
@@ -188,6 +188,10 @@ def:
           description: Fix discv5 option to allow discv5 to be an active source for node-discovery.
           globs:
             - "p2p/server.go"
+        - title: Bootnodes
+          description: Discovery bootnode addresses.
+          globs:
+            - "params/bootnodes.go"
         - title: Generated TOML config update
           globs:
             - "eth/ethconfig/gen_config.go"
@@ -222,7 +226,7 @@ def:
           globs:
             - "eth/tracers/api.go"
         - title: "Daisy Chain tests"
-          globs:
+          ignored:
             - "internal/ethapi/transaction_args_test.go"
             - "ethclient/ethclient_test.go"
             - "eth/tracers/api_test.go"
@@ -255,6 +259,10 @@ def:
           # upstream PR: https://github.com/ethereum/go-ethereum/pull/28863/
           globs:
             - "accounts/usbwallet/hub.go"
+    - title: "Testing"
+      description: Additional or modified tests, not already captured by the above diff
+      ignored:
+        - "**/*_test.go"
 
 # ignored globally, does not count towards line count
 ignore:
@@ -262,4 +270,9 @@ ignore:
   - "*.sum"
   - "go.mod"
   - "fork.yaml"
-  - ".github/*"
+  - "Makefile"
+  - ".golangci.yml"
+  - ".github/**"
+  - "**/*.gob" # data asset, not code
+  - "core/vm/testdata/precompiles/p256Verify.json" # data asset, not code
+  - "eth/tracers/internal/tracetest/testdata/**/*.json"


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

I updated my forkdiff tool to:
- Support `**` glob pattern (Go by default doesn't support it)
- Less strict with file-matching: if a later pattern matches a previous diff, but if that diff was already rendered, then don't render it again, but don't error like before either. This makes fallback glob patterns a lot easier.
- Support non-global `ignored` matching, useful to group tests with their functions, without counting them towards the final total diff line count.
- Now listing the ignored added/deleted lines separately, instead of completely ignoring.

Updated `fork.yaml` to:
- use the new type of `ignored` diff
- fix reference of upstream geth, there should only be a commit hash
- improve/fix a few extending patterns, to capture their contents properly
- add a few data files to the globally ignored section
- catch-all for tests, to not pollute the "other changes" section

The docker `forkdiff` is already updated, CI should pick up the changes.

Expected output (expanded the most relevant sections, everything is folded closed by default)

![image](https://github.com/ethereum-optimism/op-geth/assets/19571989/fec2ca4c-2acb-45a0-b13b-0196a579ea4f)

