### PR TITLE
core/vm: evm options to ignore max-bytecode-size and support caller overriding

### DIFF
--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -314,7 +314,7 @@ func gasCreateEip3860(evm *EVM, contract *Contract, stack *Stack, mem *Memory, m
 	if overflow {
 		return 0, ErrGasUintOverflow
 	}
-	if size > params.MaxInitCodeSize {
+	if size > params.MaxInitCodeSize && !evm.Config.NoMaxCodeSize {
 		return 0, fmt.Errorf("%w: size %d", ErrMaxInitCodeSizeExceeded, size)
 	}
 	// Since size <= params.MaxInitCodeSize, these multiplication cannot overflow
@@ -333,7 +333,7 @@ func gasCreate2Eip3860(evm *EVM, contract *Contract, stack *Stack, mem *Memory, 
 	if overflow {
 		return 0, ErrGasUintOverflow
 	}
-	if size > params.MaxInitCodeSize {
+	if size > params.MaxInitCodeSize && !evm.Config.NoMaxCodeSize {
 		return 0, fmt.Errorf("%w: size %d", ErrMaxInitCodeSizeExceeded, size)
 	}
 	// Since size <= params.MaxInitCodeSize, these multiplication cannot overflow

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -40,7 +40,9 @@ type Config struct {
 	ExtraEips               []int // Additional EIPS that are to be enabled
 	EnableWitnessCollection bool  // true if witness collection is enabled
 
-	PrecompileOverrides PrecompileOverrides // Precompiles can be swapped / changed / wrapped as needed
+	PrecompileOverrides PrecompileOverrides             // Precompiles can be swapped / changed / wrapped as needed
+	NoMaxCodeSize       bool                            // Ignore Max code size and max init code size limits
+	CallerOverride      func(v ContractRef) ContractRef // Swap the caller as needed, for VM prank functionality.
 }
 
 // ScopeContext contains the things that are per-call, such as stack and memory,

--- a/fork.yaml
+++ b/fork.yaml
@@ -49,12 +49,21 @@ def:
                 - "core/types/tx_dynamic_fee.go"
                 - "core/types/tx_legacy.go"
                 - "core/types/tx_blob.go"
+            - title: "EVM enhancements"
+              description: |
+                Apply L1 cost computation, and add EVM configuration for tooling and more:
+                - Disable bytecode size-limits (for large test/script contracts).
+                - Prank (solidity test terminology) the EVM-call message-sender.
+                - Override precompiles, to insert tooling precompiles and optimize precompile proving.
+              globs:
+                - "core/vm/evm.go"
+                - "core/vm/interpreter.go"
+                - "core/vm/gas_table.go"
             - title: "L1 cost computation"
               description: |
                 Transactions must pay an additional L1 cost based on the amount of rollup-data-gas they consume,
                 estimated based on gas-price-oracle information and encoded tx size."
               globs:
-                - "core/vm/evm.go"
                 - "core/evm.go"
                 - "core/types/rollup_cost.go"
                 - "core/state_processor.go"
@@ -117,7 +126,6 @@ def:
           description: ""
           globs:
             - "core/vm/contracts.go"
-            - "core/vm/interpreter.go"
             - "crypto/secp256r1/publickey.go"
             - "crypto/secp256r1/verifier.go"
     - title: "Chain Configuration"


### PR DESCRIPTION
**Description**

- New `NoMaxCodeSize` EVM config option, to run larger contracts (forge scripts specifically) in the Go EVM
- New `CallerOverride` EVM config option, to implement EVM-caller pranks, to support forge scripts.

**Tests**

Existing tests cover precompiles, max-code-size and caller usage. The config option code-paths are used and tested in the monorepo.

**Metadata**

Part of unblocking https://github.com/ethereum-optimism/optimism/issues/11490

