### PR TITLE
expose http headers & request body via peerinfo context

### DIFF
--- a/rpc/http_test.go
+++ b/rpc/http_test.go
@@ -18,6 +18,7 @@ package rpc
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -180,6 +181,7 @@ func TestHTTPPeerInfo(t *testing.T) {
 	}
 	c.SetHeader("user-agent", "ua-testing")
 	c.SetHeader("origin", "origin.example.com")
+	c.SetHeader("foobar", "baz")
 
 	// Request peer information.
 	var info PeerInfo
@@ -201,6 +203,12 @@ func TestHTTPPeerInfo(t *testing.T) {
 	}
 	if info.HTTP.Origin != "origin.example.com" {
 		t.Errorf("wrong HTTP.Origin %q", info.HTTP.UserAgent)
+	}
+	if info.HTTP.Header.Get("foobar") != "baz" {
+		t.Errorf("wrong custom Http.Header")
+	}
+	if rpc, _ := parseMessage(json.RawMessage(info.HTTP.Body)); len(rpc) != 1 && rpc[0].Method != "test_peerInfo" {
+		t.Errorf("unexpected json rpc message body")
 	}
 }
 

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -19,6 +19,7 @@ package rpc
 import (
 	"context"
 	"io"
+	"net/http"
 	"sync"
 	"sync/atomic"
 
@@ -218,6 +219,10 @@ type PeerInfo struct {
 		UserAgent string
 		Origin    string
 		Host      string
+		// Headers associated with the request
+		Header http.Header
+		// The body attached to request
+		Body []byte
 	}
 }
 

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -221,7 +221,7 @@ type PeerInfo struct {
 		Host      string
 		// Headers associated with the request
 		Header http.Header
-		// The body attached to request
+		// The body attached to the request
 		Body []byte
 	}
 }


### PR DESCRIPTION
go-ethereum library has very useful rpc libraries for creating json-rpc servers, used extensively in the optimism monorepo.

For the [sendRawTransactionConditional](https://github.com/ethereum-optimism/design-docs/blob/main/ecosystem/sendRawTransactionConditional/proposal.md) endpoint, we want to implement authentication external to the the execution engine.

This requires accessing the headers & body associated with the request which can easily be done by exposing them in the `PeerInfo` set in the context when serving a requests