### PR TITLE
core: Move blockchain head verification after possible rewind

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -410,10 +410,6 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 			}
 		}
 	}
-	// The first thing the node will do is reconstruct the verification data for
-	// the head block (ethash cache or clique voting snapshot). Might as well do
-	// it in advance.
-	bc.engine.VerifyHeader(bc, bc.CurrentHeader())
 
 	if bc.logger != nil && bc.logger.OnBlockchainInit != nil {
 		bc.logger.OnBlockchainInit(chainConfig)
@@ -466,6 +462,11 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 		}
 		rawdb.WriteChainConfig(db, genesisHash, chainConfig)
 	}
+
+	// The first thing the node will do is reconstruct the verification data for
+	// the head block (ethash cache or clique voting snapshot). Might as well do
+	// it in advance.
+	bc.engine.VerifyHeader(bc, bc.CurrentHeader())
 
 	// Start tx indexer if it's enabled.
 	if txLookupLimit != nil {

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -382,9 +382,6 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedb.Database, g
 	newcfg := genesis.configOrDefault(stored)
 	applyOverrides(newcfg)
 
-	newData, _ := json.Marshal(newcfg)
-	log.Info("New config", "json", newData)
-
 	if err := newcfg.CheckConfigForkOrder(); err != nil {
 		return newcfg, common.Hash{}, err
 	}
@@ -396,7 +393,7 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedb.Database, g
 	}
 
 	storedData, _ := json.Marshal(storedcfg)
-	log.Info("Stored config", "json", storedData)
+	log.Info("Stored config", "json", string(storedData))
 	// Special case: if a private network is being used (no genesis and also no
 	// mainnet hash in the database), we must not apply the `configOrDefault`
 	// chain config as that would be AllProtocolChanges (applying any new fork
@@ -406,6 +403,9 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedb.Database, g
 		newcfg = storedcfg
 		applyOverrides(newcfg)
 	}
+	newData, _ := json.Marshal(newcfg)
+	log.Info("New config", "json", string(newData), "genesis-nil", genesis == nil)
+
 	// Check config compatibility and write the config. Compatibility errors
 	// are returned to the caller unless we're already at block zero.
 	head := rawdb.ReadHeadHeader(db)
@@ -420,6 +420,7 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *triedb.Database, g
 	if compatErr != nil && ((head.Number.Uint64() != 0 && compatErr.RewindToBlock != 0) || (head.Time != 0 && compatErr.RewindToTime != 0)) {
 		return newcfg, stored, compatErr
 	}
+
 	// Don't overwrite if the old is identical to the new
 	if !bytes.Equal(storedData, newData) {
 		log.Info("Configs differ")

--- a/params/config.go
+++ b/params/config.go
@@ -21,6 +21,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params/forks"
 )
 
@@ -709,6 +710,7 @@ func (c *ChainConfig) CheckCompatible(newcfg *ChainConfig, height, time uint64, 
 	var lasterr *ConfigCompatError
 	for {
 		err := c.checkCompatible(newcfg, bhead, btime, genesisTimestamp)
+		log.Info("Checking compatibility", "height", bhead, "time", btime, "error", err)
 		if err == nil || (lasterr != nil && err.RewindToBlock == lasterr.RewindToBlock && err.RewindToTime == lasterr.RewindToTime) {
 			break
 		}

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -156,6 +156,18 @@ func TestCheckCompatible(t *testing.T) {
 				RewindToTime: 9,
 			},
 		},
+		{
+			stored:           &ChainConfig{HoloceneTime: newUint64(10)},
+			new:              &ChainConfig{HoloceneTime: newUint64(20)},
+			headTimestamp:    15,
+			genesisTimestamp: newUint64(5),
+			wantErr: &ConfigCompatError{
+				What:         "Holocene fork timestamp",
+				StoredTime:   newUint64(10),
+				NewTime:      newUint64(20),
+				RewindToTime: 9,
+			},
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
**Description**

If the blockchain needs a rewind due to a config change, it makes more sense to first perform that rewind and only then check the chain head's validity. The change in config might cause the loaded chain's head to be invalid before the rewind.

**Tests**

Tested on broken local Ink Sepolia node - it successfully helped recovering it from a missed Holocene activation.
