### PR TITLE
fix(list-totalcost): Add `l1Cost` instead of transaction `cost`

### DIFF
--- a/core/txpool/legacypool/list.go
+++ b/core/txpool/legacypool/list.go
@@ -344,6 +344,10 @@ func (l *list) Add(tx *types.Transaction, priceBump uint64, l1CostFn txpool.L1Co
 	l.totalcost.Add(l.totalcost, cost)
 	if l1CostFn != nil {
 		if l1Cost := l1CostFn(tx.RollupCostData()); l1Cost != nil { // add rollup cost
+			cost, overflow := uint256.FromBig(l1Cost)
+			if overflow {
+				return false, nil
+			}
 			l.totalcost.Add(l.totalcost, cost)
 		}
 	}


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Previously, `l.totalcost` was calculated incorrectly. The transaction `cost` was added twice, and the `l1Cost` was left out.

This PR fixes the sum calculation so that it is correctly calculated as `tx.Cost() + l1Cost`.
