### PR TITLE
Enable parallel prefetching of nodes within the same storage trie

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -495,6 +495,12 @@ var (
 		Usage:    "Disable heuristic state prefetch during block import (less CPU and disk IO, more time waiting for data)",
 		Category: flags.PerfCategory,
 	}
+	CachePrefetcherParallelismFlag = &cli.IntFlag{
+		Name:     "cache.prefetcher.parallelism",
+		Usage:    "Maximum number of concurrent disk reads trie prefetcher should perform at once",
+		Value:    16,
+		Category: flags.PerfCategory,
+	}
 	CachePreimagesFlag = &cli.BoolFlag{
 		Name:     "cache.preimages",
 		Usage:    "Enable recording the SHA3/keccak preimages of trie keys",
@@ -2331,15 +2337,16 @@ func MakeChain(ctx *cli.Context, stack *node.Node, readonly bool) (*core.BlockCh
 		Fatalf("%v", err)
 	}
 	cache := &core.CacheConfig{
-		TrieCleanLimit:      ethconfig.Defaults.TrieCleanCache,
-		TrieCleanNoPrefetch: ctx.Bool(CacheNoPrefetchFlag.Name),
-		TrieDirtyLimit:      ethconfig.Defaults.TrieDirtyCache,
-		TrieDirtyDisabled:   ctx.String(GCModeFlag.Name) == "archive",
-		TrieTimeLimit:       ethconfig.Defaults.TrieTimeout,
-		SnapshotLimit:       ethconfig.Defaults.SnapshotCache,
-		Preimages:           ctx.Bool(CachePreimagesFlag.Name),
-		StateScheme:         scheme,
-		StateHistory:        ctx.Uint64(StateHistoryFlag.Name),
+		TrieCleanLimit:            ethconfig.Defaults.TrieCleanCache,
+		TrieCleanNoPrefetch:       ctx.Bool(CacheNoPrefetchFlag.Name),
+		TrieDirtyLimit:            ethconfig.Defaults.TrieDirtyCache,
+		TrieDirtyDisabled:         ctx.String(GCModeFlag.Name) == "archive",
+		TrieTimeLimit:             ethconfig.Defaults.TrieTimeout,
+		TriePrefetcherParallelism: ctx.Int(CachePrefetcherParallelismFlag.Name),
+		SnapshotLimit:             ethconfig.Defaults.SnapshotCache,
+		Preimages:                 ctx.Bool(CachePreimagesFlag.Name),
+		StateScheme:               scheme,
+		StateHistory:              ctx.Uint64(StateHistoryFlag.Name),
 	}
 	if cache.TrieDirtyDisabled && !cache.Preimages {
 		cache.Preimages = true

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2543,3 +2543,11 @@ func (bc *BlockChain) SetTrieFlushInterval(interval time.Duration) {
 func (bc *BlockChain) GetTrieFlushInterval() time.Duration {
 	return time.Duration(bc.flushInterval.Load())
 }
+
+// CacheConfig returns a reference to [bc.cacheConfig]
+//
+// This is used by [miner] to set prefetch parallelism
+// during block building.
+func (bc *BlockChain) CacheConfig() *CacheConfig {
+	return bc.cacheConfig
+}

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -204,7 +204,7 @@ func (s *StateDB) SetLogger(l *tracing.Hooks) {
 // StartPrefetcher initializes a new trie prefetcher to pull in nodes from the
 // state trie concurrently while the state is mutated so that when we reach the
 // commit phase, most of the needed data is already hot.
-func (s *StateDB) StartPrefetcher(namespace string, witness *stateless.Witness) {
+func (s *StateDB) StartPrefetcher(namespace string, witness *stateless.Witness, maxConcurrency int) {
 	// Terminate any previously running prefetcher
 	s.StopPrefetcher()
 
@@ -220,7 +220,7 @@ func (s *StateDB) StartPrefetcher(namespace string, witness *stateless.Witness) 
 	// To prevent this, the account trie is always scheduled for prefetching once
 	// the prefetcher is constructed. For more details, see:
 	// https://github.com/ethereum/go-ethereum/issues/29880
-	s.prefetcher = newTriePrefetcher(s.db, s.originalRoot, namespace, witness == nil)
+	s.prefetcher = newTriePrefetcher(s.db, s.originalRoot, namespace, witness == nil, maxConcurrency)
 	if err := s.prefetcher.prefetch(common.Hash{}, s.originalRoot, common.Address{}, nil, false); err != nil {
 		log.Error("Failed to prefetch account trie", "root", s.originalRoot, "err", err)
 	}

--- a/core/state/trie_prefetcher_test.go
+++ b/core/state/trie_prefetcher_test.go
@@ -50,7 +50,7 @@ func filledStateDB() *StateDB {
 
 func TestUseAfterTerminate(t *testing.T) {
 	db := filledStateDB()
-	prefetcher := newTriePrefetcher(db.db, db.originalRoot, "", true)
+	prefetcher := newTriePrefetcher(db.db, db.originalRoot, "", true, 4)
 	skey := common.HexToHash("aaa")
 
 	if err := prefetcher.prefetch(common.Hash{}, db.originalRoot, common.Address{}, [][]byte{skey.Bytes()}, false); err != nil {
@@ -87,7 +87,7 @@ func TestVerklePrefetcher(t *testing.T) {
 
 	state, _ = New(root, sdb)
 	sRoot := state.GetStorageRoot(addr)
-	fetcher := newTriePrefetcher(sdb, root, "", false)
+	fetcher := newTriePrefetcher(sdb, root, "", false, 4)
 
 	// Read account
 	fetcher.prefetch(common.Hash{}, root, common.Address{}, [][]byte{

--- a/eth/api_debug.go
+++ b/eth/api_debug.go
@@ -474,7 +474,7 @@ func generateWitness(blockchain *core.BlockChain, block *types.Block) (*stateles
 		return nil, fmt.Errorf("failed to retrieve parent state: %w", err)
 	}
 
-	statedb.StartPrefetcher("debug_execution_witness", witness)
+	statedb.StartPrefetcher("debug_execution_witness", witness, blockchain.CacheConfig().TriePrefetcherParallelism)
 	defer statedb.StopPrefetcher()
 
 	res, err := blockchain.Processor().Process(block, statedb, *blockchain.GetVMConfig())

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -331,7 +331,7 @@ func (miner *Miner) makeEnv(parent *types.Header, header *types.Header, coinbase
 		if err != nil {
 			return nil, err
 		}
-		state.StartPrefetcher("miner", bundle)
+		state.StartPrefetcher("miner", bundle, miner.backend.BlockChain().CacheConfig().TriePrefetcherParallelism)
 	}
 	// Note the passed coinbase may be different with header.Coinbase.
 	return &environment{


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This extends the statedb prefetcher to support parallel fetches within the context of a single trie. The purpose of the statedb prefetcher is only to prewarm database caches, ensuring that all trie nodes are quickly accessible when computing the MPT state root.

Without this change, the statedb's prefetcher will perform concurrent fetching jobs for each unique trie, but perform all fetches for each trie sequentially. In certain cases, such as blocks which contain a large number of storage updates in a single large trie, this sequential prefetching behavior can result in a significant performance degradation. In extreme cases, blocks may contain updates to thousands of storage slots in a single trie, which are then fetched entirely sequentially.

This implementation utilizes a fixed worker pool per prefetcher, and allows the per-trie subfetcher to clone this trie up to N times for a given max concurrency limit of N goroutines. This approach was chosen because the trie itself is not safe for concurrent use, and the cost of copying the trie is negligible when compared to the round-trip latency of fetching the associated trie nodes from the local database.

This selects a somewhat-arbitrary 16 goroutines as the default concurrency limit for the prefetcher based on some locally-run benchmarking results on a M1 Pro with 16GB of memory, using a matrix of `trieSize` (1k, 100k, 10M), `keyCount` (10, 100, 1k, 10k), and `maxConcurrency` (1, 4, 16, 64) values. We see that there is a minor increase in overhead associated with concurrent access when accessing tries containing fewer than 1000 nodes, but around a 10x reduction in latency when accessing at least 10 keys from very large tries (10M keys). This is likely a worthwhile tradeoff for high-throughput EVM chains, as this improvement directly targets a subset of the worst-performing blocks.

**Tests**

TODO: include links to benchmarking code.

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

See https://github.com/ethereum/go-ethereum/issues/28266 for additional context and prior discussions.