### PR TITLE
core: fix genesis op-mainnet hash

### DIFF
--- a/core/superchain.go
+++ b/core/superchain.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum-optimism/superchain-registry/superchain"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 )
 
@@ -35,7 +36,7 @@ func LoadOPStackGenesis(chainID uint64) (*Genesis, error) {
 		Difficulty:    (*big.Int)(gen.Difficulty),
 		Mixhash:       common.Hash(gen.Mixhash),
 		Coinbase:      common.Address(gen.Coinbase),
-		Alloc:         make(GenesisAlloc),
+		Alloc:         make(types.GenesisAlloc),
 		Number:        gen.Number,
 		GasUsed:       gen.GasUsed,
 		ParentHash:    common.Hash(gen.ParentHash),
@@ -76,6 +77,7 @@ func LoadOPStackGenesis(chainID uint64) (*Genesis, error) {
 			return nil, fmt.Errorf("chain definition unexpectedly contains both allocation (%d) and state-hash %s", len(gen.Alloc), *gen.StateHash)
 		}
 		genesis.StateHash = (*common.Hash)(gen.StateHash)
+		genesis.Alloc = nil
 	}
 
 	genesisBlock := genesis.ToBlock()


### PR DESCRIPTION
**Description**

- Fix 1: Apply the state-root, not the block-header-hash, when exporting the genesis spec from DB content.
- Fix 2: Fix `Commit()` to actually take the state-hash, not the hash of the empty allocs, when computing the op-mainnet genesis block.

Fix https://github.com/ethereum-optimism/op-geth/issues/404

(Yes, the issue describing the missing genesis state issue was really issue number 404)
