### PR TITLE
beacon: add nil check for AccessEvents receiver before invocation

### DIFF
--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -410,7 +410,10 @@ func (beacon *Beacon) FinalizeAndAssemble(chain consensus.ChainHeaderReader, hea
 		// State-root has just been computed, we can get an accurate storage-root now.
 		h := state.GetStorageRoot(params.OptimismL2ToL1MessagePasser)
 		header.WithdrawalsHash = &h
-		state.AccessEvents().AddAccount(params.OptimismL2ToL1MessagePasser, false) // include in execution witness
+		sa := state.AccessEvents()
+		if sa != nil {
+			sa.AddAccount(params.OptimismL2ToL1MessagePasser, false) // include in execution witness
+		}
 	}
 
 	// Assemble the final block.


### PR DESCRIPTION

**Description**

If Isthmus is activated, we attempt to add the L2ToL1MessagePasser to state access events. Check that AccessEvents exists before attempting to AddAccount


**Tests**

None

**Additional context**

https://github.com/ethereum-optimism/op-geth/pull/451 added a change to update the state access events. [Action tests](https://github.com/ethereum-optimism/optimism/pull/12925) for Isthmus in the monorepo uncovered this bug.

**Metadata**

None.
