### PR TITLE
consistently use uint64 for Holocene eip-1559 params

### DIFF
--- a/consensus/misc/eip1559/eip1559_test.go
+++ b/consensus/misc/eip1559/eip1559_test.go
@@ -195,7 +195,7 @@ func TestCalcBaseFeeOptimismHolocene(t *testing.T) {
 	tests := []struct {
 		parentGasUsed     uint64
 		expectedBaseFee   int64
-		denom, elasticity uint32
+		denom, elasticity uint64
 	}{
 		{parentGasLimit / 2, parentBaseFee, 10, 2},  // target
 		{10_000_000, 9_666_667, 10, 2},              // below

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -262,7 +262,7 @@ func (miner *Miner) prepareWork(genParams *generateParams, witness bool) (*envir
 			d = miner.chainConfig.BaseFeeChangeDenominator(header.Time)
 			e = miner.chainConfig.ElasticityMultiplier()
 		}
-		header.Extra = eip1559.EncodeHoloceneExtraData(uint32(d), uint32(e))
+		header.Extra = eip1559.EncodeHoloceneExtraData(d, e)
 	} else if genParams.eip1559Params != nil {
 		return nil, errors.New("got eip1559 params, expected none")
 	}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

We were unnecessarily exposing the fact that these parameters were being encoded as uint32. Changing to always use uint64 outside of the encode/decode abstractions.
