### PR TITLE
Fix Typo in `payload_building_test.go`

### DIFF
--- a/miner/payload_building_test.go
+++ b/miner/payload_building_test.go
@@ -278,7 +278,7 @@ func testBuildPayload(t *testing.T, noTxPool, interrupt bool, params1559 []byte)
 		}
 	}
 
-	// make sure the 1559 params we've specied (if any) ends up in both the full and empty block headers
+	// make sure the 1559 params we've specified (if any) ends up in both the full and empty block headers
 	var expected []byte
 	if len(params1559) != 0 {
 		expected = []byte{0}


### PR DESCRIPTION
# Fix Typo in `payload_building_test.go`

## Description
This pull request corrects a typo in the `payload_building_test.go` file, ensuring clarity and professionalism in the comments.

**Before**:
- `specied`

**After**:
- `specified`

## References (if applicable)
- N/A

## Checklist
- [x] Typo corrected in `payload_building_test.go`
- [ ] Code functionality remains unchanged
- [ ] Documentation updated (if applicable)
