### PR TITLE
miner: drop failed txs

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -131,9 +131,11 @@ func (miner *Miner) generateWork(params *generateParams) *newPayloadResult {
 		work.state.SetTxContext(tx.Hash(), work.tcount)
 		err = miner.commitTransaction(work, tx)
 		if err != nil {
-			return &newPayloadResult{err: fmt.Errorf("failed to force-include tx: %s type: %d sender: %s nonce: %d, err: %w", tx.Hash(), tx.Type(), from, tx.Nonce(), err)}
+			// Skip included txns that fail
+			log.Warn("Failed to force-include tx", "hash", tx.Hash(), "type", tx.Type(), "sender", from, "nonce", tx.Nonce(), "err", err)
+		} else {
+			work.tcount++
 		}
-		work.tcount++
 	}
 	if !params.noTxs {
 		// use shared interrupt if present


### PR DESCRIPTION
Temporary change that allows us to stress test the execution client via [replayor](https://github.com/danyalprout/replayor). Want to publish a docker image at this commit. 