### PR TITLE
Fix Typo in `README.md`

### DIFF
--- a/cmd/evm/README.md
+++ b/cmd/evm/README.md
@@ -27,7 +27,7 @@ which can
 ### Specification
 
 The idea is to specify the behaviour of this binary very _strict_, so that other
-node implementors can build replicas based on their own state-machines, and the
+node implementers can build replicas based on their own state-machines, and the
 state generators can swap between a \`geth\`-based implementation and a \`parityvm\`-based
 implementation.
 


### PR DESCRIPTION
# Pull Request Title: Fix Typo in `README.md` - "implementors" to "implementers"

## Summary:
This pull request corrects a typo in the `README.md` file:
- Changed the word **"implementors"** to **"implementers"** for better consistency and accuracy.

## Changes Made:
- **cmd/evm/README.md**:
  - Updated the word **"implementors"** to **"implementers"** in the description of node replicas and state-machines.

## Files Changed:
- `cmd/evm/README.md`

## Testing:
- No functional
