### PR TITLE
node: Enable miner rpc in authrpc if enabled in http

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -430,6 +430,14 @@ func (n *Node) startRPC() error {
 	}
 
 	initAuth := func(port int, secret []byte) error {
+		authModules := DefaultAuthModules
+		for _, module := range n.config.HTTPModules {
+			if module == "miner" {
+				authModules = append(authModules, "miner")
+				break
+			}
+		}
+
 		// Enable auth via HTTP
 		server := n.httpAuth
 		if err := server.setListenAddr(n.config.AuthAddr, port); err != nil {
@@ -444,7 +452,7 @@ func (n *Node) startRPC() error {
 		err := server.enableRPC(allAPIs, httpConfig{
 			CorsAllowedOrigins: DefaultAuthCors,
 			Vhosts:             n.config.AuthVirtualHosts,
-			Modules:            DefaultAuthModules,
+			Modules:            authModules,
 			prefix:             DefaultAuthPrefix,
 			rpcEndpointConfig:  sharedConfig,
 		})

--- a/node/node.go
+++ b/node/node.go
@@ -431,11 +431,8 @@ func (n *Node) startRPC() error {
 
 	initAuth := func(port int, secret []byte) error {
 		authModules := DefaultAuthModules
-		for _, module := range n.config.HTTPModules {
-			if module == "miner" {
-				authModules = append(authModules, "miner")
-				break
-			}
+		if slices.Contains(n.config.HTTPModules, "miner") {
+			authModules = append(authModules, "miner")
 		}
 
 		// Enable auth via HTTP


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

This PR enables the `miner` RPC module on the AuthRPC endpoint when it's enabled for HTTP (`--http.modules miner`). This aligns with [op-reth'](https://github.com/paradigmxyz/reth/blob/e468d4d7c5ab5d4af5a19d9deaf126ab64033f8e/crates/optimism/node/src/node.rs#L235-L239)s approach.

This PR does not add any additional security exposure as AuthRPC endpoint has stricter access controls than HTTP.

A simpler alternative would be to enable this by default in DefaultAuthRpc. Let me know which approach you prefer.

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

Let me know if want me to add a test on `node_test.go`.

**Additional context**

This change is needed for [Rollup-boost](https://github.com/flashbots/rollup-boost). Rollup-boost uses the AuthRPC endpoint to communicate with builders, so having the miner module enabled there simplifies its implementation.

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
