### PR TITLE
pathdb: Pathdb full write-buffer check

### DIFF
--- a/fork.yaml
+++ b/fork.yaml
@@ -205,6 +205,12 @@ def:
           globs:
             - "eth/downloader/downloader.go"
             - "eth/downloader/receiptreference.go"
+        - title: PathDB diff-layers limit
+          description: |
+            Prevent the write-buffer to grow too large, to keep the journal optional,
+            and not restart on top of unavailable state.
+          globs:
+            - "triedb/pathdb/buffer.go"
         - title: Discv5 node discovery
           description: Fix discv5 option to allow discv5 to be an active source for node-discovery.
           globs:

--- a/triedb/pathdb/buffer.go
+++ b/triedb/pathdb/buffer.go
@@ -114,7 +114,10 @@ func (b *buffer) empty() bool {
 // full returns an indicator if the size of accumulated content exceeds the
 // configured threshold.
 func (b *buffer) full() bool {
-	return b.size() > b.limit
+	// Limit not just by data size, but also the number of layers:
+	// if we allow the write-buffer to become larger,
+	// the journal becomes critical to not roll back to an unavailable state.
+	return b.size() > b.limit || b.layers >= uint64(maxDiffLayers)
 }
 
 // size returns the approximate memory size of the held content.


### PR DESCRIPTION
**Description**

If we lose a large enough journal, then the state at startup of a full-node may be unavailable.
So prevent the write-buffer from growing too large, to keep the journal safe to delete.

Split into two commits, so the code-fix can be cherry-picked into upstream.

**Metadata**

(attempt to) Fix https://github.com/ethereum/go-ethereum/issues/31131