### PR TITLE
skip state db op when NoBaseFee is true

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -583,23 +583,23 @@ func (st *StateTransition) innerTransitionDb() (*ExecutionResult, error) {
 		if rules.IsEIP4762 && fee.Sign() != 0 {
 			st.evm.AccessEvents.AddAccount(st.evm.Context.Coinbase, true)
 		}
-	}
 
-	// Check that we are post bedrock to enable op-geth to be able to create pseudo pre-bedrock blocks (these are pre-bedrock, but don't follow l2 geth rules)
-	// Note optimismConfig will not be nil if rules.IsOptimismBedrock is true
-	if optimismConfig := st.evm.ChainConfig().Optimism; optimismConfig != nil && rules.IsOptimismBedrock && !st.msg.IsDepositTx {
-		gasCost := new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), st.evm.Context.BaseFee)
-		amtU256, overflow := uint256.FromBig(gasCost)
-		if overflow {
-			return nil, fmt.Errorf("optimism gas cost overflows U256: %d", gasCost)
-		}
-		st.state.AddBalance(params.OptimismBaseFeeRecipient, amtU256, tracing.BalanceIncreaseRewardTransactionFee)
-		if l1Cost := st.evm.Context.L1CostFunc(st.msg.RollupCostData, st.evm.Context.Time); l1Cost != nil {
-			amtU256, overflow = uint256.FromBig(l1Cost)
+		// Check that we are post bedrock to enable op-geth to be able to create pseudo pre-bedrock blocks (these are pre-bedrock, but don't follow l2 geth rules)
+		// Note optimismConfig will not be nil if rules.IsOptimismBedrock is true
+		if optimismConfig := st.evm.ChainConfig().Optimism; optimismConfig != nil && rules.IsOptimismBedrock && !st.msg.IsDepositTx {
+			gasCost := new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), st.evm.Context.BaseFee)
+			amtU256, overflow := uint256.FromBig(gasCost)
 			if overflow {
-				return nil, fmt.Errorf("optimism l1 cost overflows U256: %d", l1Cost)
+				return nil, fmt.Errorf("optimism gas cost overflows U256: %d", gasCost)
 			}
-			st.state.AddBalance(params.OptimismL1FeeRecipient, amtU256, tracing.BalanceIncreaseRewardTransactionFee)
+			st.state.AddBalance(params.OptimismBaseFeeRecipient, amtU256, tracing.BalanceIncreaseRewardTransactionFee)
+			if l1Cost := st.evm.Context.L1CostFunc(st.msg.RollupCostData, st.evm.Context.Time); l1Cost != nil {
+				amtU256, overflow = uint256.FromBig(l1Cost)
+				if overflow {
+					return nil, fmt.Errorf("optimism l1 cost overflows U256: %d", l1Cost)
+				}
+				st.state.AddBalance(params.OptimismL1FeeRecipient, amtU256, tracing.BalanceIncreaseRewardTransactionFee)
+			}
 		}
 	}
 


### PR DESCRIPTION
There's no need to do extra state db operations when NoBaseFee is set and the fee fields are 0.

This PR makes the balance handling for `OptimismBaseFeeRecipient` and `OptimismL1FeeRecipient` consistent with `Context.Coinbase`.

It'll also save a few cpu cycles for rpc calls like `eth_call`/`eth_estimate`.
