### PR TITLE
Make OptimismConfig.EIP1559DenominatorCanyon optional

### DIFF
--- a/consensus/misc/eip1559/eip1559_test.go
+++ b/consensus/misc/eip1559/eip1559_test.go
@@ -59,11 +59,12 @@ func opConfig() *params.ChainConfig {
 	config := copyConfig(params.TestChainConfig)
 	config.LondonBlock = big.NewInt(5)
 	ct := uint64(10)
+	eip1559DenominatorCanyon := uint64(250)
 	config.CanyonTime = &ct
 	config.Optimism = &params.OptimismConfig{
 		EIP1559Elasticity:        6,
 		EIP1559Denominator:       50,
-		EIP1559DenominatorCanyon: 250,
+		EIP1559DenominatorCanyon: &eip1559DenominatorCanyon,
 	}
 	return config
 }

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -282,8 +282,9 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedb.Database, g
 			if overrides != nil && overrides.OverrideOptimismCanyon != nil {
 				config.CanyonTime = overrides.OverrideOptimismCanyon
 				config.ShanghaiTime = overrides.OverrideOptimismCanyon
-				if config.Optimism != nil && config.Optimism.EIP1559DenominatorCanyon == 0 {
-					config.Optimism.EIP1559DenominatorCanyon = 250
+				if config.Optimism != nil && *config.Optimism.EIP1559DenominatorCanyon == 0 {
+					eip1559DenominatorCanyon := uint64(250)
+					config.Optimism.EIP1559DenominatorCanyon = &eip1559DenominatorCanyon
 				}
 			}
 			if overrides != nil && overrides.OverrideOptimismEcotone != nil {

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -282,7 +282,7 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedb.Database, g
 			if overrides != nil && overrides.OverrideOptimismCanyon != nil {
 				config.CanyonTime = overrides.OverrideOptimismCanyon
 				config.ShanghaiTime = overrides.OverrideOptimismCanyon
-				if config.Optimism != nil {
+				if config.Optimism != nil && (config.Optimism.EIP1559DenominatorCanyon == nil || *config.Optimism.EIP1559DenominatorCanyon == 0) {
 					eip1559DenominatorCanyon := uint64(250)
 					config.Optimism.EIP1559DenominatorCanyon = &eip1559DenominatorCanyon
 				}

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -282,7 +282,7 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedb.Database, g
 			if overrides != nil && overrides.OverrideOptimismCanyon != nil {
 				config.CanyonTime = overrides.OverrideOptimismCanyon
 				config.ShanghaiTime = overrides.OverrideOptimismCanyon
-				if config.Optimism != nil && *config.Optimism.EIP1559DenominatorCanyon == 0 {
+				if config.Optimism != nil {
 					eip1559DenominatorCanyon := uint64(250)
 					config.Optimism.EIP1559DenominatorCanyon = &eip1559DenominatorCanyon
 				}

--- a/core/superchain_test.go
+++ b/core/superchain_test.go
@@ -89,5 +89,4 @@ func TestRegistryChainConfigOverride(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/core/superchain_test.go
+++ b/core/superchain_test.go
@@ -19,72 +19,81 @@ func TestOPStackGenesis(t *testing.T) {
 }
 
 func TestRegistryChainConfigOverride(t *testing.T) {
-	db := rawdb.NewMemoryDatabase()
-	genesis, err := LoadOPStackGenesis(10)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if genesis.Config.RegolithTime == nil {
-		t.Fatal("expected non-nil regolith time")
-	}
-	expectedRegolithTime := *genesis.Config.RegolithTime
-	genesis.Config.RegolithTime = nil
-
-	// initialize the DB
-	tdb := triedb.NewDatabase(db, newDbConfig(rawdb.PathScheme))
-	genesis.MustCommit(db, tdb)
-	bl := genesis.ToBlock()
-	rawdb.WriteCanonicalHash(db, bl.Hash(), 0)
-	rawdb.WriteBlock(db, bl)
-
 	var tests = []struct {
-		name                string
-		overrides           *ChainOverrides
-		setDenominator      *uint64
-		expectedDenominator uint64
+		name                 string
+		overrides            *ChainOverrides
+		setDenominator       *uint64
+		expectedDenominator  uint64
+		expectedRegolithTime *uint64
 	}{
 		{
-			name:                "ApplySuperchainUpgrades",
-			overrides:           &ChainOverrides{ApplySuperchainUpgrades: true},
-			setDenominator:      uint64ptr(50),
-			expectedDenominator: 250,
+			name:                 "ApplySuperchainUpgrades",
+			overrides:            &ChainOverrides{ApplySuperchainUpgrades: true},
+			setDenominator:       uint64ptr(50),
+			expectedDenominator:  250,
+			expectedRegolithTime: uint64ptr(0),
 		},
 		{
-			name:                "OverrideOptimismCanyon_denom_nil",
-			overrides:           &ChainOverrides{OverrideOptimismCanyon: uint64ptr(1)},
-			setDenominator:      nil,
-			expectedDenominator: 250,
+			name:                 "OverrideOptimismCanyon_denom_nil",
+			overrides:            &ChainOverrides{OverrideOptimismCanyon: uint64ptr(1)},
+			setDenominator:       nil,
+			expectedDenominator:  250,
+			expectedRegolithTime: nil,
 		},
 		{
-			name:                "OverrideOptimismCanyon_denom_0",
-			overrides:           &ChainOverrides{OverrideOptimismCanyon: uint64ptr(1)},
-			setDenominator:      uint64ptr(0),
-			expectedDenominator: 250,
+			name:                 "OverrideOptimismCanyon_denom_0",
+			overrides:            &ChainOverrides{OverrideOptimismCanyon: uint64ptr(1)},
+			setDenominator:       uint64ptr(0),
+			expectedDenominator:  250,
+			expectedRegolithTime: nil,
 		},
 		{
-			name:                "OverrideOptimismCanyon_ignore_override",
-			overrides:           &ChainOverrides{OverrideOptimismCanyon: uint64ptr(1)},
-			setDenominator:      uint64ptr(100),
-			expectedDenominator: 100,
+			name:                 "OverrideOptimismCanyon_ignore_override",
+			overrides:            &ChainOverrides{OverrideOptimismCanyon: uint64ptr(1)},
+			setDenominator:       uint64ptr(100),
+			expectedDenominator:  100,
+			expectedRegolithTime: nil,
 		},
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			db := rawdb.NewMemoryDatabase()
+			genesis, err := LoadOPStackGenesis(10)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if genesis.Config.RegolithTime == nil {
+				t.Fatal("expected non-nil regolith time")
+			}
+			genesis.Config.RegolithTime = nil
+
+			// initialize the DB
+			tdb := triedb.NewDatabase(db, newDbConfig(rawdb.PathScheme))
+			genesis.MustCommit(db, tdb)
+			bl := genesis.ToBlock()
+			rawdb.WriteCanonicalHash(db, bl.Hash(), 0)
+			rawdb.WriteBlock(db, bl)
+
 			genesis.Config.Optimism.EIP1559DenominatorCanyon = tt.setDenominator
 			// create chain config, even with incomplete genesis input: the chain config should be corrected
 			chainConfig, _, err := SetupGenesisBlockWithOverride(db, tdb, genesis, tt.overrides)
 			if err != nil {
 				t.Fatal(err)
 			}
+
 			// check if we have a corrected chain config
-			if chainConfig.RegolithTime == nil {
-				t.Fatal("expected regolith time to be corrected, but time is still nil")
-			} else if *chainConfig.RegolithTime != expectedRegolithTime {
-				t.Fatalf("expected regolith time to be %d, but got %d", expectedRegolithTime, *chainConfig.RegolithTime)
+			if tt.expectedRegolithTime == nil {
+				if chainConfig.RegolithTime != nil {
+					t.Fatal("expected regolith time to be nil")
+				}
+			} else if *chainConfig.RegolithTime != *tt.expectedRegolithTime {
+				t.Fatalf("expected regolith time to be %d, but got %d", *tt.expectedRegolithTime, *chainConfig.RegolithTime)
 			}
 
-			if tt.expectedDenominator != *chainConfig.Optimism.EIP1559DenominatorCanyon {
+			if *chainConfig.Optimism.EIP1559DenominatorCanyon != tt.expectedDenominator {
 				t.Fatalf("expected EIP1559DenominatorCanyon to be %d, but got %d", tt.expectedDenominator, *chainConfig.Optimism.EIP1559DenominatorCanyon)
 			}
 		})

--- a/params/config.go
+++ b/params/config.go
@@ -898,6 +898,9 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, headNumber *big.Int, 
 func (c *ChainConfig) BaseFeeChangeDenominator(time uint64) uint64 {
 	if c.Optimism != nil {
 		if c.IsCanyon(time) {
+			if c.Optimism.EIP1559DenominatorCanyon == nil || *c.Optimism.EIP1559DenominatorCanyon == 0 {
+				panic("invalid ChainConfig.Optimism.EIP1559DenominatorCanyon value: '0' or 'nil'")
+			}
 			return *c.Optimism.EIP1559DenominatorCanyon
 		}
 		return c.Optimism.EIP1559Denominator

--- a/params/config.go
+++ b/params/config.go
@@ -436,9 +436,9 @@ func (c *CliqueConfig) String() string {
 
 // OptimismConfig is the optimism config.
 type OptimismConfig struct {
-	EIP1559Elasticity        uint64 `json:"eip1559Elasticity"`
-	EIP1559Denominator       uint64 `json:"eip1559Denominator"`
-	EIP1559DenominatorCanyon uint64 `json:"eip1559DenominatorCanyon"`
+	EIP1559Elasticity        uint64  `json:"eip1559Elasticity"`
+	EIP1559Denominator       uint64  `json:"eip1559Denominator"`
+	EIP1559DenominatorCanyon *uint64 `json:"eip1559DenominatorCanyon,omitempty"`
 }
 
 // String implements the stringer interface, returning the optimism fee config details.
@@ -898,7 +898,7 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, headNumber *big.Int, 
 func (c *ChainConfig) BaseFeeChangeDenominator(time uint64) uint64 {
 	if c.Optimism != nil {
 		if c.IsCanyon(time) {
-			return c.Optimism.EIP1559DenominatorCanyon
+			return *c.Optimism.EIP1559DenominatorCanyon
 		}
 		return c.Optimism.EIP1559Denominator
 	}

--- a/params/superchain.go
+++ b/params/superchain.go
@@ -43,6 +43,7 @@ func LoadOPStackChainConfig(chainID uint64) (*ChainConfig, error) {
 	}
 
 	genesisActivation := uint64(0)
+	eip1559DenominatorCanyon := uint64(250)
 	out := &ChainConfig{
 		ChainID:                       new(big.Int).SetUint64(chainID),
 		HomesteadBlock:                common.Big0,
@@ -76,7 +77,7 @@ func LoadOPStackChainConfig(chainID uint64) (*ChainConfig, error) {
 		Optimism: &OptimismConfig{
 			EIP1559Elasticity:        6,
 			EIP1559Denominator:       50,
-			EIP1559DenominatorCanyon: 250,
+			EIP1559DenominatorCanyon: &eip1559DenominatorCanyon,
 		},
 	}
 

--- a/params/superchain.go
+++ b/params/superchain.go
@@ -43,7 +43,6 @@ func LoadOPStackChainConfig(chainID uint64) (*ChainConfig, error) {
 	}
 
 	genesisActivation := uint64(0)
-	eip1559DenominatorCanyon := uint64(250)
 	out := &ChainConfig{
 		ChainID:                       new(big.Int).SetUint64(chainID),
 		HomesteadBlock:                common.Big0,
@@ -77,7 +76,7 @@ func LoadOPStackChainConfig(chainID uint64) (*ChainConfig, error) {
 		Optimism: &OptimismConfig{
 			EIP1559Elasticity:        6,
 			EIP1559Denominator:       50,
-			EIP1559DenominatorCanyon: &eip1559DenominatorCanyon,
+			EIP1559DenominatorCanyon: newUint64(250),
 		},
 	}
 


### PR DESCRIPTION
Prior to this PR the `OptimismConfig.EIP1559DenominatorCanyon` field was required, so when Unmarshaled from a json file in the superchain-registry, it was populated with the default `0` value if it was missing. 

This PR makes that field optional, so that it is initialized as `nil`, and only populated if it is present in the json file. This allows the new superchain-registry `add-chain check-genesis` command to be backwards compatible with chains that did not have canyon activated at genesis.

### Additional context
* superchain-registry PR to add the `add-chain check-genesis` command: https://github.com/ethereum-optimism/superchain-registry/pull/354