### PR TITLE
Add tests for tracing successful deposits

### DIFF
--- a/eth/tracers/internal/tracetest/testdata/call_tracer/deposit.json
+++ b/eth/tracers/internal/tracetest/testdata/call_tracer/deposit.json
@@ -1,0 +1,52 @@
+{
+  "context": {
+    "difficulty": "3699098917",
+    "gasLimit": "5258985",
+    "miner": "0xd049bfd667cb46aa3ef5df0da3e57db3be39e511",
+    "number": "2294631",
+    "timestamp": "1513675366"
+  },
+  "genesis": {
+    "alloc": {
+      "0xBc339E628E6fe32C39E84392D087567B2743Ea35": {
+        "balance": "0x99999999999999999"
+      }
+    },
+    "config": {
+      "chainId": 3,
+      "daoForkSupport": true,
+      "eip150Hash": "0x41941023680923e0fe4d74a34bdac8141f2540e3ae90623718e47d66d1ca4a2d",
+      "ethash": {},
+      "eip150Block": 0,
+      "eip155Block": 0,
+      "eip158Block": 0,
+      "byzantiumBlock": 0,
+      "constantinopleBlock": 0,
+      "petersburgBlock": 0,
+      "istanbulBlock": 0,
+      "berlinBlock": 0,
+      "londonBlock": 0
+    },
+    "difficulty": "3699098917",
+    "extraData": "0x4554482e45544846414e532e4f52472d4641313738394444",
+    "gasLimit": "5263953",
+    "hash": "0x03a0f62a8106793dafcfae7b75fd2654322062d585a19cea568314d7205790dc",
+    "miner": "0xbbf5029fd710d227630c8b7d338051b8e76d50b3",
+    "mixHash": "0x15482cc64b7c00a947f5bf015dfc010db1a6a668c74df61974d6a7848c174408",
+    "nonce": "0xd1bdb150f6fd170e",
+    "number": "2294630",
+    "stateRoot": "0x1ab1a534e84cc787cda1db21e0d5920ab06017948075b759166cfea7274657a1",
+    "timestamp": "1513675347",
+    "totalDifficulty": "7160543502214733"
+  },
+  "input": "0x7ef85aa0b4f9f798a5fe956d1b79c3eff355febf9e1039a7440948845536982cb62aa03194bc339e628e6fe32c39e84392d087567b2743ea3594bc339e628e6fe32c39e84392d087567b2743ea3580871aa535d3d0c00083030d408000",
+  "result": {
+    "from":"0xBc339E628E6fe32C39E84392D087567B2743Ea35",
+    "to": "0xbc339e628e6fe32c39e84392d087567b2743ea35",
+    "gas":"0x30d40",
+    "gasUsed":"0x30d40",
+    "input":"0x00",
+    "value": "0x1aa535d3d0c000",
+    "type":"CALL"
+  }
+}

--- a/eth/tracers/internal/tracetest/testdata/call_tracer_flat/deposit.json
+++ b/eth/tracers/internal/tracetest/testdata/call_tracer_flat/deposit.json
@@ -1,0 +1,65 @@
+{
+  "context": {
+    "difficulty": "3699098917",
+    "gasLimit": "5258985",
+    "miner": "0xd049bfd667cb46aa3ef5df0da3e57db3be39e511",
+    "number": "2294631",
+    "timestamp": "1513675366"
+  },
+  "genesis": {
+    "alloc": {
+      "0xBc339E628E6fe32C39E84392D087567B2743Ea35": {
+        "balance": "0x99999999999999999"
+      }
+    },
+    "config": {
+      "daoForkSupport": true,
+      "chainId": 3,
+      "eip150Hash": "0x41941023680923e0fe4d74a34bdac8141f2540e3ae90623718e47d66d1ca4a2d",
+      "ethash": {},
+      "eip150Block": 0,
+      "eip155Block": 0,
+      "eip158Block": 0,
+      "byzantiumBlock": 0,
+      "constantinopleBlock": 0,
+      "petersburgBlock": 0,
+      "istanbulBlock": 0,
+      "berlinBlock": 0,
+      "londonBlock": 0
+    },
+    "difficulty": "3699098917",
+    "extraData": "0x4554482e45544846414e532e4f52472d4641313738394444",
+    "gasLimit": "5263953",
+    "hash": "0x03a0f62a8106793dafcfae7b75fd2654322062d585a19cea568314d7205790dc",
+    "miner": "0xbbf5029fd710d227630c8b7d338051b8e76d50b3",
+    "mixHash": "0x15482cc64b7c00a947f5bf015dfc010db1a6a668c74df61974d6a7848c174408",
+    "nonce": "0xd1bdb150f6fd170e",
+    "number": "2294630",
+    "stateRoot": "0x1ab1a534e84cc787cda1db21e0d5920ab06017948075b759166cfea7274657a1",
+    "timestamp": "1513675347",
+    "totalDifficulty": "7160543502214733"
+  },
+  "input": "0x7ef85aa0b4f9f798a5fe956d1b79c3eff355febf9e1039a7440948845536982cb62aa03194bc339e628e6fe32c39e84392d087567b2743ea3594bc339e628e6fe32c39e84392d087567b2743ea3580871aa535d3d0c00083030d408000",
+  "result": [{
+    "type": "call",
+    "action": {
+      "author": "0x0000000000000000000000000000000000000000",
+      "refundAddress": "0x0000000000000000000000000000000000000000",
+      "from":"0xBc339E628E6fe32C39E84392D087567B2743Ea35",
+      "to": "0xbc339e628e6fe32c39e84392d087567b2743ea35",
+      "gas":"0x30d40",
+      "gasUsed":"0x30d40",
+      "input":"0x00",
+      "value": "0x1aa535d3d0c000",
+      "callType":"call",
+      "address": "0x0000000000000000000000000000000000000000",
+      "balance": "0x0"
+    },
+    "result": {
+      "address": "0x0000000000000000000000000000000000000000",
+      "gasUsed": "0x30d40",
+      "output": "0x"
+    },
+    "traceAddress": []
+  }]
+}


### PR DESCRIPTION
**Description**

Add tests for tracing successful deposits (we already have tests for failed deposits). Geth 1.14.0 has quite a lot of changes around tracing and I figured it was worth adding a sanity check test prior to merging upstream.
