### PR TITLE
interop: experimental sequencer executing message check support

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -159,6 +159,7 @@ var (
 		utils.RollupSequencerTxConditionalCostRateLimitFlag,
 		utils.RollupHistoricalRPCFlag,
 		utils.RollupHistoricalRPCTimeoutFlag,
+		utils.RollupInteropRPCFlag,
 		utils.RollupDisableTxPoolGossipFlag,
 		utils.RollupComputePendingBlock,
 		utils.RollupHaltOnIncompatibleProtocolVersionFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -939,6 +939,12 @@ var (
 		Category: flags.RollupCategory,
 	}
 
+	RollupInteropRPCFlag = &cli.StringFlag{
+		Name:     "rollup.interoprpc",
+		Usage:    "RPC endpoint for interop message verification (experimental).",
+		Category: flags.RollupCategory,
+	}
+
 	RollupDisableTxPoolGossipFlag = &cli.BoolFlag{
 		Name:     "rollup.disabletxpoolgossip",
 		Usage:    "Disable transaction pool gossip.",
@@ -1940,6 +1946,9 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	}
 	if ctx.IsSet(RollupHistoricalRPCTimeoutFlag.Name) {
 		cfg.RollupHistoricalRPCTimeout = ctx.Duration(RollupHistoricalRPCTimeoutFlag.Name)
+	}
+	if ctx.IsSet(RollupInteropRPCFlag.Name) {
+		cfg.InteropMessageRPC = ctx.String(RollupInteropRPCFlag.Name)
 	}
 	cfg.RollupDisableTxPoolGossip = ctx.Bool(RollupDisableTxPoolGossipFlag.Name)
 	cfg.RollupDisableTxPoolAdmission = cfg.RollupSequencerHTTP != "" && !ctx.Bool(RollupEnableTxPoolAdmissionFlag.Name)

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -154,6 +154,8 @@ type Message struct {
 	IsDepositTx    bool                 // IsDepositTx indicates the message is force-included and can persist a mint.
 	Mint           *big.Int             // Mint is the amount to mint before EVM processing, or nil if there is no minting.
 	RollupCostData types.RollupCostData // RollupCostData caches data to compute the fee we charge for data availability
+
+	PostValidation func(evm *vm.EVM, result *ExecutionResult) error
 }
 
 // TransactionToMessage converts a transaction into a Message.
@@ -447,6 +449,13 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		}
 		err = nil
 	}
+
+	if st.msg.PostValidation != nil {
+		if err := st.msg.PostValidation(st.evm, result); err != nil {
+			return nil, err
+		}
+	}
+
 	return result, err
 }
 

