### PR TITLE
ci: add build-and-deploy job for GitHub Pages deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,11 +78,11 @@ jobs:
       - run:
           name: Build pages
           command: |
-            mkdir -p tmp/pages
-            mv index.html tmp/pages/index.html
-            touch tmp/pages/.nojekyll
+            mkdir -p /tmp/pages
+            mv index.html /tmp/pages/index.html
+            touch /tmp/pages/.nojekyll
             if [ "$CIRCLE_PROJECT_REPONAME" == "op-geth" ] && [ "$CIRCLE_PROJECT_USERNAME" == "ethereum-optimism" ]; then
-              echo "op-geth.optimism.io" > tmp/pages/CNAME
+              echo "op-geth.optimism.io" > /tmp/pages/CNAME
             fi
 
       # Deploy to GitHub Pages
@@ -99,7 +99,7 @@ jobs:
             rm -rf *
 
             # Copy new files
-            cp -a tmp/pages/. .
+            cp -a /tmp/pages/. .
 
             # Commit and push
             git add .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,6 @@ jobs:
             git fetch --depth 1000
 
       # Build forkdiff using Docker
-      - setup_remote_docker
       - run:
           name: Build forkdiff
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,8 +110,7 @@ jobs:
             # Commit and push
             git add .
             git commit -m "Deploy to GitHub Pages [skip ci]"
-            echo "${GITHUB_APP_TOKEN}" > gh-token
-            # git -c "http.extraheader=Authorization: Bearer ${GITHUB_APP_TOKEN}"  push origin ${pages_branch} --force
+            git push "https://x-access-token:${GITHUB_APP_TOKEN}@github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git" ${pages_branch} --force
 
   docker-release:
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,17 +91,12 @@ jobs:
           command: |
             pages_branch="gh-pages-test"
 
-            # Create or switch to gh-pages branch
-            if git ls-remote --heads origin ${pages_branch}; then
-              git fetch origin ${pages_branch}
-              git checkout ${pages_branch}
-            else
-              git checkout --orphan ${pages_branch}
-              git rm -rf .
-            fi
+            # Create new orphan branch without parent history
+            git checkout --orphan ${pages_branch}
+            git reset --hard  # Remove all files from staging
 
-            # Clean existing files (equivalent to clean: true)
-            git rm -rf .
+            # Clean working directory
+            rm -rf *
 
             # Copy new files
             cp -a tmp/pages/. .
@@ -109,6 +104,7 @@ jobs:
             # Commit and push
             git add .
             git commit -m "Deploy to GitHub Pages [skip ci]"
+
             # git push origin ${pages_branch} --force
 
   docker-release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ jobs:
 
             # Commit and push
             git add .
-            git commit -m "Deploy to GitHub Pages [skip ci]"
+            git commit -m "Deploying to gh-pages from @ ${SOURCE_REPO}@${SOURCE_COMMIT} 🚀"
             git push "https://x-access-token:${GITHUB_APP_TOKEN}@github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git" ${pages_branch} --force
 
   docker-release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,10 +305,4 @@ workflows:
           context: circleci-repo-op-geth
           filters:
             branches:
-              only: migrate-to-circleci
-
-      # - build-and-deploy:
-      #   context: circleci-repo-op-geth
-      #     filters:
-      #       branches:
-      #         only: optimism
+              only: optimism

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ version: 2.1
 orbs:
   gcp-cli: circleci/gcp-cli@3.0.1
   slack: circleci/slack@4.10.1
+  utils: ethereum-optimism/circleci-utils@0.0.7
 
 parameters:
   go_version:
@@ -88,7 +89,27 @@ jobs:
       - run:
           name: Deploy to GitHub Pages
           command: |
