### PR TITLE
Revert "Holocene: handle Holocene l1 attributes...

### DIFF
--- a/core/types/rollup_cost.go
+++ b/core/types/rollup_cost.go
@@ -54,8 +54,6 @@ var (
 	BedrockL1AttributesSelector = []byte{0x01, 0x5d, 0x8e, 0xb9}
 	// EcotoneL1AttributesSelector is the selector indicating Ecotone style L1 gas attributes.
 	EcotoneL1AttributesSelector = []byte{0x44, 0x0a, 0x5e, 0x20}
-	// HoloceneL1AttributesSelector is the selector indicating Holocene style L1 gas attributes.
-	HoloceneL1AttributesSelector = []byte{0xd1, 0xfb, 0xe1, 0x5b}
 
 	// L1BlockAddr is the address of the L1Block contract which stores the L1 gas attributes.
 	L1BlockAddr = common.HexToAddress("0x4200000000000000000000000000000000000015")
@@ -266,7 +264,7 @@ func extractL1GasParams(config *params.ChainConfig, time uint64, data []byte) (g
 	// If so, fall through to the pre-ecotone format
 	// Both Ecotone and Fjord use the same function selector
 	if config.IsEcotone(time) && len(data) >= 4 && !bytes.Equal(data[0:4], BedrockL1AttributesSelector) {
-		p, err := extractL1GasParamsPostEcotone(config.IsHolocene(time), data)
+		p, err := extractL1GasParamsPostEcotone(data)
 		if err != nil {
 			return gasParams{}, err
 		}
@@ -311,18 +309,13 @@ func extractL1GasParamsPreEcotone(config *params.ChainConfig, time uint64, data 
 }
 
 // extractL1GasParamsPostEcotone extracts the gas parameters necessary to compute gas from L1 attribute
-// info calldata after the Ecotone upgrade, other than the very first Ecotone block.
-func extractL1GasParamsPostEcotone(isHolocene bool, data []byte) (gasParams, error) {
-	expectedLen := 164
-	if isHolocene && (len(data) < 4 || bytes.Equal(data[0:4], HoloceneL1AttributesSelector)) {
-		// We check that the Holocene selector is present to exclude the very first block after the
-		// Holocene upgrade, which should still have Ecotone style (len=164) attributes.
-		expectedLen = 180
-	}
-	if len(data) != expectedLen {
-		return gasParams{}, fmt.Errorf("expected %d L1 info bytes, got %d", expectedLen, len(data))
+// info calldata after the Ecotone upgrade, but not for the very first Ecotone block.
+func extractL1GasParamsPostEcotone(data []byte) (gasParams, error) {
+	if len(data) != 164 {
+		return gasParams{}, fmt.Errorf("expected 164 L1 info bytes, got %d", len(data))
 	}
 	// data layout assumed for Ecotone:
+	// offset type varname
 	// 0     <selector>
 	// 4     uint32 _basefeeScalar
 	// 8     uint32 _blobBaseFeeScalar
@@ -333,10 +326,6 @@ func extractL1GasParamsPostEcotone(isHolocene bool, data []byte) (gasParams, err
 	// 68    uint256 _blobBaseFee,
 	// 100   bytes32 _hash,
 	// 132   bytes32 _batcherHash,
-	//
-	// added by Holocene:
-	// 164   uint64 _eip1559Denominator,
-	// 172   uint64 _eip1559Elasticity,
 	l1BaseFee := new(big.Int).SetBytes(data[36:68])
 	l1BlobBaseFee := new(big.Int).SetBytes(data[68:100])
 	l1BaseFeeScalar := binary.BigEndian.Uint32(data[4:8])

--- a/core/types/rollup_cost_test.go
+++ b/core/types/rollup_cost_test.go
@@ -174,69 +174,7 @@ func TestExtractEcotoneGasParams(t *testing.T) {
 
 	// make sure wrong amont of data results in error
 	data = append(data, 0x00) // tack on garbage byte
-	_, err = extractL1GasParamsPostEcotone(false, data)
-	require.Error(t, err)
-
-	// make sure holocene attributes result in error prior to Holocene activation
-	data = getHoloceneL1Attributes(
-		baseFee,
-		blobBaseFee,
-		baseFeeScalar,
-		blobBaseFeeScalar,
-	)
-	gasparams, err = extractL1GasParams(config, zeroTime, data)
-	require.Error(t, err)
-}
-
-func TestExtractHoloceneGasParams(t *testing.T) {
-	zeroTime := uint64(0)
-	// create a config where holocene upgrade is active
-	config := &params.ChainConfig{
-		Optimism:     params.OptimismTestConfig.Optimism,
-		RegolithTime: &zeroTime,
-		EcotoneTime:  &zeroTime,
-		HoloceneTime: &zeroTime,
-	}
-	require.True(t, config.IsOptimismEcotone(zeroTime))
-	require.True(t, config.IsOptimismHolocene(zeroTime))
-
-	// make sure empty attributes returns error
-	data := []byte{}
-	_, err := extractL1GasParamsPostEcotone(true, data)
-	require.Error(t, err)
-
-	// Check that we still allow Ecotone-style L1 attributes post-Holocene, since the very first Holocene block will
-	// have Ecotone attributes.
-	data = getEcotoneL1Attributes(
-		baseFee,
-		blobBaseFee,
-		baseFeeScalar,
-		blobBaseFeeScalar,
-	)
-	gasparams, err := extractL1GasParams(config, zeroTime, data)
-	require.NoError(t, err)
-	costFunc := gasparams.costFunc
-	c, g := costFunc(emptyTx.RollupCostData())
-	require.Equal(t, ecotoneGas, g)
-	require.Equal(t, ecotoneFee, c)
-
-	// Now confirm Holocene-style L1 attributes work.
-	data = getHoloceneL1Attributes(
-		baseFee,
-		blobBaseFee,
-		baseFeeScalar,
-		blobBaseFeeScalar,
-	)
-	gasparams, err = extractL1GasParams(config, zeroTime, data)
-	require.NoError(t, err)
-	costFunc = gasparams.costFunc
-	c, g = costFunc(emptyTx.RollupCostData())
-	require.Equal(t, ecotoneGas, g)
-	require.Equal(t, ecotoneFee, c)
-
-	// make sure wrong amont of data results in error
-	data = append(data, 0x00) // tack on garbage byte
-	_, err = extractL1GasParamsPostEcotone(true, data)
+	_, err = extractL1GasParamsPostEcotone(data)
 	require.Error(t, err)
 }
 
@@ -322,13 +260,6 @@ func getEcotoneL1Attributes(baseFee, blobBaseFee, baseFeeScalar, blobBaseFeeScal
 	data = append(data, blobBaseFee.FillBytes(uint256Slice)...)
 	data = append(data, ignored.FillBytes(uint256Slice)...)
 	data = append(data, ignored.FillBytes(uint256Slice)...)
-	return data
-}
-
-func getHoloceneL1Attributes(baseFee, blobBaseFee, baseFeeScalar, blobBaseFeeScalar *big.Int) []byte {
-	data := getEcotoneL1Attributes(baseFee, blobBaseFee, baseFeeScalar, blobBaseFeeScalar)
-	copy(data, HoloceneL1AttributesSelector)
-	data = append(data, make([]byte, 16)...) // add 0 values for the two new attributes
 	return data
 }
 


### PR DESCRIPTION

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This reverts commit c283254e5447f127e3b9350860985911dab9cd2f, which is no longer needed now that we are going to use the block header for the new Holocene eip1559 parameters instead of L1 attributes.
