### PR TITLE
Use CrossUnsafe for Interop Ingress Filter

### DIFF
--- a/core/txpool/ingress_filters.go
+++ b/core/txpool/ingress_filters.go
@@ -53,5 +53,7 @@ func (f *interopFilter) FilterTx(ctx context.Context, tx *types.Transaction) boo
 	ctx, cancel := context.WithTimeout(ctx, time.Second*2)
 	defer cancel()
 	// check with the supervisor if the transaction should be allowed given the executing messages
-	return f.checkFn(ctx, ems, interoptypes.Unsafe) == nil
+	// the message can be unsafe (discovered only via P2P unsafe blocks), but it must be cross-valid
+	// so CrossUnsafe is used here
+	return f.checkFn(ctx, ems, interoptypes.CrossUnsafe) == nil
 }


### PR DESCRIPTION
Using only `Unsafe` opens the possibility that the EM is known, but not indexed (or awaiting data which would validate it), which might sometimes allow EMs which won't pass the miner's checks.