### PR TITLE
Expose method to force statedb to use singlethreaded mode even when multiple CPUs are available

### DIFF
--- a/core/state/workers.go
+++ b/core/state/workers.go
@@ -2,7 +2,6 @@ package state
 
 import (
 	"errors"
-	"runtime"
 
 	"golang.org/x/sync/errgroup"
 )
@@ -13,8 +12,8 @@ type workerGroup interface {
 	Wait() error
 }
 
-func newWorkerGroup() workerGroup {
-	if runtime.NumCPU() <= 1 {
+func newWorkerGroup(singlethreaded bool) workerGroup {
+	if singlethreaded {
 		return &inlineWorkerGroup{}
 	} else {
 		var grp errgroup.Group


### PR DESCRIPTION
**Description**

Expose method to force statedb to use singlethreaded mode even when multiple CPUs are available. This allows op-program to force single threaded mode and avoid race conditions with requesting data from the PreimageOracle.

Follow up to https://github.com/ethereum-optimism/op-geth/pull/370
