### PR TITLE
Isthmus: withdrawals root in block header

### DIFF
--- a/beacon/engine/gen_ed.go
+++ b/beacon/engine/gen_ed.go
@@ -36,6 +36,7 @@ func (e ExecutableData) MarshalJSON() ([]byte, error) {
 		ExcessBlobGas    *hexutil.Uint64         `json:"excessBlobGas"`
 		Deposits         types.Deposits          `json:"depositRequests"`
 		ExecutionWitness *types.ExecutionWitness `json:"executionWitness,omitempty"`
+		WithdrawalsRoot  *common.Hash            `json:"withdrawalsRoot,omitempty"`
 	}
 	var enc ExecutableData
 	enc.ParentHash = e.ParentHash
@@ -62,6 +63,7 @@ func (e ExecutableData) MarshalJSON() ([]byte, error) {
 	enc.ExcessBlobGas = (*hexutil.Uint64)(e.ExcessBlobGas)
 	enc.Deposits = e.Deposits
 	enc.ExecutionWitness = e.ExecutionWitness
+	enc.WithdrawalsRoot = e.WithdrawalsRoot
 	return json.Marshal(&enc)
 }
 
@@ -87,6 +89,7 @@ func (e *ExecutableData) UnmarshalJSON(input []byte) error {
 		ExcessBlobGas    *hexutil.Uint64         `json:"excessBlobGas"`
 		Deposits         *types.Deposits         `json:"depositRequests"`
 		ExecutionWitness *types.ExecutionWitness `json:"executionWitness,omitempty"`
+		WithdrawalsRoot  *common.Hash            `json:"withdrawalsRoot,omitempty"`
 	}
 	var dec ExecutableData
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -165,6 +168,9 @@ func (e *ExecutableData) UnmarshalJSON(input []byte) error {
 	}
 	if dec.ExecutionWitness != nil {
 		e.ExecutionWitness = dec.ExecutionWitness
+	}
+	if dec.WithdrawalsRoot != nil {
+		e.WithdrawalsRoot = dec.WithdrawalsRoot
 	}
 	return nil
 }

