### PR TITLE
core/vm: improve precompile overrides functionality

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -63,12 +63,9 @@ func (evm *EVM) precompile(addr common.Address) (PrecompiledContract, bool) {
 		precompiles = PrecompiledContractsHomestead
 	}
 	p, ok := precompiles[addr]
-	// Restrict overrides to known precompiles
-	if ok && evm.chainConfig.IsOptimism() && evm.Config.OptimismPrecompileOverrides != nil {
-		override, ok := evm.Config.OptimismPrecompileOverrides(evm.chainRules, p, addr)
-		if ok {
-			return override, ok
-		}
+	if evm.Config.PrecompileOverrides != nil {
+		override := evm.Config.PrecompileOverrides(evm.chainRules, p, addr)
+		return override, override != nil
 	}
 	return p, ok
 }

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -29,7 +29,8 @@ import (
 )
 
 // PrecompileOverrides is a function that can be used to override the default precompiled contracts
-type PrecompileOverrides func(params.Rules, PrecompiledContract, common.Address) (PrecompiledContract, bool)
+// Nil is returned when there is no precompile. The original is returned if the existing precompile should run.
+type PrecompileOverrides func(rules params.Rules, original PrecompiledContract, addr common.Address) PrecompiledContract
 
 // Config are the configuration options for the Interpreter
 type Config struct {
@@ -39,7 +40,7 @@ type Config struct {
 	ExtraEips               []int // Additional EIPS that are to be enabled
 	EnableWitnessCollection bool  // true if witness collection is enabled
 
-	OptimismPrecompileOverrides PrecompileOverrides // Precompile overrides for Optimism
+	PrecompileOverrides PrecompileOverrides // Precompiles can be swapped / changed / wrapped as needed
 }
 
 // ScopeContext contains the things that are per-call, such as stack and memory,


### PR DESCRIPTION
**Description**

This changes the `OptimismPrecompileOverrides` to `PrecompileOverrides`,
 such that we can override precompiles at any time, and override not just existing precompiles, but add/remove ones.

The API is simplified to take the existing precompile, and return the precompile to be used.

- Disabling a precompile = return nil.
- Adding a precompile = return your choice of precompile.
- Overriding a precompile = return the original precompile.

**Tests**

Testing in monorepo. See PR: <TODO depends on this PR>

**Additional context**

This more flexible precompile overriding is needed for EVM cheatcodes/logging support in deployment/test tooling.
