### PR TITLE
core: fix call to post-validation evm message hook

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -155,6 +155,8 @@ type Message struct {
 	Mint           *big.Int             // Mint is the amount to mint before EVM processing, or nil if there is no minting.
 	RollupCostData types.RollupCostData // RollupCostData caches data to compute the fee we charge for data availability
 
+	// PostValidation is an optional check of the resulting post-state, if and when the message is
+	// applied fully to the EVM. This function may return an error to deny inclusion of the message.
 	PostValidation func(evm *vm.EVM, result *ExecutionResult) error
 }
 
@@ -450,7 +452,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		err = nil
 	}
 
-	if st.msg.PostValidation != nil {
+	if err == nil && st.msg.PostValidation != nil {
 		if err := st.msg.PostValidation(st.evm, result); err != nil {
 			return nil, err
 		}

--- a/miner/miner_test.go
+++ b/miner/miner_test.go
@@ -188,8 +188,8 @@ func TestRejectedConditionalTx(t *testing.T) {
 	})
 	tx.SetConditional(&types.TransactionConditional{TimestampMax: uint64Ptr(timestamp - 1)})
 
-	// 1 pending tx
-	miner.txpool.Add(types.Transactions{tx}, true, false)
+	// 1 pending tx (synchronously, it has to be there before it can be rejected)
+	miner.txpool.Add(types.Transactions{tx}, true, true)
 	if !miner.txpool.Has(tx.Hash()) {
 		t.Fatalf("conditional tx is not in the mempool")
 	}


### PR DESCRIPTION
**Description**

The post-validation check was running even when the EVM aborted without returning an execution-result. E.g. this may happen during block-building, when a tx does not pass state-transition pre-checks, and inclusion is aborted.

This post-validation hook was only set when the experimental Interop fork functionality is enabled, and thus not a production issue for mainnet.

**Tests**

E2E tests hit block-building code-path, although with flakes. I'll look into regression-testing it, but creating a more deliberate version of it e.g. with an action-test might mean it ignores the tx before even running the pre-checks.

**Additional context**

Reported by @mslipper, example in: https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/72874/workflows/2ec0d66a-c736-4e19-ad98-031fb11428db/jobs/2986089/steps 
