### PR TITLE
tracing: Show OptimismBaseFeeRecipient in prestate

### DIFF
--- a/eth/tracers/internal/tracetest/calltrace_test.go
+++ b/eth/tracers/internal/tracetest/calltrace_test.go
@@ -112,8 +112,8 @@ func testCallTracer(tracerName string, dirPath string, t *testing.T) {
 			// Configure a blockchain with the given prestate
 			var (
 				signer  = types.MakeSigner(test.Genesis.Config, new(big.Int).SetUint64(uint64(test.Context.Number)), uint64(test.Context.Time))
-				context = test.Context.toBlockContext(test.Genesis)
 				st      = tests.MakePreState(rawdb.NewMemoryDatabase(), test.Genesis.Alloc, false, rawdb.HashScheme)
+				context = test.Context.toBlockContext(test.Genesis, st.StateDB)
 			)
 			st.Close()
 
@@ -202,13 +202,13 @@ func benchTracer(tracerName string, test *callTracerTest, b *testing.B) {
 		b.Fatalf("failed to parse testcase input: %v", err)
 	}
 	signer := types.MakeSigner(test.Genesis.Config, new(big.Int).SetUint64(uint64(test.Context.Number)), uint64(test.Context.Time))
-	context := test.Context.toBlockContext(test.Genesis)
+	state := tests.MakePreState(rawdb.NewMemoryDatabase(), test.Genesis.Alloc, false, rawdb.HashScheme)
+	defer state.Close()
+	context := test.Context.toBlockContext(test.Genesis, state.StateDB)
 	msg, err := core.TransactionToMessage(tx, signer, context.BaseFee)
 	if err != nil {
 		b.Fatalf("failed to prepare transaction for tracing: %v", err)
 	}
-	state := tests.MakePreState(rawdb.NewMemoryDatabase(), test.Genesis.Alloc, false, rawdb.HashScheme)
-	defer state.Close()
 
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/eth/tracers/internal/tracetest/flat_calltrace_test.go
+++ b/eth/tracers/internal/tracetest/flat_calltrace_test.go
@@ -96,8 +96,8 @@ func flatCallTracerTestRunner(tracerName string, filename string, dirPath string
 		return fmt.Errorf("failed to parse testcase input: %v", err)
 	}
 	signer := types.MakeSigner(test.Genesis.Config, new(big.Int).SetUint64(uint64(test.Context.Number)), uint64(test.Context.Time))
-	context := test.Context.toBlockContext(test.Genesis)
 	state := tests.MakePreState(rawdb.NewMemoryDatabase(), test.Genesis.Alloc, false, rawdb.HashScheme)
+	context := test.Context.toBlockContext(test.Genesis, state.StateDB)
 	defer state.Close()
 
 	// Create the tracer, the EVM environment and run it

--- a/eth/tracers/internal/tracetest/prestate_test.go
+++ b/eth/tracers/internal/tracetest/prestate_test.go
@@ -89,8 +89,8 @@ func testPrestateTracer(tracerName string, dirPath string, t *testing.T) {
 			// Configure a blockchain with the given prestate
 			var (
 				signer  = types.MakeSigner(test.Genesis.Config, new(big.Int).SetUint64(uint64(test.Context.Number)), uint64(test.Context.Time))
-				context = test.Context.toBlockContext(test.Genesis)
 				state   = tests.MakePreState(rawdb.NewMemoryDatabase(), test.Genesis.Alloc, false, rawdb.HashScheme)
+				context = test.Context.toBlockContext(test.Genesis, state.StateDB)
 			)
 			defer state.Close()
 

--- a/eth/tracers/internal/tracetest/testdata/prestate_tracer_with_diff_mode/optimism.json
+++ b/eth/tracers/internal/tracetest/testdata/prestate_tracer_with_diff_mode/optimism.json
@@ -1,0 +1,94 @@
+{
+  "genesis": {
+    "baseFeePerGas": "1000000000",
+    "blobGasUsed": "0",
+    "difficulty": "0",
+    "excessBlobGas": "0",
+    "extraData": "0x",
+    "gasLimit": "11500000",
+    "hash": "0x4a3a3699d4d328652bfea00c9fdc2be4768519142e10e0d6cebdbec5056f101e",
+    "miner": "0x0000000000000000000000000000000000000000",
+    "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "nonce": "0x0000000000000000",
+    "number": "0",
+    "parentBeaconBlockRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "stateRoot": "0x0344388281802511fb31b24f96f087a8b935683646d2a75de96465703505e065",
+    "timestamp": "0",
+    "withdrawals": [],
+    "withdrawalsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+    "alloc": {
+        "0x0000000000000000000000000000000000000000": {
+          "balance": "0x0"
+        },
+        "0xf7b094d8c987eff69afec8f93153ac9829577125": {
+          "balance": "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7"
+        }
+      },
+    "config": {
+        "chainId": 1337,
+        "homesteadBlock": 0,
+        "eip150Block": 0,
+        "eip155Block": 0,
+        "eip158Block": 0,
+        "byzantiumBlock": 0,
+        "constantinopleBlock": 0,
+        "petersburgBlock": 0,
+        "istanbulBlock": 0,
+        "muirGlacierBlock": 0,
+        "berlinBlock": 0,
+        "londonBlock": 0,
+        "arrowGlacierBlock": 0,
+        "grayGlacierBlock": 0,
+        "bedrockBlock": 0,
+        "shanghaiTime": 0,
+        "cancunTime": 0,
+        "terminalTotalDifficulty": 0,
+        "terminalTotalDifficultyPassed": true,
+        "depositContractAddress": "0x0000000000000000000000000000000000000000",
+	"optimism": {
+	    "eip1559Elasticity": 6,
+	    "eip1559Denominator": 50,
+	    "eip1559DenominatorCanyon": 250
+	}
+    }
+  },
+  "context": {
+    "number": "1",
+    "difficulty": "0",
+    "timestamp": "1729512767",
+    "gasLimit": "11511229",
+    "miner": "0x0000000000000000000000000000000000000000",
+    "baseFeePerGas": "875000000",
+    "random": "0x0000000000000000000000000000000000000000000000000000000000000000"
+  },
+    "random": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "input": "0x02f8708205398001847735940182520894f7b094d8c987eff69afec8f93153ac9829577125880de0b6b3a764000080c001a0e44882c072410fbadfd4783a71be745edfcedd9fc9ab55b66e25bb039db2f579a017c13129640ceff7ffa674bcff74bcce168404aa8450a67ece2737ca5a554a12",
+  "result": {
+    "post": {
+      "0x0000000000000000000000000000000000000000": {
+        "balance": "0x5208"
+      },
+      "0x4200000000000000000000000000000000000019": {
+	  "balance": "0x10b643590600"
+      },
+      "0xf7b094d8c987eff69afec8f93153ac9829577125": {
+        "balance": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffef49bca6a7ef",
+        "nonce": 1
+      }
+    },
+    "pre": {
+      "0x0000000000000000000000000000000000000000": {
+        "balance": "0x0"
+      },
+      "0x4200000000000000000000000000000000000019": {
+	  "balance": "0x0"
+      },
+      "0xf7b094d8c987eff69afec8f93153ac9829577125": {
+        "balance": "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7"
+      }
+    }
+  },
+  "tracerConfig": {
+    "diffMode": true
+  }
+}

--- a/eth/tracers/internal/tracetest/util.go
+++ b/eth/tracers/internal/tracetest/util.go
@@ -53,7 +53,7 @@ type traceContext struct {
 	BaseFee    *math.HexOrDecimal256 `json:"baseFeePerGas"`
 }
 
-func (c *traceContext) toBlockContext(genesis *core.Genesis) vm.BlockContext {
+func (c *traceContext) toBlockContext(genesis *core.Genesis, statedb types.StateGetter) vm.BlockContext {
 	context := vm.BlockContext{
 		CanTransfer: core.CanTransfer,
 		Transfer:    core.Transfer,
@@ -62,6 +62,7 @@ func (c *traceContext) toBlockContext(genesis *core.Genesis) vm.BlockContext {
 		Time:        uint64(c.Time),
 		Difficulty:  (*big.Int)(c.Difficulty),
 		GasLimit:    uint64(c.GasLimit),
+		L1CostFunc:  types.NewL1CostFunc(genesis.Config, statedb),
 	}
 	if genesis.Config.IsLondon(context.BlockNumber) {
 		context.BaseFee = (*big.Int)(c.BaseFee)

--- a/eth/tracers/native/prestate.go
+++ b/eth/tracers/native/prestate.go
@@ -69,6 +69,9 @@ type prestateTracer struct {
 	reason    error       // Textual reason for the interruption
 	created   map[common.Address]bool
 	deleted   map[common.Address]bool
+
+	// Required on OP-Stack to detect Optimism flag
+	chainConfig *params.ChainConfig
 }
 
 type prestateTracerConfig struct {
@@ -88,6 +91,9 @@ func newPrestateTracer(ctx *tracers.Context, cfg json.RawMessage, chainConfig *p
 		config:  config,
 		created: make(map[common.Address]bool),
 		deleted: make(map[common.Address]bool),
+
+		// Required on OP-Stack to detect Optimism flag
+		chainConfig: chainConfig,
 	}
 	return &tracers.Tracer{
 		Hooks: &tracing.Hooks{
@@ -167,6 +173,10 @@ func (t *prestateTracer) OnTxStart(env *tracing.VMContext, tx *types.Transaction
 			continue
 		}
 		t.lookupAccount(addr)
+	}
+
+	if t.chainConfig.Optimism != nil {
+		t.lookupAccount(params.OptimismBaseFeeRecipient)
 	}
 }
 


### PR DESCRIPTION
**Description**

The OptimismBaseFeeRecipient should show up in prestate tracing results (both the normal prestate and the diff mode prestate results) if IsOptimism.

**Tests**

I added one prestate diff test with Optimism turned on to show that it works correctly. This required adding Random (so that IsMerge is true) and L1CostFunc to the test block context.
I can add a second test for the plain prestate mode if you like.

**Additional context**

Previous discussion at https://discord.com/channels/1244729134312198194/1282997447609552986

Fixes https://github.com/ethereum-optimism/op-geth/issues/410