### PR TITLE
Holocene: handle Holocene l1 attributes in l1 data fee computation

### DIFF
--- a/core/types/rollup_cost.go
+++ b/core/types/rollup_cost.go
@@ -54,6 +54,8 @@ var (
 	BedrockL1AttributesSelector = []byte{0x01, 0x5d, 0x8e, 0xb9}
 	// EcotoneL1AttributesSelector is the selector indicating Ecotone style L1 gas attributes.
 	EcotoneL1AttributesSelector = []byte{0x44, 0x0a, 0x5e, 0x20}
+	// HoloceneL1AttributesSelector is the selector indicating Holocene style L1 gas attributes.
+	HoloceneL1AttributesSelector = []byte{0xd1, 0xfb, 0xe1, 0x5b}
 
 	// L1BlockAddr is the address of the L1Block contract which stores the L1 gas attributes.
 	L1BlockAddr = common.HexToAddress("0x4200000000000000000000000000000000000015")
@@ -264,7 +266,7 @@ func extractL1GasParams(config *params.ChainConfig, time uint64, data []byte) (g
 	// If so, fall through to the pre-ecotone format
 	// Both Ecotone and Fjord use the same function selector
 	if config.IsEcotone(time) && len(data) >= 4 && !bytes.Equal(data[0:4], BedrockL1AttributesSelector) {
-		p, err := extractL1GasParamsPostEcotone(data)
+		p, err := extractL1GasParamsPostEcotone(config.IsHolocene(time), data)
 		if err != nil {
 			return gasParams{}, err
 		}
@@ -309,13 +311,16 @@ func extractL1GasParamsPreEcotone(config *params.ChainConfig, time uint64, data 
 }
 
 // extractL1GasParamsPostEcotone extracts the gas parameters necessary to compute gas from L1 attribute
-// info calldata after the Ecotone upgrade, but not for the very first Ecotone block.
-func extractL1GasParamsPostEcotone(data []byte) (gasParams, error) {
-	if len(data) != 164 {
+// info calldata after the Ecotone upgrade, other than the very first Ecotone block.
+func extractL1GasParamsPostEcotone(isHolocene bool, data []byte) (gasParams, error) {
+	if isHolocene && len(data) >= 4 && bytes.Equal(data[0:4], HoloceneL1AttributesSelector) {
+		if len(data) != 180 {
+			return gasParams{}, fmt.Errorf("expected 180 L1 info bytes, got %d", len(data))
+		}
+	} else if len(data) != 164 {
 		return gasParams{}, fmt.Errorf("expected 164 L1 info bytes, got %d", len(data))
 	}
 	// data layout assumed for Ecotone:
-	// offset type varname
 	// 0     <selector>
 	// 4     uint32 _basefeeScalar
 	// 8     uint32 _blobBaseFeeScalar
@@ -326,6 +331,10 @@ func extractL1GasParamsPostEcotone(data []byte) (gasParams, error) {
 	// 68    uint256 _blobBaseFee,
 	// 100   bytes32 _hash,
 	// 132   bytes32 _batcherHash,
+	//
+	// added by Holocene:
+	// 164   uint64 _eip1559Denominator,
+	// 172   uint64 _eip1559Elasticity,
 	l1BaseFee := new(big.Int).SetBytes(data[36:68])
 	l1BlobBaseFee := new(big.Int).SetBytes(data[68:100])
 	l1BaseFeeScalar := binary.BigEndian.Uint32(data[4:8])


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Holocene introduces a [new L1 attributes](https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/holocene/l1-attributes.md#l1-block-attributes) format which needs to be properly parsed in the L1 cost function calculation, even though in this part of the code, the new attributes do not affect the computation.

**Tests**

Added unit tests to confirm Holocene-style l1 attributes are handled properly after the Holocene upgrade within l1 data fee related code, and also that Ecotone-style attributes remain handled without error to support the fact that the first Holocene block will have the older style L1 attributes.

**Metatdata**

https://github.com/ethereum-optimism/specs/issues/340