### PR TITLE
core: do not hash header if header is still changing

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -229,7 +229,11 @@ func ApplyTransactionExtended(config *params.ChainConfig, bc ChainContext, autho
 	blockContext := NewEVMBlockContext(header, bc, author, config, statedb)
 	txContext := NewEVMTxContext(msg)
 	vmenv := vm.NewEVM(blockContext, txContext, statedb, config, cfg)
-	return ApplyTransactionWithEVM(msg, config, gp, statedb, header.Number, header.Hash(), tx, usedGas, vmenv)
+	blockHash := common.Hash{}
+	if header.Root != (common.Hash{}) { // if the header is sealed, then hydrate the receipt with it. If not, then blockhash is still changing, not worth computing.
+		blockHash = header.Hash()
+	}
+	return ApplyTransactionWithEVM(msg, config, gp, statedb, header.Number, blockHash, tx, usedGas, vmenv)
 }
 
 // ProcessBeaconBlockRoot applies the EIP-4788 system call to the beacon block root


### PR DESCRIPTION
**Description**

In the block-building code (triggered by `miner` package `commitTransaction`, which is used by engine-API) it runs this code-path where every time a transaction is applied, it takes the template block-header and re-encodes and hashes it.
This same function is also used by the op-program version of the engine-API.

This is inefficient in the same way in upstream L1 geth block-building code too.

One way to temporay-fix it, is to not compute the block-hash, when the state-root is still not set. A zero state-root implies that the block-building is not done.

This is a temporary fix. Ideally we improve the geth block-building API, so it's not running into this thing to begin with. Constructing receipts on the way is one thing, but trying to hydrate the metadata before the block is even finished is just bad.

This PR is a draft to help track this optimization until upstream block-building is improved.
