### PR TITLE
Support purely single threaded execution

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -42,7 +42,6 @@ import (
 	"github.com/ethereum/go-ethereum/trie/triestate"
 	"github.com/ethereum/go-ethereum/trie/utils"
 	"github.com/holiman/uint256"
-	"golang.org/x/sync/errgroup"
 )
 
 // TriesInMemory represents the number of layers that are kept in RAM.
@@ -167,6 +166,8 @@ type StateDB struct {
 	StorageUpdated atomic.Int64
 	AccountDeleted int
 	StorageDeleted atomic.Int64
+
+	singlethreaded bool
 }
 
 // New creates a new state from a given trie.
@@ -194,6 +195,10 @@ func New(root common.Hash, db Database, snaps *snapshot.Tree) (*StateDB, error) 
 		sdb.snap = sdb.snaps.Snapshot(root)
 	}
 	return sdb, nil
+}
+
+func (s *StateDB) MakeSingleThreaded() {
+	s.singlethreaded = true
 }
 
 // SetLogger sets the logger for account update hooks.
@@ -851,9 +856,9 @@ func (s *StateDB) IntermediateRoot(deleteEmptyObjects bool) common.Hash {
 	// method will internally call a blocking trie fetch from the prefetcher,
 	// so there's no need to explicitly wait for the prefetchers to finish.
 	var (
-		start   = time.Now()
-		workers errgroup.Group
+		start = time.Now()
 	)
+	workers := newWorkerGroup(s.singlethreaded)
 	if s.db.TrieDB().IsVerkle() {
 		// Whilst MPT storage tries are independent, Verkle has one single trie
 		// for all the accounts and all the storage slots merged together. The
@@ -1225,10 +1230,10 @@ func (s *StateDB) commit(deleteEmptyObjects bool) (*stateUpdate, error) {
 	// off some milliseconds from the commit operation. Also accumulate the code
 	// writes to run in parallel with the computations.
 	var (
-		start   = time.Now()
-		root    common.Hash
-		workers errgroup.Group
+		start = time.Now()
+		root  common.Hash
 	)
+	workers := newWorkerGroup(s.singlethreaded)
 	// Schedule the account trie first since that will be the biggest, so give
 	// it the most time to crunch.
 	//

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -166,8 +166,6 @@ type StateDB struct {
 	StorageUpdated atomic.Int64
 	AccountDeleted int
 	StorageDeleted atomic.Int64
-
-	singlethreaded bool
 }
 
 // New creates a new state from a given trie.
@@ -195,10 +193,6 @@ func New(root common.Hash, db Database, snaps *snapshot.Tree) (*StateDB, error) 
 		sdb.snap = sdb.snaps.Snapshot(root)
 	}
 	return sdb, nil
-}
-
-func (s *StateDB) MakeSingleThreaded() {
-	s.singlethreaded = true
 }
 
 // SetLogger sets the logger for account update hooks.
@@ -858,7 +852,7 @@ func (s *StateDB) IntermediateRoot(deleteEmptyObjects bool) common.Hash {
 	var (
 		start = time.Now()
 	)
-	workers := newWorkerGroup(s.singlethreaded)
+	workers := newWorkerGroup()
 	if s.db.TrieDB().IsVerkle() {
 		// Whilst MPT storage tries are independent, Verkle has one single trie
 		// for all the accounts and all the storage slots merged together. The
@@ -1233,7 +1227,7 @@ func (s *StateDB) commit(deleteEmptyObjects bool) (*stateUpdate, error) {
 		start = time.Now()
 		root  common.Hash
 	)
-	workers := newWorkerGroup(s.singlethreaded)
+	workers := newWorkerGroup()
 	// Schedule the account trie first since that will be the biggest, so give
 	// it the most time to crunch.
 	//

--- a/core/state/workers.go
+++ b/core/state/workers.go
@@ -1,0 +1,37 @@
+package state
+
+import (
+	"errors"
+
+	"golang.org/x/sync/errgroup"
+)
+
+type workerGroup interface {
+	Go(func() error)
+	SetLimit(int)
+	Wait() error
+}
+
+func newWorkerGroup(singlethreaded bool) workerGroup {
+	if singlethreaded {
+		return &inlineWorkerGroup{}
+	} else {
+		var grp errgroup.Group
+		return &grp
+	}
+}
+
+type inlineWorkerGroup struct {
+	err error
+}
+
+func (i *inlineWorkerGroup) Go(action func() error) {
+	i.err = errors.Join(i.err, action())
+}
+
+func (i *inlineWorkerGroup) SetLimit(_ int) {
+}
+
+func (i *inlineWorkerGroup) Wait() error {
+	return i.err
+}

--- a/core/state/workers.go
+++ b/core/state/workers.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"errors"
+	"runtime"
 
 	"golang.org/x/sync/errgroup"
 )
@@ -12,8 +13,8 @@ type workerGroup interface {
 	Wait() error
 }
 
-func newWorkerGroup(singlethreaded bool) workerGroup {
-	if singlethreaded {
+func newWorkerGroup() workerGroup {
+	if runtime.NumCPU() == 1 {
 		return &inlineWorkerGroup{}
 	} else {
 		var grp errgroup.Group

--- a/core/state/workers.go
+++ b/core/state/workers.go
@@ -14,7 +14,7 @@ type workerGroup interface {
 }
 
 func newWorkerGroup() workerGroup {
-	if runtime.NumCPU() == 1 {
+	if runtime.NumCPU() <= 1 {
 		return &inlineWorkerGroup{}
 	} else {
 		var grp errgroup.Group

--- a/fork.yaml
+++ b/fork.yaml
@@ -218,6 +218,13 @@ def:
         See upstream Geth PR 28940, and op-geth PR 368 for details.
       globs:
         - "triedb/pathdb/journal.go"
+    - title: "Single threaded execution"
+      description: |
+        The cannon fault proofs virtual machine does not support the creation of threads. To ensure compatibility, 
+        thread creation is avoided when only a single CPU is available.
+      globs:
+        - "core/state/workers.go"
+        - "trie/hasher.go"
     - title: "User API enhancements"
       description: "Encode the Deposit Tx properties, the L1 costs, and daisy-chain RPC-calls for pre-Bedrock historical data"
       sub:

--- a/trie/hasher.go
+++ b/trie/hasher.go
@@ -17,6 +17,7 @@
 package trie
 
 import (
+	"runtime"
 	"sync"
 
 	"github.com/ethereum/go-ethereum/crypto"
@@ -45,7 +46,7 @@ var hasherPool = sync.Pool{
 
 func newHasher(parallel bool) *hasher {
 	h := hasherPool.Get().(*hasher)
-	h.parallel = parallel
+	h.parallel = parallel && runtime.NumCPU() > 1
 	return h
 }
 


### PR DESCRIPTION
**Description**

Modifies `StateDB` to execute all tasks on a single thread when there is a single CPU rather than spawning go routines to compute account storage roots in parallel. Also ensures the hasher only uses parallel mode when there are multiple CPUs available to accelerate the work.

This ensures compatibility with cannon where there is only a single CPU and thread creation is not supported.
