### PR TITLE
tracing: fix BalanceChangeReason stringer

### DIFF
--- a/core/tracing/gen_balance_change_reason_stringer.go
+++ b/core/tracing/gen_balance_change_reason_stringer.go
@@ -23,15 +23,25 @@ func _() {
 	_ = x[BalanceIncreaseSelfdestruct-12]
 	_ = x[BalanceDecreaseSelfdestruct-13]
 	_ = x[BalanceDecreaseSelfdestructBurn-14]
+	_ = x[BalanceMint-200]
 }
 
-const _BalanceChangeReason_name = "BalanceChangeUnspecifiedBalanceIncreaseRewardMineUncleBalanceIncreaseRewardMineBlockBalanceIncreaseWithdrawalBalanceIncreaseGenesisBalanceBalanceIncreaseRewardTransactionFeeBalanceDecreaseGasBuyBalanceIncreaseGasReturnBalanceIncreaseDaoContractBalanceDecreaseDaoAccountBalanceChangeTransferBalanceChangeTouchAccountBalanceIncreaseSelfdestructBalanceDecreaseSelfdestructBalanceDecreaseSelfdestructBurn"
+const (
+	_BalanceChangeReason_name_0 = "BalanceChangeUnspecifiedBalanceIncreaseRewardMineUncleBalanceIncreaseRewardMineBlockBalanceIncreaseWithdrawalBalanceIncreaseGenesisBalanceBalanceIncreaseRewardTransactionFeeBalanceDecreaseGasBuyBalanceIncreaseGasReturnBalanceIncreaseDaoContractBalanceDecreaseDaoAccountBalanceChangeTransferBalanceChangeTouchAccountBalanceIncreaseSelfdestructBalanceDecreaseSelfdestructBalanceDecreaseSelfdestructBurn"
+	_BalanceChangeReason_name_1 = "BalanceMint"
+)
 
-var _BalanceChangeReason_index = [...]uint16{0, 24, 54, 84, 109, 138, 173, 194, 218, 244, 269, 290, 315, 342, 369, 400}
+var (
+	_BalanceChangeReason_index_0 = [...]uint16{0, 24, 54, 84, 109, 138, 173, 194, 218, 244, 269, 290, 315, 342, 369, 400}
+)
 
 func (i BalanceChangeReason) String() string {
-	if i >= BalanceChangeReason(len(_BalanceChangeReason_index)-1) {
+	switch {
+	case i <= 14:
+		return _BalanceChangeReason_name_0[_BalanceChangeReason_index_0[i]:_BalanceChangeReason_index_0[i+1]]
+	case i == 200:
+		return _BalanceChangeReason_name_1
+	default:
 		return "BalanceChangeReason(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
-	return _BalanceChangeReason_name[_BalanceChangeReason_index[i]:_BalanceChangeReason_index[i+1]]
 }

--- a/fork.yaml
+++ b/fork.yaml
@@ -336,6 +336,10 @@ def:
           # upstream PR: https://github.com/ethereum/go-ethereum/pull/28863/
           globs:
             - "accounts/usbwallet/hub.go"
+    - title: Code-generation
+      description: Some code files are auto-generated, based on changes elsewhere.
+      ignore:
+        - "core/tracing/gen_balance_change_reason_stringer.go"
     - title: "Testing"
       description: Additional or modified tests, not already captured by the above diff
       ignore:


### PR DESCRIPTION
**Description**

op-geth was missing a `go:generate` run to update the balance stringer.

**Metadata**

Fixes https://github.com/ethereum-optimism/op-geth/issues/408
