### PR TITLE
core/types: transaction conditional KnownAccounts fix && HexOrDecimal deser

### DIFF
--- a/core/types/gen_transaction_conditional_json.go
+++ b/core/types/gen_transaction_conditional_json.go
@@ -5,9 +5,8 @@ package types
 import (
 	"encoding/json"
 	"math/big"
-	"bytes"
 
-	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/common/math"
 )
 
 var _ = (*transactionConditionalMarshalling)(nil)
@@ -15,36 +14,32 @@ var _ = (*transactionConditionalMarshalling)(nil)
 // MarshalJSON marshals as JSON.
 func (t TransactionConditional) MarshalJSON() ([]byte, error) {
 	type TransactionConditional struct {
-		KnownAccounts  KnownAccounts   `json:"knownAccounts"`
-		BlockNumberMin *hexutil.Big    `json:"blockNumberMin,omitempty"`
-		BlockNumberMax *hexutil.Big    `json:"blockNumberMax,omitempty"`
-		TimestampMin   *hexutil.Uint64 `json:"timestampMin,omitempty"`
-		TimestampMax   *hexutil.Uint64 `json:"timestampMax,omitempty"`
+		KnownAccounts  KnownAccounts         `json:"knownAccounts"`
+		BlockNumberMin *math.HexOrDecimal256 `json:"blockNumberMin,omitempty"`
+		BlockNumberMax *math.HexOrDecimal256 `json:"blockNumberMax,omitempty"`
+		TimestampMin   *math.HexOrDecimal64  `json:"timestampMin,omitempty"`
+		TimestampMax   *math.HexOrDecimal64  `json:"timestampMax,omitempty"`
 	}
 	var enc TransactionConditional
 	enc.KnownAccounts = t.KnownAccounts
-	enc.BlockNumberMin = (*hexutil.Big)(t.BlockNumberMin)
-	enc.BlockNumberMax = (*hexutil.Big)(t.BlockNumberMax)
-	enc.TimestampMin = (*hexutil.Uint64)(t.TimestampMin)
-	enc.TimestampMax = (*hexutil.Uint64)(t.TimestampMax)
+	enc.BlockNumberMin = (*math.HexOrDecimal256)(t.BlockNumberMin)
+	enc.BlockNumberMax = (*math.HexOrDecimal256)(t.BlockNumberMax)
+	enc.TimestampMin = (*math.HexOrDecimal64)(t.TimestampMin)
+	enc.TimestampMax = (*math.HexOrDecimal64)(t.TimestampMax)
 	return json.Marshal(&enc)
 }
 
 // UnmarshalJSON unmarshals from JSON.
 func (t *TransactionConditional) UnmarshalJSON(input []byte) error {
 	type TransactionConditional struct {
-		KnownAccounts  *KnownAccounts  `json:"knownAccounts"`
-		BlockNumberMin *hexutil.Big    `json:"blockNumberMin,omitempty"`
-		BlockNumberMax *hexutil.Big    `json:"blockNumberMax,omitempty"`
-		TimestampMin   *hexutil.Uint64 `json:"timestampMin,omitempty"`
-		TimestampMax   *hexutil.Uint64 `json:"timestampMax,omitempty"`
+		KnownAccounts  *KnownAccounts        `json:"knownAccounts"`
+		BlockNumberMin *math.HexOrDecimal256 `json:"blockNumberMin,omitempty"`
+		BlockNumberMax *math.HexOrDecimal256 `json:"blockNumberMax,omitempty"`
+		TimestampMin   *math.HexOrDecimal64  `json:"timestampMin,omitempty"`
+		TimestampMax   *math.HexOrDecimal64  `json:"timestampMax,omitempty"`
 	}
 	var dec TransactionConditional
-	// --- Not Generated. Disallow unknown fields
-	decoder := json.NewDecoder(bytes.NewReader(input))
-	decoder.DisallowUnknownFields() // Force errors
-	// ---
-	if err := decoder.Decode(&dec); err != nil {
+	if err := json.Unmarshal(input, &dec); err != nil {
 		return err
 	}
 	if dec.KnownAccounts != nil {

--- a/core/types/transaction_conditional.go
+++ b/core/types/transaction_conditional.go
@@ -6,7 +6,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/common/math"
 )
 
 // KnownAccounts represents a set of KnownAccounts
@@ -42,7 +42,7 @@ func (ka *KnownAccount) UnmarshalJSON(data []byte) error {
 }
 
 // MarshalJSON will serialize the KnownAccount into JSON bytes.
-func (ka *KnownAccount) MarshalJSON() ([]byte, error) {
+func (ka KnownAccount) MarshalJSON() ([]byte, error) {
 	if ka.StorageRoot != nil {
 		return json.Marshal(ka.StorageRoot)
 	}
@@ -86,10 +86,10 @@ type TransactionConditional struct {
 
 // field type overrides for gencodec
 type transactionConditionalMarshalling struct {
-	BlockNumberMax *hexutil.Big
-	BlockNumberMin *hexutil.Big
-	TimestampMin   *hexutil.Uint64
-	TimestampMax   *hexutil.Uint64
+	BlockNumberMax *math.HexOrDecimal256
+	BlockNumberMin *math.HexOrDecimal256
+	TimestampMin   *math.HexOrDecimal64
+	TimestampMax   *math.HexOrDecimal64
 }
 
 // Validate will perform sanity checks on the preconditions. This does not check the aggregate cost of the preconditions.

--- a/core/types/transaction_conditional_test.go
+++ b/core/types/transaction_conditional_test.go
@@ -204,11 +204,19 @@ func TestTransactionConditionalSerDeser(t *testing.T) {
 		},
 		{
 			name:     "BlockNumberMax",
-			input:    `{"blockNumberMin":"0x1", "blockNumberMax":"0x2"}`,
+			input:    `{"blockNumberMax":"0x2"}`,
 			mustFail: false,
 			expected: TransactionConditional{
-				BlockNumberMin: big.NewInt(1),
 				BlockNumberMax: big.NewInt(2),
+			},
+		},
+		{
+			name:     "BlockNumber (decimal)",
+			input:    `{"blockNumberMin": 0, "blockNumberMax": 1}`,
+			mustFail: false,
+			expected: TransactionConditional{
+				BlockNumberMin: big.NewInt(0),
+				BlockNumberMax: big.NewInt(1),
 			},
 		},
 		{
@@ -228,10 +236,13 @@ func TestTransactionConditionalSerDeser(t *testing.T) {
 			},
 		},
 		{
-			name:     "UnknownField",
-			input:    `{"foobarbaz": 1234}`,
-			mustFail: true,
-			expected: TransactionConditional{KnownAccounts: nil},
+			name:     "Timestamp (decimal)",
+			input:    `{"timestampMin": 0, "timestampMax": 1}`,
+			mustFail: false,
+			expected: TransactionConditional{
+				TimestampMin: uint64Ptr(0),
+				TimestampMax: uint64Ptr(1),
+			},
 		},
 	}
 


### PR DESCRIPTION
KnownAccounts should not use a pointer receiver for `MarshalJSON`. We can also leverage the `math.HexOrDecimal` to be more lenient when deserializing the conditional number values