--- a/core/types/interoptypes/interop.go
+++ b/core/types/interoptypes/interop.go
@@ -1,0 +1,162 @@
+package interoptypes
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/holiman/uint256"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+var ExecutingMessageEventTopic = crypto.Keccak256Hash([]byte("ExecutingMessage(bytes32,(address,uint256,uint256,uint256,uint256))"))
+
+type Message struct {
+	Identifier  Identifier  `json:"identifier"`
+	PayloadHash common.Hash `json:"payloadHash"`
+}
+
+func (m *Message) DecodeEvent(topics []common.Hash, data []byte) error {
+	if len(topics) != 2 { // event hash, indexed payloadHash
+		return fmt.Errorf("unexpected number of event topics: %d", len(topics))
+	}
+	if topics[0] != ExecutingMessageEventTopic {
+		return fmt.Errorf("unexpected event topic %q", topics[0])
+	}
+	if len(data) != 32*5 {
+		return fmt.Errorf("unexpected identifier data length: %d", len(data))
+	}
+	take := func(length uint) []byte {
+		taken := data[:length]
+		data = data[length:]
+		return taken
+	}
+	takeZeroes := func(length uint) error {
+		for _, v := range take(length) {
+			if v != 0 {
+				return errors.New("expected zero")
+			}
+		}
+		return nil
+	}
+	if err := takeZeroes(12); err != nil {
+		return fmt.Errorf("invalid address padding: %w", err)
+	}
+	m.Identifier.Origin = common.Address(take(20))
+	if err := takeZeroes(32 - 8); err != nil {
+		return fmt.Errorf("invalid block number padding: %w", err)
+	}
+	m.Identifier.BlockNumber = binary.BigEndian.Uint64(take(8))
+	if err := takeZeroes(32 - 8); err != nil {
+		return fmt.Errorf("invalid log index padding: %w", err)
+	}
+	m.Identifier.LogIndex = binary.BigEndian.Uint64(take(8))
+	if err := takeZeroes(32 - 8); err != nil {
+		return fmt.Errorf("invalid timestamp padding: %w", err)
+	}
+	m.Identifier.Timestamp = binary.BigEndian.Uint64(take(8))
+	m.Identifier.ChainID.SetBytes32(take(32))
+	m.PayloadHash = topics[1]
+	return nil
+}
+
+func ExecutingMessagesFromLogs(logs []*types.Log) ([]Message, error) {
+	var executingMessages []Message
+	for i, l := range logs {
+		if l.Address == params.InteropCrossL2InboxAddress {
+			// ignore events that do not match this
+			if len(l.Topics) == 0 || l.Topics[0] != ExecutingMessageEventTopic {
+				continue
+			}
+			var msg Message
+			if err := msg.DecodeEvent(l.Topics, l.Data); err != nil {
+				return nil, fmt.Errorf("invalid executing message %d, tx-log %d: %w", len(executingMessages), i, err)
+			}
+			executingMessages = append(executingMessages, msg)
+		}
+	}
+	return executingMessages, nil
+}
+
+type Identifier struct {
+	Origin      common.Address
+	BlockNumber uint64
+	LogIndex    uint64
+	Timestamp   uint64
+	ChainID     uint256.Int // flat, not a pointer, to make Identifier safe as map key
+}
+
+type identifierMarshaling struct {
+	Origin      common.Address `json:"origin"`
+	BlockNumber hexutil.Uint64 `json:"blockNumber"`
+	LogIndex    hexutil.Uint64 `json:"logIndex"`
+	Timestamp   hexutil.Uint64 `json:"timestamp"`
+	ChainID     hexutil.U256   `json:"chainID"`
+}
+
+func (id Identifier) MarshalJSON() ([]byte, error) {
+	var enc identifierMarshaling
+	enc.Origin = id.Origin
+	enc.BlockNumber = hexutil.Uint64(id.BlockNumber)
+	enc.LogIndex = hexutil.Uint64(id.LogIndex)
+	enc.Timestamp = hexutil.Uint64(id.Timestamp)
+	enc.ChainID = (hexutil.U256)(id.ChainID)
+	return json.Marshal(&enc)
+}
+
+func (id *Identifier) UnmarshalJSON(input []byte) error {
+	var dec identifierMarshaling
+	if err := json.Unmarshal(input, &dec); err != nil {
+		return err
+	}
+	id.Origin = dec.Origin
+	id.BlockNumber = uint64(dec.BlockNumber)
+	id.LogIndex = uint64(dec.LogIndex)
+	id.Timestamp = uint64(dec.Timestamp)
+	id.ChainID = (uint256.Int)(dec.ChainID)
+	return nil
+}
+
+type SafetyLevel string
+
+func (lvl SafetyLevel) String() string {
+	return string(lvl)
+}
+
+func (lvl SafetyLevel) Valid() bool {
+	switch lvl {
+	case Finalized, Safe, CrossUnsafe, Unsafe:
+		return true
+	default:
+		return false
+	}
+}
+
+func (lvl SafetyLevel) MarshalText() ([]byte, error) {
+	return []byte(lvl), nil
+}
+
+func (lvl *SafetyLevel) UnmarshalText(text []byte) error {
+	if lvl == nil {
+		return errors.New("cannot unmarshal into nil SafetyLevel")
+	}
+	x := SafetyLevel(text)
+	if !x.Valid() {
+		return fmt.Errorf("unrecognized safety level: %q", text)
+	}
+	*lvl = x
+	return nil
+}
+
+const (
+	Finalized   SafetyLevel = "finalized"
+	Safe        SafetyLevel = "safe"
+	CrossUnsafe SafetyLevel = "cross-unsafe"
+	Unsafe      SafetyLevel = "unsafe"
+)

--- a/core/types/interoptypes/interop.go
+++ b/core/types/interoptypes/interop.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 
 	"github.com/holiman/uint256"
 
