### PR TITLE
fix: Only apply effective gas limit when building new blocks

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -120,7 +120,7 @@ func (miner *Miner) generateWork(params *generateParams) *newPayloadResult {
 
 		// If we're building blocks with mempool transactions, we need to ensure that the
 		// gas limit is not higher than the effective gas limit. We must still accept any
-		// force-included transactions with gas usage up to the block header's limit.
+		// explicitly selected transactions with gas usage up to the block header's limit.
 		if !params.noTxs {
 			effectiveGasLimit := miner.config.EffectiveGasCeil
 			if effectiveGasLimit != 0 && effectiveGasLimit < gasLimit {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -116,9 +116,16 @@ func (miner *Miner) generateWork(params *generateParams) *newPayloadResult {
 		return &newPayloadResult{err: err}
 	}
 	if work.gasPool == nil {
-		gasLimit := miner.config.EffectiveGasCeil
-		if gasLimit == 0 || gasLimit > work.header.GasLimit {
-			gasLimit = work.header.GasLimit
+		gasLimit := work.header.GasLimit
+
+		// If we're building blocks with mempool transactions, we need to ensure that the
+		// gas limit is not higher than the effective gas limit. We must still accept any
+		// force-included transactions with gas usage up to the block header's limit.
+		if !params.noTxs {
+			effectiveGasLimit := miner.config.EffectiveGasCeil
+			if effectiveGasLimit != 0 && effectiveGasLimit < gasLimit {
+				gasLimit = effectiveGasLimit
+			}
 		}
 		work.gasPool = new(core.GasPool).AddGas(gasLimit)
 	}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This changes the behavior of the miner's effective gas limit such that this no longer applies to blocks with the `noTxs` flag set.

As the effective gas limit is not a consensus property, other nodes must not reject sequenced blocks which contain a greater amount of gas than this "effective" limit, and thus this should only be applied when building blocks containing mempool transactions. Otherwise only the true consensus gas limit should be enforced.

This is an important fix when running multiple sequencers under consensus, as any increase to the effective gas limit on one sequencer may cause the others to reject any blocks with this higher limit and fork off to their own chain.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
