### PR TITLE
core: make isForkTimestampIncompatible return false when either fork is post genesis

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -955,7 +955,7 @@ func configBlockEqual(x, y *big.Int) bool {
 // isForkTimestampIncompatible returns true if a fork scheduled at timestamp s1
 // cannot be rescheduled to timestamp s2 because head is already past the fork.
 func isForkTimestampIncompatible(s1, s2 *uint64, head uint64, genesis *uint64) bool {
-	return (isTimestampForked(s1, head) || isTimestampForked(s2, head)) && !configTimestampEqual(s1, s2) && !isTimestampPreGenesis(s1, genesis) && !isTimestampPreGenesis(s2, genesis)
+	return (isTimestampForked(s1, head) || isTimestampForked(s2, head)) && !configTimestampEqual(s1, s2) && (!isTimestampPreGenesis(s1, genesis) || !isTimestampPreGenesis(s2, genesis))
 }
 
 func isTimestampPreGenesis(s, genesis *uint64) bool {

--- a/params/config.go
+++ b/params/config.go
@@ -955,7 +955,7 @@ func configBlockEqual(x, y *big.Int) bool {
 // isForkTimestampIncompatible returns true if a fork scheduled at timestamp s1
 // cannot be rescheduled to timestamp s2 because head is already past the fork.
 func isForkTimestampIncompatible(s1, s2 *uint64, head uint64, genesis *uint64) bool {
-	return (isTimestampForked(s1, head) || isTimestampForked(s2, head)) && !configTimestampEqual(s1, s2) && (!isTimestampPreGenesis(s1, genesis) || !isTimestampPreGenesis(s2, genesis))
+	return (isTimestampForked(s1, head) || isTimestampForked(s2, head)) && !configTimestampEqual(s1, s2) && !(isTimestampPreGenesis(s1, genesis) && isTimestampPreGenesis(s2, genesis))
 }
 
 func isTimestampPreGenesis(s, genesis *uint64) bool {

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -144,6 +144,18 @@ func TestCheckCompatible(t *testing.T) {
 			genesisTimestamp: newUint64(24),
 			wantErr:          nil,
 		},
+		{
+			stored:           &ChainConfig{HoloceneTime: newUint64(10)},
+			new:              &ChainConfig{HoloceneTime: newUint64(20)},
+			headTimestamp:    25,
+			genesisTimestamp: newUint64(15),
+			wantErr: &ConfigCompatError{
+				What:         "Holocene fork timestamp",
+				StoredTime:   newUint64(10),
+				NewTime:      newUint64(20),
+				RewindToTime: 9,
+			},
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
If a hardfork activation timestamp is moved from before genesis to after, or from after to before genesis, this could modify the chain history and should be detected as an incompatibility requiring a database rewind. 

This PR adds a test for that situation (failing on the base branch) plus a one line fix. 