--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -275,8 +275,13 @@ func ExecutableDataToBlockNoHash(data ExecutableData, versionedHashes []common.H
 	// ExecutableData before withdrawals are enabled by marshaling
 	// Withdrawals as the json null value.
 	var withdrawalsRoot *common.Hash
-	if config.IsOptimismIsthmus(data.Timestamp) && data.WithdrawalsRoot == nil {
-		return nil, fmt.Errorf("attribute WithdrawalsRoot is required for Isthmus blocks")
+	if config.IsOptimismIsthmus(data.Timestamp) {
+		if data.WithdrawalsRoot == nil {
+			return nil, fmt.Errorf("attribute WithdrawalsRoot is required for Isthmus blocks")
+		}
+		if data.Withdrawals == nil || len(data.Withdrawals) > 0 {
+			return nil, fmt.Errorf("expected non-nil empty withdrawals operation list in Isthmus, but got: %v", data.Withdrawals)
+		}
 	}
 	if data.WithdrawalsRoot != nil {
 		h := *data.WithdrawalsRoot // copy, avoid any sharing of memory

--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -95,7 +95,7 @@ type ExecutableData struct {
 	Deposits         types.Deposits          `json:"depositRequests"`
 	ExecutionWitness *types.ExecutionWitness `json:"executionWitness,omitempty"`
 
-	// OP-Stack Holocene specific field:
+	// OP-Stack Isthmus specific field:
 	// instead of computing the root from a withdrawals list, set it directly.
 	// The "withdrawals" list attribute must be non-nil but empty.
 	WithdrawalsRoot *common.Hash `json:"withdrawalsRoot,omitempty"`
@@ -230,8 +230,8 @@ func decodeTransactions(enc [][]byte) ([]*types.Transaction, error) {
 // and that the blockhash of the constructed block matches the parameters. Nil
 // Withdrawals value will propagate through the returned block. Empty
 // Withdrawals value must be passed via non-nil, length 0 value in data.
-func ExecutableDataToBlock(data ExecutableData, versionedHashes []common.Hash, beaconRoot *common.Hash) (*types.Block, error) {
-	block, err := ExecutableDataToBlockNoHash(data, versionedHashes, beaconRoot)
+func ExecutableDataToBlock(data ExecutableData, versionedHashes []common.Hash, beaconRoot *common.Hash, config *params.ChainConfig) (*types.Block, error) {
+	block, err := ExecutableDataToBlockNoHash(data, versionedHashes, beaconRoot, config)
 	if err != nil {
 		return nil, err
 	}
@@ -244,7 +244,7 @@ func ExecutableDataToBlock(data ExecutableData, versionedHashes []common.Hash, b
 // ExecutableDataToBlockNoHash is analogous to ExecutableDataToBlock, but is used
 // for stateless execution, so it skips checking if the executable data hashes to
 // the requested hash (stateless has to *compute* the root hash, it's not given).
-func ExecutableDataToBlockNoHash(data ExecutableData, versionedHashes []common.Hash, beaconRoot *common.Hash) (*types.Block, error) {
+func ExecutableDataToBlockNoHash(data ExecutableData, versionedHashes []common.Hash, beaconRoot *common.Hash, config *params.ChainConfig) (*types.Block, error) {
 	txs, err := decodeTransactions(data.Transactions)
 	if err != nil {
 		return nil, err
@@ -275,10 +275,10 @@ func ExecutableDataToBlockNoHash(data ExecutableData, versionedHashes []common.H
 	// ExecutableData before withdrawals are enabled by marshaling
 	// Withdrawals as the json null value.
 	var withdrawalsRoot *common.Hash
+	if config.IsOptimismIsthmus(data.Timestamp) && data.WithdrawalsRoot == nil {
+		return nil, fmt.Errorf("attribute WithdrawalsRoot is required for Isthmus blocks")
+	}
 	if data.WithdrawalsRoot != nil {
-		if data.Withdrawals == nil || len(data.Withdrawals) != 0 {
-			return nil, fmt.Errorf("attribute WithdrawalsRoot was set. Expecting non-nil empty withdrawals list, but got %v", data.Withdrawals)
-		}
 		h := *data.WithdrawalsRoot // copy, avoid any sharing of memory
 		withdrawalsRoot = &h
 	} else if data.Withdrawals != nil {

--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -403,6 +403,15 @@ func (beacon *Beacon) FinalizeAndAssemble(chain consensus.ChainHeaderReader, hea
 	// Assign the final state root to header.
 	header.Root = state.IntermediateRoot(true)
 
+	if chain.Config().IsOptimismHolocene(header.Time) {
+		if body.Withdrawals == nil || len(body.Withdrawals) > 0 { // We verify nil/empty withdrawals in the CL pre-holocene
+			return nil, fmt.Errorf("expected non-nil empty withdrawals operation list in Holocene, but got: %v", body.Withdrawals)
+		}
+		// State-root has just been computed, we can get an accurate storage-root now.
+		h := state.GetStorageRoot(params.OptimismL2ToL1MessagePasser)
+		header.WithdrawalsHash = &h
+	}
+
 	// Assemble the final block.
 	block := types.NewBlock(header, body, receipts, trie.NewStackTrie(nil))
 

--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -403,9 +403,9 @@ func (beacon *Beacon) FinalizeAndAssemble(chain consensus.ChainHeaderReader, hea
 	// Assign the final state root to header.
 	header.Root = state.IntermediateRoot(true)
 
-	if chain.Config().IsOptimismHolocene(header.Time) {
-		if body.Withdrawals == nil || len(body.Withdrawals) > 0 { // We verify nil/empty withdrawals in the CL pre-holocene
-			return nil, fmt.Errorf("expected non-nil empty withdrawals operation list in Holocene, but got: %v", body.Withdrawals)
+	if chain.Config().IsOptimismIsthmus(header.Time) {
+		if body.Withdrawals == nil || len(body.Withdrawals) > 0 { // We verify nil/empty withdrawals in the CL pre-Isthmus
+			return nil, fmt.Errorf("expected non-nil empty withdrawals operation list in Isthmus, but got: %v", body.Withdrawals)
 		}
 		// State-root has just been computed, we can get an accurate storage-root now.
 		h := state.GetStorageRoot(params.OptimismL2ToL1MessagePasser)
@@ -413,7 +413,7 @@ func (beacon *Beacon) FinalizeAndAssemble(chain consensus.ChainHeaderReader, hea
 	}
 
 	// Assemble the final block.
-	block := types.NewBlock(header, body, receipts, trie.NewStackTrie(nil))
+	block := types.NewBlock(header, body, receipts, trie.NewStackTrie(nil), chain.Config())
 
 	// Create the block witness and attach to block.
 	// This step needs to happen as late as possible to catch all access events.

--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -410,6 +410,7 @@ func (beacon *Beacon) FinalizeAndAssemble(chain consensus.ChainHeaderReader, hea
 		// State-root has just been computed, we can get an accurate storage-root now.
 		h := state.GetStorageRoot(params.OptimismL2ToL1MessagePasser)
 		header.WithdrawalsHash = &h
+		state.AccessEvents().AddAccount(params.OptimismL2ToL1MessagePasser, false) // include in execution witness
 	}
 
 	// Assemble the final block.

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -597,7 +597,7 @@ func (c *Clique) FinalizeAndAssemble(chain consensus.ChainHeaderReader, header *
 	header.Root = state.IntermediateRoot(chain.Config().IsEIP158(header.Number))
 
 	// Assemble and return the final block for sealing.
-	return types.NewBlock(header, &types.Body{Transactions: body.Transactions}, receipts, trie.NewStackTrie(nil)), nil
+	return types.NewBlock(header, &types.Body{Transactions: body.Transactions}, receipts, trie.NewStackTrie(nil), chain.Config()), nil
 }
 
 // Authorize injects a private key into the consensus engine to mint new blocks

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -304,7 +304,7 @@ func (c *Clique) verifyHeader(chain consensus.ChainHeaderReader, header *types.H
 	}
 	// Verify the non-existence of withdrawalsHash.
 	if header.WithdrawalsHash != nil {
-		return fmt.Errorf("invalid withdrawalsHash: have %x, expected nil", header.WithdrawalsHash)
+		return fmt.Errorf("invalid withdrawalsHash: have %s, expected nil", header.WithdrawalsHash)
 	}
 	if chain.Config().IsCancun(header.Number, header.Time) {
 		return errors.New("clique does not support cancun fork")

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -520,7 +520,7 @@ func (ethash *Ethash) FinalizeAndAssemble(chain consensus.ChainHeaderReader, hea
 	header.Root = state.IntermediateRoot(chain.Config().IsEIP158(header.Number))
 
 	// Header seems complete, assemble into a block and return
-	return types.NewBlock(header, &types.Body{Transactions: body.Transactions, Uncles: body.Uncles}, receipts, trie.NewStackTrie(nil)), nil
+	return types.NewBlock(header, &types.Body{Transactions: body.Transactions, Uncles: body.Uncles, Withdrawals: body.Withdrawals}, receipts, trie.NewStackTrie(nil), chain.Config()), nil
 }
 
 // SealHash returns the hash of a block prior to it being sealed.

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -270,7 +270,7 @@ func (ethash *Ethash) verifyHeader(chain consensus.ChainHeaderReader, header, pa
 	}
 	// Verify the non-existence of withdrawalsHash.
 	if header.WithdrawalsHash != nil {
-		return fmt.Errorf("invalid withdrawalsHash: have %x, expected nil", header.WithdrawalsHash)
+		return fmt.Errorf("invalid withdrawalsHash: have %s, expected nil", header.WithdrawalsHash)
 	}
 	if chain.Config().IsCancun(header.Number, header.Time) {
 		return errors.New("ethash does not support cancun fork")

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -73,7 +73,7 @@ func (v *BlockValidator) ValidateBody(block *types.Block) error {
 		if block.Withdrawals() == nil {
 			return errors.New("missing withdrawals in block body")
 		}
-		if v.config.IsOptimismHolocene(header.Time) {
+		if v.config.IsOptimismIsthmus(header.Time) {
 			if len(block.Withdrawals()) > 0 {
 				return errors.New("no withdrawal block-operations allowed, withdrawalsRoot is set to storage root")
 			}
@@ -160,9 +160,9 @@ func (v *BlockValidator) ValidateState(block *types.Block, statedb *state.StateD
 	if root := statedb.IntermediateRoot(v.config.IsEIP158(header.Number)); header.Root != root {
 		return fmt.Errorf("invalid merkle root (remote: %x local: %x) dberr: %w", header.Root, root, statedb.Error())
 	}
-	if v.config.IsOptimismHolocene(block.Time()) {
+	if v.config.IsOptimismIsthmus(block.Time()) {
 		if header.WithdrawalsHash == nil {
-			return errors.New("expected withdrawals root in OP-Stack post-Holocene block header")
+			return errors.New("expected withdrawals root in OP-Stack post-Isthmus block header")
 		}
 		// Validate the withdrawals root against the L2 withdrawals storage, similar to how the StateRoot is verified.
 		if root := statedb.GetStorageRoot(params.OptimismL2ToL1MessagePasser); *header.WithdrawalsHash != root {

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -73,7 +73,12 @@ func (v *BlockValidator) ValidateBody(block *types.Block) error {
 		if block.Withdrawals() == nil {
 			return errors.New("missing withdrawals in block body")
 		}
-		if hash := types.DeriveSha(block.Withdrawals(), trie.NewStackTrie(nil)); hash != *header.WithdrawalsHash {
+		if v.config.IsOptimismHolocene(header.Time) {
+			if len(block.Withdrawals()) > 0 {
+				return errors.New("no withdrawal block-operations allowed, withdrawalsRoot is set to storage root")
+			}
+			// The withdrawalsHash is verified in ValidateState, like the state root, as verification requires state merkleization.
+		} else if hash := types.DeriveSha(block.Withdrawals(), trie.NewStackTrie(nil)); hash != *header.WithdrawalsHash {
 			return fmt.Errorf("withdrawals root hash mismatch (header value %x, calculated %x)", *header.WithdrawalsHash, hash)
 		}
 	} else if block.Withdrawals() != nil {
@@ -154,6 +159,15 @@ func (v *BlockValidator) ValidateState(block *types.Block, statedb *state.StateD
 	// an error if they don't match.
 	if root := statedb.IntermediateRoot(v.config.IsEIP158(header.Number)); header.Root != root {
 		return fmt.Errorf("invalid merkle root (remote: %x local: %x) dberr: %w", header.Root, root, statedb.Error())
+	}
+	if v.config.IsOptimismHolocene(block.Time()) {
+		if header.WithdrawalsHash == nil {
+			return errors.New("expected withdrawals root in OP-Stack post-Holocene block header")
+		}
+		// Validate the withdrawals root against the L2 withdrawals storage, similar to how the StateRoot is verified.
+		if root := statedb.GetStorageRoot(params.OptimismL2ToL1MessagePasser); *header.WithdrawalsHash != root {
+			return fmt.Errorf("invalid withdrawals hash (remote: %s local: %s) dberr: %w", *header.WithdrawalsHash, root, statedb.Error())
+		}
 	}
 	return nil
 }

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -79,7 +79,7 @@ func (v *BlockValidator) ValidateBody(block *types.Block) error {
 			}
 			// The withdrawalsHash is verified in ValidateState, like the state root, as verification requires state merkleization.
 		} else if hash := types.DeriveSha(block.Withdrawals(), trie.NewStackTrie(nil)); hash != *header.WithdrawalsHash {
-			return fmt.Errorf("withdrawals root hash mismatch (header value %x, calculated %x)", *header.WithdrawalsHash, hash)
+			return fmt.Errorf("withdrawals root hash mismatch (header value %s, calculated %s)", *header.WithdrawalsHash, hash)
 		}
 	} else if block.Withdrawals() != nil {
 		// Withdrawals are not allowed prior to Shanghai fork

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -329,6 +329,10 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 				b.header.Difficulty = big.NewInt(0)
 			}
 		}
+		if config.IsIsthmus(b.header.Time) {
+			b.withdrawals = make([]*types.Withdrawal, 0)
+			b.header.WithdrawalsHash = &types.EmptyWithdrawalsHash
+		}
 		// Mutate the state and block according to any hard-fork specs
 		if daoBlock := config.DAOForkBlock; daoBlock != nil {
 			limit := new(big.Int).Add(daoBlock, params.DAOForkExtraRange)

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -329,9 +329,10 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 				b.header.Difficulty = big.NewInt(0)
 			}
 		}
-		if config.IsIsthmus(b.header.Time) {
+		if config.IsOptimismIsthmus(b.header.Time) {
 			b.withdrawals = make([]*types.Withdrawal, 0)
-			b.header.WithdrawalsHash = &types.EmptyWithdrawalsHash
+			h := types.EmptyWithdrawalsHash
+			b.header.WithdrawalsHash = &h
 		}
 		// Mutate the state and block according to any hard-fork specs
 		if daoBlock := config.DAOForkBlock; daoBlock != nil {

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -126,8 +126,11 @@ func ReadGenesis(db ethdb.Database) (*Genesis, error) {
 	return &genesis, nil
 }
 
-// hashAlloc computes the state root according to the genesis specification.
-func hashAlloc(ga *types.GenesisAlloc, isVerkle bool) (common.Hash, error) {
+// hashAlloc returns the following:
+// * computed state root according to the genesis specification.
+// * storage root of the L2ToL1MessagePasser contract.
+// * error if any, when committing the genesis state (if so, state root and storage root will be empty).
+func hashAlloc(ga *types.GenesisAlloc, isVerkle, isIsthmus bool) (common.Hash, common.Hash, error) {
 	// If a genesis-time verkle trie is requested, create a trie config
 	// with the verkle trie enabled so that the tree can be initialized
 	// as such.
@@ -143,7 +146,7 @@ func hashAlloc(ga *types.GenesisAlloc, isVerkle bool) (common.Hash, error) {
 	db := rawdb.NewMemoryDatabase()
 	statedb, err := state.New(types.EmptyRootHash, state.NewDatabase(triedb.NewDatabase(db, config), nil))
 	if err != nil {
-		return common.Hash{}, err
+		return common.Hash{}, common.Hash{}, err
 	}
 	for addr, account := range *ga {
 		if account.Balance != nil {
@@ -155,15 +158,27 @@ func hashAlloc(ga *types.GenesisAlloc, isVerkle bool) (common.Hash, error) {
 			statedb.SetState(addr, key, value)
 		}
 	}
-	return statedb.Commit(0, false)
+
+	stateRoot, err := statedb.Commit(0, false)
+	if err != nil {
+		return common.Hash{}, common.Hash{}, err
+	}
+	// get the storage root of the L2ToL1MessagePasser contract
+	var storageRootMessagePasser common.Hash
+	if isIsthmus {
+		storageRootMessagePasser = statedb.GetStorageRoot(params.OptimismL2ToL1MessagePasser)
+	}
+
+	return stateRoot, storageRootMessagePasser, nil
 }
 
 // flushAlloc is very similar with hash, but the main difference is all the
-// generated states will be persisted into the given database.
-func flushAlloc(ga *types.GenesisAlloc, triedb *triedb.Database) (common.Hash, error) {
+// generated states will be persisted into the given database. Returns the
+// same values as hashAlloc.
+func flushAlloc(ga *types.GenesisAlloc, triedb *triedb.Database, isIsthmus bool) (common.Hash, common.Hash, error) {
 	statedb, err := state.New(types.EmptyRootHash, state.NewDatabase(triedb, nil))
 	if err != nil {
-		return common.Hash{}, err
+		return common.Hash{}, common.Hash{}, err
 	}
 	for addr, account := range *ga {
 		if account.Balance != nil {
@@ -177,17 +192,22 @@ func flushAlloc(ga *types.GenesisAlloc, triedb *triedb.Database) (common.Hash, e
 			statedb.SetState(addr, key, value)
 		}
 	}
-	root, err := statedb.Commit(0, false)
+	stateRoot, err := statedb.Commit(0, false)
 	if err != nil {
-		return common.Hash{}, err
+		return common.Hash{}, common.Hash{}, err
+	}
+	// get the storage root of the L2ToL1MessagePasser contract
+	var storageRootMessagePasser common.Hash
+	if isIsthmus {
+		storageRootMessagePasser = statedb.GetStorageRoot(params.OptimismL2ToL1MessagePasser)
 	}
 	// Commit newly generated states into disk if it's not empty.
-	if root != types.EmptyRootHash {
-		if err := triedb.Commit(root, true); err != nil {
-			return common.Hash{}, err
+	if stateRoot != types.EmptyRootHash {
+		if err := triedb.Commit(stateRoot, true); err != nil {
+			return common.Hash{}, common.Hash{}, err
 		}
 	}
-	return root, nil
+	return stateRoot, storageRootMessagePasser, nil
 }
 
 func getGenesisState(db ethdb.Database, blockhash common.Hash) (alloc types.GenesisAlloc, err error) {
@@ -477,22 +497,27 @@ func (g *Genesis) IsVerkle() bool {
 
 // ToBlock returns the genesis block according to genesis specification.
 func (g *Genesis) ToBlock() *types.Block {
-	var root common.Hash
+	var stateRoot, storageRootMessagePasser common.Hash
 	var err error
 	if g.StateHash != nil {
 		if len(g.Alloc) > 0 {
 			panic(fmt.Errorf("cannot both have genesis hash %s "+
 				"and non-empty state-allocation", *g.StateHash))
 		}
-		root = *g.StateHash
-	} else if root, err = hashAlloc(&g.Alloc, g.IsVerkle()); err != nil {
+		// stateHash is only relevant for pre-bedrock (and hence pre-isthmus) chains.
+		// we bail here since this is not a valid usage of StateHash
+		if g.Config.IsIsthmus(g.Timestamp) {
+			panic(fmt.Errorf("stateHash usage disallowed in chain with isthmus active at genesis"))
+		}
+		stateRoot = *g.StateHash
+	} else if stateRoot, storageRootMessagePasser, err = hashAlloc(&g.Alloc, g.IsVerkle(), g.Config.IsIsthmus(g.Timestamp)); err != nil {
 		panic(err)
 	}
-	return g.toBlockWithRoot(root)
+	return g.toBlockWithRoot(stateRoot, storageRootMessagePasser)
 }
 
 // toBlockWithRoot constructs the genesis block with the given genesis state root.
-func (g *Genesis) toBlockWithRoot(root common.Hash) *types.Block {
+func (g *Genesis) toBlockWithRoot(stateRoot, storageRootMessagePasser common.Hash) *types.Block {
 	head := &types.Header{
 		Number:     new(big.Int).SetUint64(g.Number),
 		Nonce:      types.EncodeNonce(g.Nonce),
@@ -505,7 +530,7 @@ func (g *Genesis) toBlockWithRoot(root common.Hash) *types.Block {
 		Difficulty: g.Difficulty,
 		MixDigest:  g.Mixhash,
 		Coinbase:   g.Coinbase,
-		Root:       root,
+		Root:       stateRoot,
 	}
 	if g.GasLimit == 0 {
 		head.GasLimit = params.GenesisGasLimit
@@ -549,8 +574,17 @@ func (g *Genesis) toBlockWithRoot(root common.Hash) *types.Block {
 			head.RequestsHash = &types.EmptyRequestsHash
 			requests = make(types.Requests, 0)
 		}
+		// If Isthmus is active at genesis, set the WithdrawalRoot to the storage root of the L2ToL1MessagePasser contract.
+		if g.Config.IsIsthmus(g.Timestamp) {
+			if storageRootMessagePasser == (common.Hash{}) {
+				// if there was no MessagePasser contract storage, set the WithdrawalsHash to the empty hash
+				head.WithdrawalsHash = &types.EmptyWithdrawalsHash
+			} else {
+				head.WithdrawalsHash = &storageRootMessagePasser
+			}
+		}
 	}
-	return types.NewBlock(head, &types.Body{Withdrawals: withdrawals, Requests: requests}, nil, trie.NewStackTrie(nil))
+	return types.NewBlock(head, &types.Body{Withdrawals: withdrawals, Requests: requests}, nil, trie.NewStackTrie(nil), g.Config)
 }
 
 // Commit writes the block and state of a genesis specification to the database.
@@ -569,23 +603,23 @@ func (g *Genesis) Commit(db ethdb.Database, triedb *triedb.Database) (*types.Blo
 	if config.Clique != nil && len(g.ExtraData) < 32+crypto.SignatureLength {
 		return nil, errors.New("can't start clique chain without signers")
 	}
-	var stateHash common.Hash
+	var stateRoot, storageRootMessagePasser common.Hash
+	var err error
 	if len(g.Alloc) == 0 {
 		if g.StateHash == nil {
 			log.Warn("Empty genesis alloc, and no 'stateHash' override was set")
-			stateHash = types.EmptyRootHash // default to the hash of the empty state. Some unit-tests rely on this.
+			stateRoot = types.EmptyRootHash // default to the hash of the empty state. Some unit-tests rely on this.
 		} else {
-			stateHash = *g.StateHash
+			stateRoot = *g.StateHash
 		}
 	} else {
 		// flush the data to disk and compute the state root
-		root, err := flushAlloc(&g.Alloc, triedb)
+		stateRoot, storageRootMessagePasser, err = flushAlloc(&g.Alloc, triedb, g.Config.IsIsthmus(g.Timestamp))
 		if err != nil {
 			return nil, err
 		}
-		stateHash = root
 	}
-	block := g.toBlockWithRoot(stateHash)
+	block := g.toBlockWithRoot(stateRoot, storageRootMessagePasser)
 
 	// Marshal the genesis state specification and persist.
 	blob, err := json.Marshal(g.Alloc)

--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -223,13 +223,16 @@ func TestReadWriteGenesisAlloc(t *testing.T) {
 			{1}: {Balance: big.NewInt(1), Storage: map[common.Hash]common.Hash{{1}: {1}}},
 			{2}: {Balance: big.NewInt(2), Storage: map[common.Hash]common.Hash{{2}: {2}}},
 		}
-		hash, _ = hashAlloc(alloc, false)
+		stateRoot, storageRootMessagePasser, _ = hashAlloc(alloc, false, false)
 	)
+	if storageRootMessagePasser != (common.Hash{}) {
+		t.Fatalf("unexpected storage root")
+	}
 	blob, _ := json.Marshal(alloc)
-	rawdb.WriteGenesisStateSpec(db, hash, blob)
+	rawdb.WriteGenesisStateSpec(db, stateRoot, blob)
 
 	var reload types.GenesisAlloc
-	err := reload.UnmarshalJSON(rawdb.ReadGenesisStateSpec(db, hash))
+	err := reload.UnmarshalJSON(rawdb.ReadGenesisStateSpec(db, stateRoot))
 	if err != nil {
 		t.Fatalf("Failed to load genesis state %v", err)
 	}

--- a/core/rawdb/accessors_indexes_test.go
+++ b/core/rawdb/accessors_indexes_test.go
@@ -76,7 +76,7 @@ func TestLookupStorage(t *testing.T) {
 			tx3 := types.NewTransaction(3, common.BytesToAddress([]byte{0x33}), big.NewInt(333), 3333, big.NewInt(33333), []byte{0x33, 0x33, 0x33})
 			txs := []*types.Transaction{tx1, tx2, tx3}
 
-			block := types.NewBlock(&types.Header{Number: big.NewInt(314)}, &types.Body{Transactions: txs}, nil, newTestHasher())
+			block := types.NewBlock(&types.Header{Number: big.NewInt(314)}, &types.Body{Transactions: txs}, nil, newTestHasher(), params.TestChainConfig)
 
 			// Check that no transactions entries are in a pristine database
 			for i, tx := range txs {

--- a/core/rawdb/chain_iterator_test.go
+++ b/core/rawdb/chain_iterator_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
 )
 
 func TestChainIterator(t *testing.T) {
@@ -34,7 +35,7 @@ func TestChainIterator(t *testing.T) {
 	var block *types.Block
 	var txs []*types.Transaction
 	to := common.BytesToAddress([]byte{0x11})
-	block = types.NewBlock(&types.Header{Number: big.NewInt(int64(0))}, nil, nil, newTestHasher()) // Empty genesis block
+	block = types.NewBlock(&types.Header{Number: big.NewInt(int64(0))}, nil, nil, newTestHasher(), params.TestChainConfig) // Empty genesis block
 	WriteBlock(chainDb, block)
 	WriteCanonicalHash(chainDb, block.Hash(), block.NumberU64())
 	for i := uint64(1); i <= 10; i++ {
@@ -60,7 +61,7 @@ func TestChainIterator(t *testing.T) {
 			})
 		}
 		txs = append(txs, tx)
-		block = types.NewBlock(&types.Header{Number: big.NewInt(int64(i))}, &types.Body{Transactions: types.Transactions{tx}}, nil, newTestHasher())
+		block = types.NewBlock(&types.Header{Number: big.NewInt(int64(i))}, &types.Body{Transactions: types.Transactions{tx}}, nil, newTestHasher(), params.TestChainConfig)
 		WriteBlock(chainDb, block)
 		WriteCanonicalHash(chainDb, block.Hash(), block.NumberU64())
 	}
@@ -111,7 +112,7 @@ func TestIndexTransactions(t *testing.T) {
 	to := common.BytesToAddress([]byte{0x11})
 
 	// Write empty genesis block
-	block = types.NewBlock(&types.Header{Number: big.NewInt(int64(0))}, nil, nil, newTestHasher())
+	block = types.NewBlock(&types.Header{Number: big.NewInt(int64(0))}, nil, nil, newTestHasher(), params.TestChainConfig)
 	WriteBlock(chainDb, block)
 	WriteCanonicalHash(chainDb, block.Hash(), block.NumberU64())
 
@@ -138,7 +139,7 @@ func TestIndexTransactions(t *testing.T) {
 			})
 		}
 		txs = append(txs, tx)
-		block = types.NewBlock(&types.Header{Number: big.NewInt(int64(i))}, &types.Body{Transactions: types.Transactions{tx}}, nil, newTestHasher())
+		block = types.NewBlock(&types.Header{Number: big.NewInt(int64(i))}, &types.Body{Transactions: types.Transactions{tx}}, nil, newTestHasher(), params.TestChainConfig)
 		WriteBlock(chainDb, block)
 		WriteCanonicalHash(chainDb, block.Hash(), block.NumberU64())
 	}

--- a/core/rlp_test.go
+++ b/core/rlp_test.go
@@ -199,3 +199,23 @@ func BenchmarkHashing(b *testing.B) {
 		b.Fatalf("hash wrong, got %x exp %x", got, exp)
 	}
 }
+
+func TestBlockRlpEncodeDecode(t *testing.T) {
+	zeroTime := uint64(0)
+
+	// create a config where Isthmus upgrade is active
+	config := *params.OptimismTestConfig
+	config.ShanghaiTime = &zeroTime
+	config.IsthmusTime = &zeroTime
+
+	block := getBlock(&config, 10, 2, 50)
+
+	blockRlp, err := rlp.EncodeToBytes(block)
+	assert.Nil(t, err)
+
+	var decoded types.Block
+	err = rlp.DecodeBytes(blockRlp, &decoded)
+	assert.Nil(t, err)
+
+	assert.Equal(t, decoded.Hash(), block.Hash())
+}

--- a/core/rlp_test.go
+++ b/core/rlp_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/sha3"
 )
 
@@ -207,15 +207,16 @@ func TestBlockRlpEncodeDecode(t *testing.T) {
 	config := *params.OptimismTestConfig
 	config.ShanghaiTime = &zeroTime
 	config.IsthmusTime = &zeroTime
+	require.True(t, config.IsOptimismIsthmus(zeroTime))
 
 	block := getBlock(&config, 10, 2, 50)
 
 	blockRlp, err := rlp.EncodeToBytes(block)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	var decoded types.Block
 	err = rlp.DecodeBytes(blockRlp, &decoded)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, decoded.Hash(), block.Hash())
+	require.Equal(t, decoded.Hash(), block.Hash())
 }

--- a/core/rlp_test.go
+++ b/core/rlp_test.go
@@ -27,10 +27,14 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/stretchr/testify/assert"
 	"golang.org/x/crypto/sha3"
 )
 
-func getBlock(transactions int, uncles int, dataSize int) *types.Block {
+func getBlock(config *params.ChainConfig, transactions int, uncles int, dataSize int) *types.Block {
+	if config == nil {
+		config = params.TestChainConfig
+	}
 	var (
 		aa     = common.HexToAddress("0x000000000000000000000000000000000000aaaa")
 		engine = ethash.NewFaker()
@@ -40,7 +44,7 @@ func getBlock(transactions int, uncles int, dataSize int) *types.Block {
 		address = crypto.PubkeyToAddress(key.PublicKey)
 		funds   = big.NewInt(1_000_000_000_000_000_000)
 		gspec   = &Genesis{
-			Config: params.TestChainConfig,
+			Config: config,
 			Alloc:  types.GenesisAlloc{address: {Balance: funds}},
 		}
 	)
@@ -83,7 +87,7 @@ func TestRlpIterator(t *testing.T) {
 
 func testRlpIterator(t *testing.T, txs, uncles, datasize int) {
 	desc := fmt.Sprintf("%d txs [%d datasize] and %d uncles", txs, datasize, uncles)
-	bodyRlp, _ := rlp.EncodeToBytes(getBlock(txs, uncles, datasize).Body())
+	bodyRlp, _ := rlp.EncodeToBytes(getBlock(nil, txs, uncles, datasize).Body())
 	it, err := rlp.NewListIterator(bodyRlp)
 	if err != nil {
 		t.Fatal(err)
@@ -142,7 +146,7 @@ func BenchmarkHashing(b *testing.B) {
 		blockRlp []byte
 	)
 	{
-		block := getBlock(200, 2, 50)
+		block := getBlock(nil, 200, 2, 50)
 		bodyRlp, _ = rlp.EncodeToBytes(block.Body())
 		blockRlp, _ = rlp.EncodeToBytes(block)
 	}

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -425,7 +425,7 @@ func GenerateBadBlock(parent *types.Block, engine consensus.Engine, txs types.Tr
 	if config.IsShanghai(header.Number, header.Time) {
 		body.Withdrawals = []*types.Withdrawal{}
 	}
-	return types.NewBlock(header, body, receipts, trie.NewStackTrie(nil))
+	return types.NewBlock(header, body, receipts, trie.NewStackTrie(nil), config)
 }
 
 var (

--- a/core/txpool/legacypool/legacypool_test.go
+++ b/core/txpool/legacypool/legacypool_test.go
@@ -86,7 +86,7 @@ func (bc *testBlockChain) CurrentBlock() *types.Header {
 }
 
 func (bc *testBlockChain) GetBlock(hash common.Hash, number uint64) *types.Block {
-	return types.NewBlock(bc.CurrentBlock(), nil, nil, trie.NewStackTrie(nil))
+	return types.NewBlock(bc.CurrentBlock(), nil, nil, trie.NewStackTrie(nil), bc.config)
 }
 
 func (bc *testBlockChain) StateAt(common.Hash) (*state.StateDB, error) {

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -429,6 +429,14 @@ func (b *Block) ReceiptHash() common.Hash { return b.header.ReceiptHash }
 func (b *Block) UncleHash() common.Hash   { return b.header.UncleHash }
 func (b *Block) Extra() []byte            { return common.CopyBytes(b.header.Extra) }
 
+func (b *Block) WithdrawalsRoot() *common.Hash {
+	if b.header.WithdrawalsHash == nil {
+		return nil
+	}
+	h := *b.header.WithdrawalsHash
+	return &h
+}
+
 func (b *Block) BaseFee() *big.Int {
 	if b.header.BaseFee == nil {
 		return nil

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -295,7 +295,7 @@ func NewBlock(header *Header, body *Body, receipts []*Receipt, hasher TrieHasher
 		}
 	}
 
-	if config.IsIsthmus(header.Time) {
+	if config.IsOptimismIsthmus(header.Time) {
 		if withdrawals == nil || len(withdrawals) > 0 {
 			panic(fmt.Sprintf("expected non-nil empty withdrawals operation list in Isthmus, but got: %v", body.Withdrawals))
 		}

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-verkle"
 )
@@ -257,7 +258,7 @@ type extblock struct {
 //
 // The body elements and the receipts are used to recompute and overwrite the
 // relevant portions of the header.
-func NewBlock(header *Header, body *Body, receipts []*Receipt, hasher TrieHasher) *Block {
+func NewBlock(header *Header, body *Body, receipts []*Receipt, hasher TrieHasher, config *params.ChainConfig) *Block {
 	if body == nil {
 		body = &Body{}
 	}
@@ -294,7 +295,14 @@ func NewBlock(header *Header, body *Body, receipts []*Receipt, hasher TrieHasher
 		}
 	}
 
-	if withdrawals == nil {
+	if config.IsIsthmus(header.Time) {
+		if withdrawals == nil || len(withdrawals) > 0 {
+			panic(fmt.Sprintf("expected non-nil empty withdrawals operation list in Isthmus, but got: %v", body.Withdrawals))
+		}
+		b.header.WithdrawalsHash = header.WithdrawalsHash
+		b.withdrawals = make(Withdrawals, 0)
+	} else if withdrawals == nil {
+		// pre-Canyon
 		b.header.WithdrawalsHash = nil
 	} else if len(withdrawals) == 0 {
 		b.header.WithdrawalsHash = &EmptyWithdrawalsHash

--- a/core/types/block_test.go
+++ b/core/types/block_test.go
@@ -254,7 +254,8 @@ func makeBenchBlock() *Block {
 			Extra:      []byte("benchmark uncle"),
 		}
 	}
-	return NewBlock(header, &Body{Transactions: txs, Uncles: uncles}, receipts, blocktest.NewHasher())
+	withdrawals := make([]*Withdrawal, 0)
+	return NewBlock(header, &Body{Transactions: txs, Uncles: uncles, Withdrawals: withdrawals}, receipts, blocktest.NewHasher(), params.TestChainConfig)
 }
 
 func TestRlpDecodeParentHash(t *testing.T) {

--- a/eth/api_debug.go
+++ b/eth/api_debug.go
@@ -482,6 +482,9 @@ func generateWitness(blockchain *core.BlockChain, block *types.Block) (*stateles
 		return nil, fmt.Errorf("failed to process block %d: %w", block.Number(), err)
 	}
 
+	// OP-Stack warning: below has the side-effect of including the withdrawals storage-root
+	// into the execution witness through the storage lookup by ValidateState, triggering the pre-fetcher.
+	// The Process function only runs through Finalize steps, not through FinalizeAndAssemble, missing merkleization.
 	if err := blockchain.Validator().ValidateState(block, statedb, res, false); err != nil {
 		return nil, fmt.Errorf("failed to validate block %d: %w", block.Number(), err)
 	}

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -881,6 +881,7 @@ func (api *ConsensusAPI) newPayload(params engine.ExecutableData, versionedHashe
 			"len(params.Transactions)", len(params.Transactions),
 			"len(params.Withdrawals)", len(params.Withdrawals),
 			"len(params.Deposits)", len(params.Deposits),
+			"params.WithdrawalsRoot", params.WithdrawalsRoot,
 			"beaconRoot", beaconRoot,
 			"error", err)
 		return api.invalid(err, nil), nil
@@ -996,6 +997,7 @@ func (api *ConsensusAPI) executeStatelessPayload(params engine.ExecutableData, v
 			"len(params.Transactions)", len(params.Transactions),
 			"len(params.Withdrawals)", len(params.Withdrawals),
 			"len(params.Deposits)", len(params.Deposits),
+			"params.WithdrawalsRoot", params.WithdrawalsRoot,
 			"beaconRoot", beaconRoot,
 			"error", err)
 		errorMsg := err.Error()

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -853,7 +853,7 @@ func (api *ConsensusAPI) newPayload(params engine.ExecutableData, versionedHashe
 	defer api.newPayloadLock.Unlock()
 
 	log.Trace("Engine API request received", "method", "NewPayload", "number", params.Number, "hash", params.BlockHash)
-	block, err := engine.ExecutableDataToBlock(params, versionedHashes, beaconRoot)
+	block, err := engine.ExecutableDataToBlock(params, versionedHashes, beaconRoot, api.eth.BlockChain().Config())
 	if err != nil {
 		bgu := "nil"
 		if params.BlobGasUsed != nil {
@@ -969,7 +969,7 @@ func (api *ConsensusAPI) newPayload(params engine.ExecutableData, versionedHashe
 func (api *ConsensusAPI) executeStatelessPayload(params engine.ExecutableData, versionedHashes []common.Hash, beaconRoot *common.Hash, opaqueWitness hexutil.Bytes) (engine.StatelessPayloadStatusV1, error) {
 	log.Trace("Engine API request received", "method", "ExecuteStatelessPayload", "number", params.Number, "hash", params.BlockHash)
 
-	block, err := engine.ExecutableDataToBlockNoHash(params, versionedHashes, beaconRoot)
+	block, err := engine.ExecutableDataToBlockNoHash(params, versionedHashes, beaconRoot, api.eth.BlockChain().Config())
 	if err != nil {
 		bgu := "nil"
 		if params.BlobGasUsed != nil {

--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -326,7 +326,7 @@ func TestEth2NewBlock(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create the executable data, block %d: %v", i, err)
 		}
-		block, err := engine.ExecutableDataToBlock(*execData, nil, nil)
+		block, err := engine.ExecutableDataToBlock(*execData, nil, nil, ethservice.BlockChain().Config())
 		if err != nil {
 			t.Fatalf("Failed to convert executable data to block %v", err)
 		}
@@ -368,7 +368,7 @@ func TestEth2NewBlock(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create the executable data %v", err)
 		}
-		block, err := engine.ExecutableDataToBlock(*execData, nil, nil)
+		block, err := engine.ExecutableDataToBlock(*execData, nil, nil, ethservice.BlockChain().Config())
 		if err != nil {
 			t.Fatalf("Failed to convert executable data to block %v", err)
 		}
@@ -1012,7 +1012,7 @@ func TestSimultaneousNewBlock(t *testing.T) {
 				t.Fatal(testErr)
 			}
 		}
-		block, err := engine.ExecutableDataToBlock(*execData, nil, nil)
+		block, err := engine.ExecutableDataToBlock(*execData, nil, nil, ethservice.BlockChain().Config())
 		if err != nil {
 			t.Fatalf("Failed to convert executable data to block %v", err)
 		}
@@ -1614,7 +1614,7 @@ func TestBlockToPayloadWithBlobs(t *testing.T) {
 		},
 	}
 
-	block := types.NewBlock(&header, &types.Body{Transactions: txs}, nil, trie.NewStackTrie(nil))
+	block := types.NewBlock(&header, &types.Body{Transactions: txs}, nil, trie.NewStackTrie(nil), params.OptimismTestConfig)
 	envelope := engine.BlockToExecutableData(block, nil, sidecars)
 	var want int
 	for _, tx := range txs {
@@ -1629,7 +1629,7 @@ func TestBlockToPayloadWithBlobs(t *testing.T) {
 	if got := len(envelope.BlobsBundle.Blobs); got != want {
 		t.Fatalf("invalid number of blobs: got %v, want %v", got, want)
 	}
-	_, err := engine.ExecutableDataToBlock(*envelope.ExecutionPayload, make([]common.Hash, 1), nil)
+	_, err := engine.ExecutableDataToBlock(*envelope.ExecutionPayload, make([]common.Hash, 1), nil, params.OptimismTestConfig)
 	if err != nil {
 		t.Error(err)
 	}

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -146,6 +146,11 @@ type Downloader struct {
 
 // BlockChain encapsulates functions required to sync a (full or snap) blockchain.
 type BlockChain interface {
+	// Config returns the chain configuration.
+	// OP-Stack diff, to adjust withdrawal-hash verification.
+	// Usage of ths in the Downloader is discouraged.
+	Config() *params.ChainConfig
+
 	// HasHeader verifies a header's presence in the local chain.
 	HasHeader(common.Hash, uint64) bool
 
@@ -201,7 +206,7 @@ func New(stateDb ethdb.Database, mux *event.TypeMux, chain BlockChain, dropPeer 
 	dl := &Downloader{
 		stateDB:        stateDb,
 		mux:            mux,
-		queue:          newQueue(blockCacheMaxItems, blockCacheInitialItems),
+		queue:          newQueue(chain.Config(), blockCacheMaxItems, blockCacheInitialItems),
 		peers:          newPeerSet(),
 		blockchain:     chain,
 		dropPeer:       dropPeer,

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -122,7 +122,7 @@ func (f *fetchResult) Done(kind uint) bool {
 }
 
 type OPStackChainConfig interface {
-	IsOptimismHolocene(time uint64) bool
+	IsOptimismIsthmus(time uint64) bool
 }
 
 // queue represents hashes that are either need fetching or are being fetched
@@ -815,8 +815,8 @@ func (q *queue) DeliverBodies(id string, txLists [][]*types.Transaction, txListH
 			if withdrawalLists[index] == nil {
 				return errInvalidBody
 			}
-			if q.opConfig != nil && q.opConfig.IsOptimismHolocene(header.Time) {
-				// If Holocene, we expect an empty list of withdrawal operations,
+			if q.opConfig != nil && q.opConfig.IsOptimismIsthmus(header.Time) {
+				// If Isthmus, we expect an empty list of withdrawal operations,
 				// but the WithdrawalsHash in the header is used for the withdrawals state storage-root.
 				if withdrawalListHashes[index] != types.EmptyWithdrawalsHash {
 					return errInvalidBody

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -121,6 +121,10 @@ func (f *fetchResult) Done(kind uint) bool {
 	return v&(1<<kind) == 0
 }
 
+type OPStackChainConfig interface {
+	IsOptimismHolocene(time uint64) bool
+}
+
 // queue represents hashes that are either need fetching or are being fetched
 type queue struct {
 	mode SyncMode // Synchronisation mode to decide on the block parts to schedule for fetching
@@ -156,10 +160,15 @@ type queue struct {
 	closed bool
 
 	logTime time.Time // Time instance when status was last reported
+
+	// opConfig is used for OP-Stack chain configuration checks.
+	// This may be nil if not an OP-Stack chain.
+	opConfig OPStackChainConfig
 }
 
 // newQueue creates a new download queue for scheduling block retrieval.
-func newQueue(blockCacheLimit int, thresholdInitialSize int) *queue {
+// The
+func newQueue(opConfig OPStackChainConfig, blockCacheLimit int, thresholdInitialSize int) *queue {
 	lock := new(sync.RWMutex)
 	q := &queue{
 		headerContCh:     make(chan bool, 1),
@@ -169,6 +178,7 @@ func newQueue(blockCacheLimit int, thresholdInitialSize int) *queue {
 		receiptWakeCh:    make(chan bool, 1),
 		active:           sync.NewCond(lock),
 		lock:             lock,
+		opConfig:         opConfig,
 	}
 	q.Reset(blockCacheLimit, thresholdInitialSize)
 	return q
@@ -805,7 +815,13 @@ func (q *queue) DeliverBodies(id string, txLists [][]*types.Transaction, txListH
 			if withdrawalLists[index] == nil {
 				return errInvalidBody
 			}
-			if withdrawalListHashes[index] != *header.WithdrawalsHash {
+			if q.opConfig != nil && q.opConfig.IsOptimismHolocene(header.Time) {
+				// If Holocene, we expect an empty list of withdrawal operations,
+				// but the WithdrawalsHash in the header is used for the withdrawals state storage-root.
+				if withdrawalListHashes[index] != types.EmptyWithdrawalsHash {
+					return errInvalidBody
+				}
+			} else if withdrawalListHashes[index] != *header.WithdrawalsHash {
 				return errInvalidBody
 			}
 		}

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -167,7 +167,7 @@ type queue struct {
 }
 
 // newQueue creates a new download queue for scheduling block retrieval.
-// The
+// The opConfig argument may be nil, if not an OP-Stack chain.
 func newQueue(opConfig OPStackChainConfig, blockCacheLimit int, thresholdInitialSize int) *queue {
 	lock := new(sync.RWMutex)
 	q := &queue{

--- a/eth/downloader/queue_test.go
+++ b/eth/downloader/queue_test.go
@@ -97,7 +97,7 @@ func TestBasics(t *testing.T) {
 	numOfBlocks := len(emptyChain.blocks)
 	numOfReceipts := len(emptyChain.blocks) / 2
 
-	q := newQueue(10, 10)
+	q := newQueue(nil, 10, 10)
 	if !q.Idle() {
 		t.Errorf("new queue should be idle")
 	}
@@ -196,7 +196,7 @@ func TestBasics(t *testing.T) {
 func TestEmptyBlocks(t *testing.T) {
 	numOfBlocks := len(emptyChain.blocks)
 
-	q := newQueue(10, 10)
+	q := newQueue(nil, 10, 10)
 
 	q.Prepare(1, SnapSync)
 
@@ -275,7 +275,7 @@ func XTestDelivery(t *testing.T) {
 	if false {
 		log.SetDefault(log.NewLogger(slog.NewTextHandler(os.Stdout, nil)))
 	}
-	q := newQueue(10, 10)
+	q := newQueue(nil, 10, 10)
 	var wg sync.WaitGroup
 	q.Prepare(1, SnapSync)
 	wg.Add(1)

--- a/eth/gasprice/optimism-gasprice_test.go
+++ b/eth/gasprice/optimism-gasprice_test.go
@@ -103,7 +103,7 @@ func newOpTestBackend(t *testing.T, txs []testTxData) *opTestBackend {
 		nonce++
 	}
 	hasher := trie.NewStackTrie(nil)
-	b := types.NewBlock(&header, &types.Body{Transactions: ts}, nil, hasher)
+	b := types.NewBlock(&header, &types.Body{Transactions: ts}, nil, hasher, params.OptimismTestConfig)
 	return &opTestBackend{block: b, receipts: rs}
 }
 

--- a/fork.yaml
+++ b/fork.yaml
@@ -329,6 +329,14 @@ def:
             similar to a withdrawal of the Beacon-chain into the Ethereum L1 execution chain.
           globs:
             - "eth/tracers/live/supply.go"
+        - title: EVM t8ntool
+          description: |
+            The EVM `t8ntool` has not been updated with most op-stack features and does not
+            use the same sealer logic as used in Geth consensus. Isthumus hard fork adds
+            a `withdrawalsRoot` field in the block header. We note that the `t8ntool` is
+            not updated to handle the newly added `withdrawalsRoot` field in the block header.
+          globs:
+            - "cmd/evm/internal/t8ntool/block.go"
     - title: "Hardware wallet support"
       description: Extend Ledger wallet support for newer devices on Macos
       sub:

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -2767,7 +2767,7 @@ func TestRPCMarshalBlock(t *testing.T) {
 		}
 		txs = append(txs, tx)
 	}
-	block := types.NewBlock(&types.Header{Number: big.NewInt(100)}, &types.Body{Transactions: txs}, nil, blocktest.NewHasher())
+	block := types.NewBlock(&types.Header{Number: big.NewInt(100)}, &types.Body{Transactions: txs}, nil, blocktest.NewHasher(), params.MainnetChainConfig)
 
 	var testSuite = []struct {
 		inclTx bool
@@ -2982,7 +2982,7 @@ func TestRPCGetBlockOrHeader(t *testing.T) {
 			Address:   common.Address{0x12, 0x34},
 			Amount:    10,
 		}
-		pending = types.NewBlock(&types.Header{Number: big.NewInt(11), Time: 42}, &types.Body{Transactions: types.Transactions{tx}, Withdrawals: types.Withdrawals{withdrawal}}, nil, blocktest.NewHasher())
+		pending = types.NewBlock(&types.Header{Number: big.NewInt(11), Time: 42}, &types.Body{Transactions: types.Transactions{tx}, Withdrawals: types.Withdrawals{withdrawal}}, nil, blocktest.NewHasher(), params.TestChainConfig)
 	)
 	backend := newTestBackend(t, genBlocks, genesis, ethash.NewFaker(), func(i int, b *core.BlockGen) {
 		// Transfer from account[0] to account[1]

--- a/internal/ethapi/simulate.go
+++ b/internal/ethapi/simulate.go
@@ -249,7 +249,7 @@ func (sim *simulator) processBlock(ctx context.Context, block *simBlock, header,
 	if sim.chainConfig.IsShanghai(header.Number, header.Time) {
 		withdrawals = make([]*types.Withdrawal, 0)
 	}
-	b := types.NewBlock(header, &types.Body{Transactions: txes, Withdrawals: withdrawals}, receipts, trie.NewStackTrie(nil))
+	b := types.NewBlock(header, &types.Body{Transactions: txes, Withdrawals: withdrawals}, receipts, trie.NewStackTrie(nil), sim.chainConfig)
 	repairLogs(callResults, b.Hash())
 	return b, callResults, nil
 }

--- a/miner/miner_test.go
+++ b/miner/miner_test.go
@@ -80,7 +80,7 @@ func (bc *testBlockChain) CurrentBlock() *types.Header {
 }
 
 func (bc *testBlockChain) GetBlock(hash common.Hash, number uint64) *types.Block {
-	return types.NewBlock(bc.CurrentBlock(), nil, nil, trie.NewStackTrie(nil))
+	return types.NewBlock(bc.CurrentBlock(), nil, nil, trie.NewStackTrie(nil), bc.Config())
 }
 
 func (bc *testBlockChain) StateAt(common.Hash) (*state.StateDB, error) {

--- a/params/config.go
+++ b/params/config.go
@@ -351,6 +351,7 @@ type ChainConfig struct {
 	FjordTime    *uint64 `json:"fjordTime,omitempty"`    // Fjord switch time (nil = no fork, 0 = already on Optimism Fjord)
 	GraniteTime  *uint64 `json:"graniteTime,omitempty"`  // Granite switch time (nil = no fork, 0 = already on Optimism Granite)
 	HoloceneTime *uint64 `json:"holoceneTime,omitempty"` // Holocene switch time (nil = no fork, 0 = already on Optimism Holocene)
+	IsthmusTime  *uint64 `json:"isthmusTime,omitempty"`  // Isthmus switch time (nil = no fork, 0 = already on Optimism Isthmus)
 
 	InteropTime *uint64 `json:"interopTime,omitempty"` // Interop switch time (nil = no fork, 0 = already on optimism interop)
 
@@ -655,6 +656,10 @@ func (c *ChainConfig) IsHolocene(time uint64) bool {
 	return isTimestampForked(c.HoloceneTime, time)
 }
 
+func (c *ChainConfig) IsIsthmus(time uint64) bool {
+	return isTimestampForked(c.IsthmusTime, time)
+}
+
 func (c *ChainConfig) IsInterop(time uint64) bool {
 	return isTimestampForked(c.InteropTime, time)
 }
@@ -691,6 +696,10 @@ func (c *ChainConfig) IsOptimismGranite(time uint64) bool {
 
 func (c *ChainConfig) IsOptimismHolocene(time uint64) bool {
 	return c.IsOptimism() && c.IsHolocene(time)
+}
+
+func (c *ChainConfig) IsOptimismIsthmus(time uint64) bool {
+	return c.IsOptimism() && c.IsIsthmus(time)
 }
 
 // IsOptimismPreBedrock returns true iff this is an optimism node & bedrock is not yet active

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -27,6 +27,8 @@ var (
 	OptimismBaseFeeRecipient = common.HexToAddress("0x4200000000000000000000000000000000000019")
 	// The L1 portion of the transaction fee accumulates at this predeploy
 	OptimismL1FeeRecipient = common.HexToAddress("0x420000000000000000000000000000000000001A")
+	// The L2 withdrawals contract predeploy address
+	OptimismL2ToL1MessagePasser = common.HexToAddress("0x4200000000000000000000000000000000000016")
 )
 
 const (


### PR DESCRIPTION
**Description**

L2 withdrawals storage root is retrieve from the state upon block-sealing, and then inserted into the header as withdrawals-root.

The L1 withdrawals-root is computed as an MPT hash of withdrawals operations. The OP-Stack uses contract-storage instead. In some places this means  we have to verify the block-body withdrawals-list is empty, while the header is set to the storage root.

**Tests**

Work in progress.

**Additional context**

This PR is used as feature-branch. Changes will not be merged into `optimism` until the withdrawals changes (specs, op-geth, op-node, and ideally other implementations) are complete for Holocene upgrade.

**Metadata**

Part of https://github.com/ethereum-optimism/optimism/issues/12044
