### PR TITLE
Add 'chain' flag to start node from custom genesis.json without init cmd

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -175,6 +175,7 @@ var (
 		utils.BeaconGenesisTimeFlag,
 		utils.BeaconCheckpointFlag,
 		utils.CollectWitnessFlag,
+		utils.CustomChainFlag,
 	}, utils.NetworkFlags, utils.DatabaseFlags)
 
 	rpcFlags = []cli.Flag{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -660,6 +660,11 @@ var (
 		Usage:    "Enable state witness generation during block execution. Work in progress flag, don't use.",
 		Category: flags.MiscCategory,
 	}
+	CustomChainFlag = &cli.StringFlag{
+		Name:     "chain",
+		Usage:    "Path to a custom chain specification file",
+		Category: flags.EthCategory,
+	}
 
 	// MISC settings
 	SyncTargetFlag = &cli.StringFlag{
@@ -1619,6 +1624,12 @@ func SetDataDir(ctx *cli.Context, cfg *node.Config) {
 		cfg.DataDir = filepath.Join(node.DefaultDataDir(), "holesky")
 	case ctx.IsSet(OPNetworkFlag.Name) && cfg.DataDir == node.DefaultDataDir():
 		cfg.DataDir = filepath.Join(node.DefaultDataDir(), ctx.String(OPNetworkFlag.Name))
+	case ctx.IsSet(CustomChainFlag.Name) && cfg.DataDir == node.DefaultDataDir():
+		genesis, err := readGenesisFromPath(ctx.String(CustomChainFlag.Name))
+		if err != nil {
+			Fatalf("Failed to read genesis file: %v", err)
+		}
+		cfg.DataDir = filepath.Join(node.DefaultDataDir(), "custom-"+genesis.Config.ChainID.String())
 	}
 }
 
@@ -2081,6 +2092,15 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 			cfg.NetworkId = genesis.Config.ChainID.Uint64()
 		}
 		cfg.Genesis = genesis
+
+	case ctx.IsSet(CustomChainFlag.Name):
+		genesis, _, err := initJSONChainGenesis(ctx, stack, ctx.String(CustomChainFlag.Name))
+		if err != nil {
+			Fatalf("Failed to initialize custom chain: %v", err)
+		}
+		cfg.Genesis = genesis
+		cfg.NetworkId = genesis.Config.ChainID.Uint64()
+
 	default:
 		if cfg.NetworkId == 1 {
 			SetDNSDiscoveryDefaults(cfg, params.MainnetGenesisHash)
@@ -2458,4 +2478,44 @@ func MakeTrieDatabase(ctx *cli.Context, disk ethdb.Database, preimage bool, read
 		config.PathDB = pathdb.Defaults
 	}
 	return triedb.NewDatabase(disk, config)
+}
+
+func readGenesisFromPath(genesisPath string) (*core.Genesis, error) {
+	file, err := os.Open(genesisPath)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	genesis := new(core.Genesis)
+	if err := json.NewDecoder(file).Decode(genesis); err != nil {
+		return nil, err
+	}
+	return genesis, nil
+}
+
+// initJSONChainGenesis based on the init command
+func initJSONChainGenesis(ctx *cli.Context, stack *node.Node, genesisPath string) (*core.Genesis, common.Hash, error) {
+	genesis, err := readGenesisFromPath(genesisPath)
+	if err != nil {
+		return nil, common.Hash{}, err
+	}
+
+	var overrides core.ChainOverrides
+	chaindb, err := stack.OpenDatabaseWithFreezer("chaindata", 0, 0, ctx.String(AncientFlag.Name), "", false)
+	if err != nil {
+		return nil, common.Hash{}, err
+	}
+	defer chaindb.Close()
+
+	triedb := MakeTrieDatabase(ctx, chaindb, ctx.Bool(CachePreimagesFlag.Name), false, genesis.IsVerkle())
+	defer triedb.Close()
+
+	_, hash, err := core.SetupGenesisBlockWithOverride(chaindb, triedb, genesis, &overrides)
+	if err != nil {
+		return nil, common.Hash{}, err
+	}
+
+	log.Info("Successfully wrote genesis state", "database", "chaindata", "hash", hash)
+	return genesis, hash, nil
 }


### PR DESCRIPTION

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This PR adds a new flag `--chain <genesis.json>` to the `geth` command. If set, `geth` will load the genesis from the provided JSON file. With this PR, it is not necessary anymore to run `geth init` to start a chain for a custom network.

Thus, it simplifies both the DevEx and the containerization of the EL node.

**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