-            echo "here we would deploy"
+            pages_branch="gh-pages-test"
+
+            # Create or switch to gh-pages branch
+            if git ls-remote --heads origin ${pages_branch}; then
+              git fetch origin ${pages_branch}
+              git checkout ${pages_branch}
+            else
+              git checkout --orphan ${pages_branch}
+              git rm -rf .
+            fi
+
+            # Clean existing files (equivalent to clean: true)
+            git rm -rf .
+
+            # Copy new files
+            cp -a tmp/pages/. .
+
+            # Commit and push
+            git add .
+            git commit -m "Deploy to GitHub Pages [skip ci]"
+            # git push origin ${pages_branch} --force
 
   docker-release:
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,12 +84,18 @@ jobs:
             if [ "$CIRCLE_PROJECT_REPONAME" == "op-geth" ] && [ "$CIRCLE_PROJECT_USERNAME" == "ethereum-optimism" ]; then
               echo "op-geth.optimism.io" > /tmp/pages/CNAME
             fi
-
+      - utils/get-github-access-token:
+          private-key-str: GITHUB_APP_KEY
+          app-id: GITHUB_APP_ID
+          repo: $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
       # Deploy to GitHub Pages
       - run:
           name: Deploy to GitHub Pages
           command: |
             pages_branch="gh-pages-test"
+
+            git config --global user.email "circleci-"
+            git config --global user.name "CircleCI Bot"
 
             # Create new orphan branch without parent history
             git checkout --orphan ${pages_branch}
@@ -105,7 +111,7 @@ jobs:
             git add .
             git commit -m "Deploy to GitHub Pages [skip ci]"
 
-            git push origin ${pages_branch} --force
+            # git push origin ${pages_branch} --force
 
   docker-release:
     environment:
@@ -290,11 +296,13 @@ workflows:
   merge:
     jobs:
       - build-and-deploy:
+          context: circleci-repo-op-geth
           filters:
             branches:
               only: migrate-to-circleci
 
       # - build-and-deploy:
+      #   context: circleci-repo-op-geth
       #     filters:
       #       branches:
       #         only: optimism

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,8 +110,7 @@ jobs:
             # Commit and push
             git add .
             git commit -m "Deploy to GitHub Pages [skip ci]"
-
-            # git push origin ${pages_branch} --force
+            git -c "http.extraheader=Authorization: Bearer ${GITHUB_APP_TOKEN}"  push origin ${pages_branch} --force
 
   docker-release:
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
             git add .
             git commit -m "Deploy to GitHub Pages [skip ci]"
 
-            # git push origin ${pages_branch} --force
+            git push origin ${pages_branch} --force
 
   docker-release:
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,8 +94,15 @@ jobs:
           command: |
             pages_branch="gh-pages-test"
 
-            git config --global user.email "circleci-"
-            git config --global user.name "CircleCI Bot"
+            SOURCE_COMMIT=$(git rev-parse HEAD)
+            SOURCE_REPO="${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
+
+            COMMIT_USER_NAME=$(git log -1 --pretty=format:'%an')
+            COMMIT_USER_EMAIL=$(git log -1 --pretty=format:'%ae')
+
+            # Git operations with committer's identity
+            git config --global user.name "${COMMIT_USER_NAME}"
+            git config --global user.email "${COMMIT_USER_EMAIL}"
 
             # Create new orphan branch without parent history
             git checkout --orphan ${pages_branch}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,8 @@ jobs:
             # Commit and push
             git add .
             git commit -m "Deploy to GitHub Pages [skip ci]"
-            git -c "http.extraheader=Authorization: Bearer ${GITHUB_APP_TOKEN}"  push origin ${pages_branch} --force
+            echo "${GITHUB_APP_TOKEN}" > gh-token
+            # git -c "http.extraheader=Authorization: Bearer ${GITHUB_APP_TOKEN}"  push origin ${pages_branch} --force
 
   docker-release:
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,45 @@ commands:
             echo "export GOOGLE_APPLICATION_CREDENTIALS='<< parameters.gcp_cred_config_file_path >>'" | tee -a "$BASH_ENV"
 
 jobs:
