### PR TITLE
node: Enable debug rpc in authrpc if enabled in http

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -434,6 +434,9 @@ func (n *Node) startRPC() error {
 		if slices.Contains(n.config.HTTPModules, "miner") {
 			authModules = append(authModules, "miner")
 		}
+		if slices.Contains(n.config.HTTPModules, "debug") {
+			authModules = append(authModules, "debug")
+		}
 
 		// Enable auth via HTTP
 		server := n.httpAuth


### PR DESCRIPTION
Now that the `debug` module is being [used](https://github.com/ethereum-optimism/optimism/blob/9d94936939484b7898d29db581de5703f7685367/op-node/node/node.go#L464) in op-node, it's convenient to automatically enable debug in authrpc if enabled in http.

This is in the same spirit as https://github.com/ethereum-optimism/op-geth/pull/491.