### PR TITLE
Make L1BlobBaseFee an interface{} during version transition

### DIFF
--- a/core/types/gen_receipt_json.go
+++ b/core/types/gen_receipt_json.go
@@ -34,7 +34,7 @@ func (r Receipt) MarshalJSON() ([]byte, error) {
 		BlockNumber           *hexutil.Big    `json:"blockNumber,omitempty"`
 		TransactionIndex      hexutil.Uint    `json:"transactionIndex"`
 		L1GasPrice            *hexutil.Big    `json:"l1GasPrice,omitempty"`
-		L1BlobBaseFee         *hexutil.Big    `json:"l1BlobBaseFee,omitempty"`
+		L1BlobBaseFee         interface{}     `json:"l1BlobBaseFee,omitempty"`
 		L1GasUsed             *hexutil.Big    `json:"l1GasUsed,omitempty"`
 		L1Fee                 *hexutil.Big    `json:"l1Fee,omitempty"`
 		FeeScalar             *big.Float      `json:"l1FeeScalar,omitempty"`
@@ -60,7 +60,7 @@ func (r Receipt) MarshalJSON() ([]byte, error) {
 	enc.BlockNumber = (*hexutil.Big)(r.BlockNumber)
 	enc.TransactionIndex = hexutil.Uint(r.TransactionIndex)
 	enc.L1GasPrice = (*hexutil.Big)(r.L1GasPrice)
-	enc.L1BlobBaseFee = (*hexutil.Big)(r.L1BlobBaseFee)
+	enc.L1BlobBaseFee = r.L1BlobBaseFee
 	enc.L1GasUsed = (*hexutil.Big)(r.L1GasUsed)
 	enc.L1Fee = (*hexutil.Big)(r.L1Fee)
 	enc.FeeScalar = r.FeeScalar
@@ -90,7 +90,7 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 		BlockNumber           *hexutil.Big    `json:"blockNumber,omitempty"`
 		TransactionIndex      *hexutil.Uint   `json:"transactionIndex"`
 		L1GasPrice            *hexutil.Big    `json:"l1GasPrice,omitempty"`
-		L1BlobBaseFee         *hexutil.Big    `json:"l1BlobBaseFee,omitempty"`
+		L1BlobBaseFee         interface{}     `json:"l1BlobBaseFee,omitempty"`
 		L1GasUsed             *hexutil.Big    `json:"l1GasUsed,omitempty"`
 		L1Fee                 *hexutil.Big    `json:"l1Fee,omitempty"`
 		FeeScalar             *big.Float      `json:"l1FeeScalar,omitempty"`
@@ -161,7 +161,7 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 		r.L1GasPrice = (*big.Int)(dec.L1GasPrice)
 	}
 	if dec.L1BlobBaseFee != nil {
-		r.L1BlobBaseFee = (*big.Int)(dec.L1BlobBaseFee)
+		r.L1BlobBaseFee = dec.L1BlobBaseFee
 	}
 	if dec.L1GasUsed != nil {
 		r.L1GasUsed = (*big.Int)(dec.L1GasUsed)

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -85,13 +85,13 @@ type Receipt struct {
 	TransactionIndex uint        `json:"transactionIndex"`
 
 	// Optimism: extend receipts with L1 fee info
-	L1GasPrice          *big.Int   `json:"l1GasPrice,omitempty"`          // Present from pre-bedrock. L1 Basefee after Bedrock
-	L1BlobBaseFee       *big.Int   `json:"l1BlobBaseFee,omitempty"`       // Always nil prior to the Ecotone hardfork
-	L1GasUsed           *big.Int   `json:"l1GasUsed,omitempty"`           // Present from pre-bedrock, deprecated as of Fjord
-	L1Fee               *big.Int   `json:"l1Fee,omitempty"`               // Present from pre-bedrock
-	FeeScalar           *big.Float `json:"l1FeeScalar,omitempty"`         // Present from pre-bedrock to Ecotone. Nil after Ecotone
-	L1BaseFeeScalar     *uint64    `json:"l1BaseFeeScalar,omitempty"`     // Always nil prior to the Ecotone hardfork
-	L1BlobBaseFeeScalar *uint64    `json:"l1BlobBaseFeeScalar,omitempty"` // Always nil prior to the Ecotone hardfork
+	L1GasPrice          *big.Int    `json:"l1GasPrice,omitempty"`          // Present from pre-bedrock. L1 Basefee after Bedrock
+	L1BlobBaseFee       interface{} `json:"l1BlobBaseFee,omitempty"`       // Always nil prior to the Ecotone hardfork
+	L1GasUsed           *big.Int    `json:"l1GasUsed,omitempty"`           // Present from pre-bedrock, deprecated as of Fjord
+	L1Fee               *big.Int    `json:"l1Fee,omitempty"`               // Present from pre-bedrock
+	FeeScalar           *big.Float  `json:"l1FeeScalar,omitempty"`         // Present from pre-bedrock to Ecotone. Nil after Ecotone
+	L1BaseFeeScalar     *uint64     `json:"l1BaseFeeScalar,omitempty"`     // Always nil prior to the Ecotone hardfork
+	L1BlobBaseFeeScalar *uint64     `json:"l1BlobBaseFeeScalar,omitempty"` // Always nil prior to the Ecotone hardfork
 }
 
 type receiptMarshaling struct {
@@ -108,7 +108,7 @@ type receiptMarshaling struct {
 
 	// Optimism
 	L1GasPrice            *hexutil.Big
-	L1BlobBaseFee         *hexutil.Big
+	L1BlobBaseFee         interface{}
 	L1GasUsed             *hexutil.Big
 	L1Fee                 *hexutil.Big
 	FeeScalar             *big.Float

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1916,7 +1916,8 @@ func marshalReceipt(receipt *types.Receipt, blockHash common.Hash, blockNumber u
 		}
 		// Fields added in Ecotone
 		if receipt.L1BlobBaseFee != nil {
-			fields["l1BlobBaseFee"] = (*hexutil.Big)(receipt.L1BlobBaseFee)
+			// TODO: this should be a hexutil.Big, but it's an opaque interface for backwards compatibility at the moment
+			fields["l1BlobBaseFee"] = receipt.L1BlobBaseFee
 		}
 		if receipt.L1BaseFeeScalar != nil {
 			fields["l1BaseFeeScalar"] = hexutil.Uint64(*receipt.L1BaseFeeScalar)


### PR DESCRIPTION
A quick attempt at allowing marshal/unmarshal of Receipts, regardless of the format of L1BlobBaseFee. Uses `interface{}`, which remains opaque throughout, and must be type-cast to be used.

### Testing
 `op-node` passes CI with this: https://github.com/ethereum-optimism/optimism/pull/10706

### Context
My understanding of the problem:
* Geth `1.101315.0` has a given `L1BlobBaseFee` encoding
* Geth `1.101315.1` has a *different* given `L1BlobBaseFee` encoding
* Older versions don't have this field in the receipt in the first place

When a given L2 node is connecting to L1, it uses Exported definitions in `op-geth`. Normally, this means that a consistent Node:Execution pairing are always on the same api. However, in the case of L3s or other utilities that build on-top of L2, the version of their node must now also match the *L2 host* they are connecting to. This locked compatibility currently requires a brief outage for >L2 infrastructure, as the only mutually compatible versioning between OP-Node `1.7.5` and OP-Node `1.7.6` is to have both sides upgrade in lock-step.

By abstracting out the `L1BlobBaseFee` into an `interface{}`, either format of this field should marshal.

### Caveat
I am not sure if this is the direction we would want this fix to go, as I am uncertain of the downstream impacts of this change.
There is a failing unit test related to this change which may indicate that this is not correctly done.