+  build-and-deploy:
+    machine:
+      image: ubuntu-2004:current
+    steps:
+      - checkout
+      # Fetch more history for diffing
+      - run:
+          name: Fetch git history
+          command: |
+            git fetch --depth 1000
+
+      # Build forkdiff using Docker
+      - setup_remote_docker
+      - run:
+          name: Build forkdiff
+          command: |
+            docker run --volume $(pwd):/workspace \
+              protolambda/forkdiff:0.1.0 \
+              -repo=/workspace \
+              -fork=/workspace/fork.yaml \
+              -out=/workspace/index.html
+
+      # Prepare pages directory
+      - run:
+          name: Build pages
+          command: |
+            mkdir -p tmp/pages
+            mv index.html tmp/pages/index.html
+            touch tmp/pages/.nojekyll
+            if [ "$CIRCLE_PROJECT_REPONAME" == "op-geth" ] && [ "$CIRCLE_PROJECT_USERNAME" == "ethereum-optimism" ]; then
+              echo "op-geth.optimism.io" > tmp/pages/CNAME
+            fi
+
+      # Deploy to GitHub Pages
+      - run:
+          name: Deploy to GitHub Pages
+          command: |
+            echo "here we would deploy"
+
   docker-release:
     environment:
       DOCKER_BUILDKIT: 1
@@ -107,7 +146,7 @@ jobs:
               -f Dockerfile .
       - when:
           condition:
-            equal: [ true, <<parameters.push_tags>> ]
+            equal: [true, <<parameters.push_tags>>]
           steps:
             - run:
                 name: Tag
@@ -135,7 +174,6 @@ jobs:
                       --image-path="$IMAGE_PATH"\
                       --signer-logging-level="INFO"\
                       --attestor-key-id="//cloudkms.googleapis.com/v1/projects/$ATTESTOR_PROJECT_NAME/locations/global/keyRings/$ATTESTOR_NAME-key-ring/cryptoKeys/$ATTESTOR_NAME-key/cryptoKeyVersions/1"
-
 
   build-geth:
     docker:
@@ -182,7 +220,6 @@ jobs:
           event: fail
           template: basic_fail_1
 
-
 workflows:
   main:
     jobs:
@@ -228,8 +265,20 @@ workflows:
           cron: "0 0 * * *"
           filters:
             branches:
-              only: [ "optimism" ]
+              only: ["optimism"]
     jobs:
       - check-releases:
           name: Check for new upstream releases
           context: slack
+
+  merge:
+    jobs:
+      - build-and-deploy:
+          filters:
+            branches:
+              only: migrate-to-circleci
+
+      # - build-and-deploy:
+      #     filters:
+      #       branches:
+      #         only: optimism

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,8 @@
+[submodule "tests"]
+	path = tests/testdata
+	url = https://github.com/ethereum/tests
+	shallow = true
+[submodule "evm-benchmarks"]
+	path = tests/evm-benchmarks
+	url = https://github.com/ipsilon/evm-benchmarks
+	shallow = true

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,0 @@
-[submodule "tests"]
-	path = tests/testdata
-	url = https://github.com/ethereum/tests
-	shallow = true
-[submodule "evm-benchmarks"]
-	path = tests/evm-benchmarks
-	url = https://github.com/ipsilon/evm-benchmarks
-	shallow = true


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->
This pull request includes significant updates to the CircleCI configuration to add a new build and deploy job, as well as some minor changes to the `charts` submodule.

Changes to CircleCI configuration:

* [`.circleci/config.yml`](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R55-R93): Added a new `build-and-deploy` job to fetch git history, build using Docker, prepare pages, and deploy to GitHub Pages.
* [`.circleci/config.yml`](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R273-R284): Added a new `merge` workflow to run the `build-and-deploy` job only on the `migrate-to-circleci` branch.

Minor changes:

* [`charts`](diffhunk://#diff-38edf99fd46462465404fefea8ac5bd0372e0963c7884c2b9ebfe0a88912c2f7R1): Updated the submodule commit reference.
**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

This first PR will generate a site on gh-pages-test branch.
If the action works as expected we will remove the github action and promote circleci to change gh-pages branch.

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
