### PR TITLE
refactor: remove unnecessary code

### DIFF
--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -430,8 +430,6 @@ func (api *ConsensusAPI) forkchoiceUpdated(update engine.ForkchoiceStateV1, payl
 			log.Warn("Safe block not in canonical chain")
 			return engine.STATUS_INVALID, engine.InvalidForkChoiceState.With(errors.New("safe block not in canonical chain"))
 		}
-		// Set the safe block
-		api.eth.BlockChain().SetSafe(safeBlock.Header())
 	}
 	// If payload generation was requested, create a new block to be potentially
 	// sealed by the beacon client. The payload will be requested later, and we


### PR DESCRIPTION
**Description**

This PR removes redundant code that unnecessarily overwrites an already valid `safeHead` with the same value. Since the existing `safeHead` is already valid and there is no need to reassign it, the highlighted section of code has been removed. This cleanup improves maintainability and avoids redundant operations.

**Tests**

No new tests were added as this change removes redundant code that does not alter any existing functionality or behavior. All existing tests have been verified to pass without modifications.

**Additional context**

The removed code attempted to reassign `safeHead` even when the current `safeHead` was already valid and up-to-date. This change simplifies the logic and ensures that unnecessary operations are avoided.

**Metadata**

- This PR is a minor cleanup and does not resolve or depend on any existing issue.