### PR TITLE
op-batcher: exit building loop early if there's not enough DA capacity

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -545,6 +545,12 @@ func (miner *Miner) commitTransactions(env *environment, plainTxs, blobTxs *tran
 				log.Debug("adding tx would exceed block DA size limit",
 					"hash", ltx.Hash, "txda", ltx.DABytes, "blockda", blockDABytes, "dalimit", miner.config.MaxDABlockSize)
 				txs.Pop()
+				// If the number of remaining bytes is too few to hold even the minimum possible transaction size,
+				// then we can stop early.
+				daBytesRemaining := new(big.Int).Sub(miner.config.MaxDABlockSize, daBytesAfter)
+				if daBytesRemaining.Cmp(types.MinTransactionSize) < 0 {
+					break
+				}
 				continue
 			}
 		}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Minor optimization:

If there is not enough DA capacity remaining in the block being built to support a minimum sized transaction, then block building can exit early.

**Context**

We see the DA filtering log line being triggered frequently due to this situation in Base mainnet logs.
