### PR TITLE
add ability to control DA required by blocks produced by the builder

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -568,9 +568,23 @@ func (pool *LegacyPool) Pending(filter txpool.PendingFilter) map[common.Address]
 				}
 			}
 		}
+		if filter.MaxDATxSize != nil && !pool.locals.contains(addr) {
+			for i, tx := range txs {
+				estimate := types.EstimatedL1SizeScaled(tx.RollupCostData())
+				estimate = estimate.Div(estimate, big.NewInt(1e6))
+				if estimate.Cmp(filter.MaxDATxSize) > 0 {
+					log.Debug("filtering tx that exceeds max da tx size",
+						"hash", tx.Hash(), "txda", estimate, "dalimit", filter.MaxDATxSize)
+					txs = txs[:i]
+					break
+				}
+			}
+		}
 		if len(txs) > 0 {
 			lazies := make([]*txpool.LazyTransaction, len(txs))
 			for i := 0; i < len(txs); i++ {
+				daBytes := types.EstimatedL1SizeScaled(txs[i].RollupCostData())
+				daBytes = daBytes.Div(daBytes, big.NewInt(1e6))
 				lazies[i] = &txpool.LazyTransaction{
 					Pool:      pool,
 					Hash:      txs[i].Hash(),
@@ -580,6 +594,7 @@ func (pool *LegacyPool) Pending(filter txpool.PendingFilter) map[common.Address]
 					GasTipCap: uint256.MustFromBig(txs[i].GasTipCap()),
 					Gas:       txs[i].Gas(),
 					BlobGas:   txs[i].BlobGas(),
+					DABytes:   daBytes,
 				}
 			}
 			pending[addr] = lazies

--- a/core/txpool/subpool.go
+++ b/core/txpool/subpool.go
@@ -41,6 +41,8 @@ type LazyTransaction struct {
 
 	Gas     uint64 // Amount of gas required by the transaction
 	BlobGas uint64 // Amount of blob gas required by the transaction
+
+	DABytes *big.Int // Amount of data availability bytes this transaction may require if this is a rollup
 }
 
 // Resolve retrieves the full transaction belonging to a lazy handle if it is still
@@ -83,6 +85,10 @@ type PendingFilter struct {
 
 	OnlyPlainTxs bool // Return only plain EVM transactions (peer-join announces, block space filling)
 	OnlyBlobTxs  bool // Return only blob transactions (block blob-space filling)
+
+	// OP stack addition: Maximum l1 data size allowed for an included transaction (for throttling
+	// when batcher is backlogged). Ignored if nil.
+	MaxDATxSize *big.Int
 }
 
 // SubPool represents a specialized transaction pool that lives on its own (e.g.

--- a/eth/api_miner.go
+++ b/eth/api_miner.go
@@ -56,3 +56,10 @@ func (api *MinerAPI) SetGasLimit(gasLimit hexutil.Uint64) bool {
 	api.e.Miner().SetGasCeil(uint64(gasLimit))
 	return true
 }
+
+// SetMaxDASize sets the maximum data availability size of any tx allowed in a block, and the total max l1 data size of
+// the block. 0 means no maximum.
+func (api *MinerAPI) SetMaxDASize(maxTxSize hexutil.Big, maxBlockSize hexutil.Big) bool {
+	api.e.Miner().SetMaxDASize(maxTxSize.ToInt(), maxBlockSize.ToInt())
+	return true
+}

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -671,6 +671,12 @@ web3._extend({
 			params: 1,
 			inputFormatter: [web3._extend.utils.fromDecimal]
 		}),
+		new web3._extend.Method({
+			name: 'setMaxDASize',
+			call: 'miner_setMaxDASize',
+			params: 2,
+			inputFormatter: [web3._extend.utils.fromDecimal, web3._extend.utils.fromDecimal]
+		}),
 	],
 	properties: []
 });


### PR DESCRIPTION
**Description**

Adds a function that allows an external control mechanism to throttle data availability usage by limiting the total DA requirements of transactions/blocks.

**Tests**

Unit tests demonstrating setting the values results in transactions getting appropriately filtered from the payload.

Running these changes on base-sepolia where I ran some manual invocations of the tx-size filter and confirmed they were being appropriately delayed from block inclusion until the filter was disabled.

**Additional context**

**Metadata**