@@ -53,10 +54,10 @@ func (m *Message) DecodeEvent(topics []common.Hash, data []byte) error {
 		return fmt.Errorf("invalid block number padding: %w", err)
 	}
 	m.Identifier.BlockNumber = binary.BigEndian.Uint64(take(8))
-	if err := takeZeroes(32 - 8); err != nil {
+	if err := takeZeroes(32 - 4); err != nil {
 		return fmt.Errorf("invalid log index padding: %w", err)
 	}
-	m.Identifier.LogIndex = binary.BigEndian.Uint64(take(8))
+	m.Identifier.LogIndex = binary.BigEndian.Uint32(take(4))
 	if err := takeZeroes(32 - 8); err != nil {
 		return fmt.Errorf("invalid timestamp padding: %w", err)
 	}
@@ -87,7 +88,7 @@ func ExecutingMessagesFromLogs(logs []*types.Log) ([]Message, error) {
 type Identifier struct {
 	Origin      common.Address
 	BlockNumber uint64
-	LogIndex    uint64
+	LogIndex    uint32
 	Timestamp   uint64
 	ChainID     uint256.Int // flat, not a pointer, to make Identifier safe as map key
 }
@@ -117,7 +118,10 @@ func (id *Identifier) UnmarshalJSON(input []byte) error {
 	}
 	id.Origin = dec.Origin
 	id.BlockNumber = uint64(dec.BlockNumber)
-	id.LogIndex = uint64(dec.LogIndex)
+	if dec.LogIndex > math.MaxUint32 {
+		return fmt.Errorf("log index too large: %d", dec.LogIndex)
+	}
+	id.LogIndex = uint32(dec.LogIndex)
 	id.Timestamp = uint64(dec.Timestamp)
 	id.ChainID = (uint256.Int)(dec.ChainID)
 	return nil

--- a/core/types/interoptypes/interop.go
+++ b/core/types/interoptypes/interop.go
@@ -129,9 +129,10 @@ func (lvl SafetyLevel) String() string {
 	return string(lvl)
 }
 
-func (lvl SafetyLevel) Valid() bool {
+// Valid returns if the safety level is a well-formatted safety level.
+func (lvl SafetyLevel) wellFormatted() bool {
 	switch lvl {
-	case Finalized, Safe, CrossUnsafe, Unsafe:
+	case Finalized, Safe, LocalSafe, CrossUnsafe, Unsafe, Invalid:
 		return true
 	default:
 		return false
@@ -147,7 +148,7 @@ func (lvl *SafetyLevel) UnmarshalText(text []byte) error {
 		return errors.New("cannot unmarshal into nil SafetyLevel")
 	}
 	x := SafetyLevel(text)
-	if !x.Valid() {
+	if !x.wellFormatted() {
 		return fmt.Errorf("unrecognized safety level: %q", text)
 	}
 	*lvl = x
@@ -157,6 +158,8 @@ func (lvl *SafetyLevel) UnmarshalText(text []byte) error {
 const (
 	Finalized   SafetyLevel = "finalized"
 	Safe        SafetyLevel = "safe"
+	LocalSafe   SafetyLevel = "local-safe"
 	CrossUnsafe SafetyLevel = "cross-unsafe"
 	Unsafe      SafetyLevel = "unsafe"
+	Invalid     SafetyLevel = "invalid"
 )

--- a/core/types/interoptypes/interop_test.go
+++ b/core/types/interoptypes/interop_test.go
@@ -1,0 +1,53 @@
+package interoptypes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func FuzzMessage_DecodeEvent(f *testing.F) {
+	f.Fuzz(func(t *testing.T, validEvTopic bool, numTopics uint8, data []byte) {
+		if len(data) < 32 {
+			return
+		}
+		if len(data) > 100_000 {
+			return
+		}
+		if validEvTopic { // valid even signature topic implies a topic to be there
+			numTopics += 1
+		}
+		if numTopics > 4 { // There can be no more than 4 topics per log event
+			return
+		}
+		if int(numTopics)*32 > len(data) {
+			return
+		}
+		var topics []common.Hash
+		if validEvTopic {
+			topics = append(topics, ExecutingMessageEventTopic)
+		}
+		for i := 0; i < int(numTopics); i++ {
+			var topic common.Hash
+			copy(topic[:], data[:])
+			data = data[32:]
+		}
+		require.NotPanics(t, func() {
+			var m Message
+			_ = m.DecodeEvent(topics, data)
+		})
+	})
+}
+
+func TestSafetyLevel(t *testing.T) {
+	require.True(t, Invalid.wellFormatted())
+	require.True(t, Unsafe.wellFormatted())
+	require.True(t, CrossUnsafe.wellFormatted())
+	require.True(t, LocalSafe.wellFormatted())
+	require.True(t, Safe.wellFormatted())
+	require.True(t, Finalized.wellFormatted())
+	require.False(t, SafetyLevel("hello").wellFormatted())
+	require.False(t, SafetyLevel("").wellFormatted())
+}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -20,6 +20,7 @@ package eth
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 	"runtime"
@@ -38,10 +39,12 @@ import (
 	"github.com/ethereum/go-ethereum/core/txpool/blobpool"
 	"github.com/ethereum/go-ethereum/core/txpool/legacypool"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/types/interoptypes"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/eth/downloader"
 	"github.com/ethereum/go-ethereum/eth/ethconfig"
 	"github.com/ethereum/go-ethereum/eth/gasprice"
+	"github.com/ethereum/go-ethereum/eth/interop"
 	"github.com/ethereum/go-ethereum/eth/protocols/eth"
 	"github.com/ethereum/go-ethereum/eth/protocols/snap"
 	"github.com/ethereum/go-ethereum/eth/tracers"
@@ -78,6 +81,8 @@ type Ethereum struct {
 
 	seqRPCService        *rpc.Client
 	historicalRPCService *rpc.Client
+
+	interopRPC *interop.InteropClient
 
 	// DB interfaces
 	chainDb ethdb.Database // Block chain database
@@ -320,6 +325,10 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		eth.historicalRPCService = client
 	}
 
+	if config.InteropMessageRPC != "" {
+		eth.interopRPC = interop.NewInteropClient(config.InteropMessageRPC)
+	}
+
 	// Start the RPC service
 	eth.netRPCService = ethapi.NewNetAPI(eth.p2pServer, networkID)
 
@@ -483,6 +492,12 @@ func (s *Ethereum) Stop() error {
 	if s.historicalRPCService != nil {
 		s.historicalRPCService.Close()
 	}
+	if s.interopRPC != nil {
+		s.interopRPC.Close()
+	}
+	if s.miner != nil {
+		s.miner.Close()
+	}
 
 	// Clean shutdown marker as the last thing before closing db
 	s.shutdownTracker.Stop()
@@ -547,4 +562,11 @@ func (s *Ethereum) HandleRequiredProtocolVersion(required params.ProtocolVersion
 		return s.nodeCloser()
 	}
 	return nil
+}
+
+func (s *Ethereum) CheckMessages(ctx context.Context, messages []interoptypes.Message, minSafety interoptypes.SafetyLevel) error {
+	if s.interopRPC == nil {
+		return errors.New("cannot check interop messages, no RPC available")
+	}
+	return s.interopRPC.CheckMessages(ctx, messages, minSafety)
 }

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -181,6 +181,8 @@ type Config struct {
 	RollupDisableTxPoolGossip                 bool
 	RollupDisableTxPoolAdmission              bool
 	RollupHaltOnIncompatibleProtocolVersion   string
+
+	InteropMessageRPC string `toml:",omitempty"`
 }
 
 // CreateConsensusEngine creates a consensus engine for the given chain config.

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -67,6 +67,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		RollupDisableTxPoolGossip                 bool
 		RollupDisableTxPoolAdmission              bool
 		RollupHaltOnIncompatibleProtocolVersion   string
+		InteropMessageRPC                         string `toml:",omitempty"`
 	}
 	var enc Config
 	enc.Genesis = c.Genesis
@@ -119,6 +120,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.RollupDisableTxPoolGossip = c.RollupDisableTxPoolGossip
 	enc.RollupDisableTxPoolAdmission = c.RollupDisableTxPoolAdmission
 	enc.RollupHaltOnIncompatibleProtocolVersion = c.RollupHaltOnIncompatibleProtocolVersion
+	enc.InteropMessageRPC = c.InteropMessageRPC
 	return &enc, nil
 }
 
@@ -175,6 +177,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		RollupDisableTxPoolGossip                 *bool
 		RollupDisableTxPoolAdmission              *bool
 		RollupHaltOnIncompatibleProtocolVersion   *string
+		InteropMessageRPC                         *string `toml:",omitempty"`
 	}
 	var dec Config
 	if err := unmarshal(&dec); err != nil {
@@ -329,6 +332,9 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.RollupHaltOnIncompatibleProtocolVersion != nil {
 		c.RollupHaltOnIncompatibleProtocolVersion = *dec.RollupHaltOnIncompatibleProtocolVersion
+	}
+	if dec.InteropMessageRPC != nil {
+		c.InteropMessageRPC = *dec.InteropMessageRPC
 	}
 	return nil
 }

--- a/eth/interop/interop.go
+++ b/eth/interop/interop.go
@@ -1,0 +1,57 @@
+package interop
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/core/types/interoptypes"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+type InteropClient struct {
+	mu       sync.Mutex
+	client   *rpc.Client
+	endpoint string
+	closed   bool // don't allow lazy-dials after Close
+}
+
+// maybeDial dials the endpoint if it was not already.
+func (cl *InteropClient) maybeDial(ctx context.Context) error {
+	cl.mu.Lock()
+	defer cl.mu.Unlock()
+	if cl.closed {
+		return errors.New("client is closed")
+	}
+	if cl.client != nil {
+		return nil
+	}
+	rpcClient, err := rpc.DialContext(ctx, cl.endpoint)
+	if err != nil {
+		return err
+	}
+	cl.client = rpcClient
+	return nil
+}
+
+func (cl *InteropClient) Close() {
+	cl.mu.Lock()
+	defer cl.mu.Unlock()
+	if cl.client != nil {
+		cl.client.Close()
+	}
+	cl.closed = true
+}
+
+func NewInteropClient(rpcEndpoint string) *InteropClient {
+	return &InteropClient{endpoint: rpcEndpoint}
+}
+
+// CheckMessages checks if the given messages meet the given minimum safety level.
+func (cl *InteropClient) CheckMessages(ctx context.Context, messages []interoptypes.Message, minSafety interoptypes.SafetyLevel) error {
+	// we lazy-dial the endpoint, so we can start geth, and build blocks, without supervisor endpoint availability.
+	if err := cl.maybeDial(ctx); err != nil { // a single dial attempt is made, the next call may retry.
+		return err
+	}
+	return cl.client.CallContext(ctx, nil, "supervisor_checkMessages", messages, minSafety)
+}

--- a/fork.yaml
+++ b/fork.yaml
@@ -119,6 +119,7 @@ def:
             The block-building code (in the "miner" package because of Proof-Of-Work legacy of ethereum) implements the
             changes to support the transaction-inclusion, tx-pool toggle, gaslimit, and EIP-1559 parameters of the
             Engine API.
+            This also includes experimental support for interop executing-messages to be verified through an RPC.
           globs:
             - "miner/*"
         - title: "Tx-pool tx cost updates"

--- a/miner/payload_building.go
+++ b/miner/payload_building.go
@@ -17,6 +17,7 @@
 package miner
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/binary"
 	"errors"
@@ -106,10 +107,14 @@ type Payload struct {
 	err       error
 	stopOnce  sync.Once
 	interrupt *atomic.Int32 // interrupt signal shared with worker
+
+	rpcCtx    context.Context // context to limit RPC-coupled payload checks
+	rpcCancel context.CancelFunc
 }
 
 // newPayload initializes the payload object.
-func newPayload(empty *types.Block, witness *stateless.Witness, id engine.PayloadID) *Payload {
+func newPayload(lifeCtx context.Context, empty *types.Block, witness *stateless.Witness, id engine.PayloadID) *Payload {
+	rpcCtx, rpcCancel := context.WithCancel(lifeCtx)
 	payload := &Payload{
 		id:           id,
 		empty:        empty,
@@ -117,6 +122,9 @@ func newPayload(empty *types.Block, witness *stateless.Witness, id engine.Payloa
 		stop:         make(chan struct{}),
 
 		interrupt: new(atomic.Int32),
+
+		rpcCtx:    rpcCtx,
+		rpcCancel: rpcCancel,
 	}
 	log.Info("Starting work on payload", "id", payload.id)
 	payload.cond = sync.NewCond(&payload.lock)
@@ -253,6 +261,7 @@ func (payload *Payload) resolve(onlyFull bool) *engine.ExecutionPayloadEnvelope 
 // the update anyways.
 // interruptBuilding is safe to be called concurrently.
 func (payload *Payload) interruptBuilding() {
+	payload.rpcCancel()
 	// Set the interrupt if not interrupted already.
 	// It's ok if it has either already been interrupted by payload resolution earlier,
 	// or by the timeout timer set to commitInterruptTimeout.
@@ -269,6 +278,7 @@ func (payload *Payload) interruptBuilding() {
 // transactions with interruptBuilding.
 // stopBuilding is safe to be called concurrently.
 func (payload *Payload) stopBuilding() {
+	payload.rpcCancel()
 	// Concurrent Resolve calls should only stop once.
 	payload.stopOnce.Do(func() {
 		log.Debug("Stop payload building.", "id", payload.id)
@@ -295,12 +305,14 @@ func (miner *Miner) buildPayload(args *BuildPayloadArgs, witness bool) (*Payload
 			txs:           args.Transactions,
 			gasLimit:      args.GasLimit,
 			eip1559Params: args.EIP1559Params,
+			// No RPC requests allowed.
+			rpcCtx: nil,
 		}
 		empty := miner.generateWork(emptyParams, witness)
 		if empty.err != nil {
 			return nil, empty.err
 		}
-		payload := newPayload(empty.block, empty.witness, args.Id())
+		payload := newPayload(miner.lifeCtx, empty.block, empty.witness, args.Id())
 		// make sure to make it appear as full, otherwise it will wait indefinitely for payload building to complete.
 		payload.full = empty.block
 		payload.fullFees = empty.fees
@@ -329,9 +341,10 @@ func (miner *Miner) buildPayload(args *BuildPayloadArgs, witness bool) (*Payload
 		return nil, err
 	}
 
-	payload := newPayload(nil, nil, args.Id())
+	payload := newPayload(miner.lifeCtx, nil, nil, args.Id())
 	// set shared interrupt
 	fullParams.interrupt = payload.interrupt
+	fullParams.rpcCtx = payload.rpcCtx
 
 	// Spin up a routine for updating the payload in background. This strategy
 	// can maximum the revenue for including transactions with highest fee.
@@ -375,6 +388,8 @@ func (miner *Miner) buildPayload(args *BuildPayloadArgs, witness bool) (*Payload
 		var lastDuration time.Duration
 		for {
 			select {
+			case <-miner.lifeCtx.Done():
+				stopReason = "miner-shutdown"
 			case <-timer.C:
 				// We have to prioritize the stop signal because the recommit timer
 				// might have fired while stop also got closed.

--- a/params/interop.go
+++ b/params/interop.go
@@ -1,0 +1,5 @@
+package params
+
+import "github.com/ethereum/go-ethereum/common"
+
+var InteropCrossL2InboxAddress = common.HexToAddress("0x4200000000000000000000000000000000000022")


### PR DESCRIPTION
**Description**

As sequencer (i.e. when `noTxs == false`), and when interop is active, make the block-building code-path check executing message logs with the interop RPC. And revert the tx otherwise.
If block building runs out of time to check the interop RPC, then quit the block building loop.

Note: changed the RPC to `interop_checkMessages`, with signature:
```
CheckMessages(ctx context.Context, messages []interoptypes.Message, minSafety interoptypes.SafetyLevel) error
```
Since some transactions may consume multiple interop messages, and it's more efficient to check them in batches.
Long term I'd like to replace this with a streaming protocol, with optimized message entries, attached to the block-building with a tracer hook, but for now this works well enough at a per-tx level.

When the executing messages of a tx are checked, and when they appear to be invalid, the tx is marked as rejected (using the new conditional-tx functionality), which should cause it to drop out of the tx-pool, so that it's not considered for building of future blocks (unless re-submitted, which should be rate-limited outside of the sequencer).

**Tests**

Work in progress. This is a draft for monorepo integration tests to build on top of.


**Metadata**

Fix https://github.com/ethereum-optimism/optimism/issues/10891
