### PR TITLE
ci: only mark finalized releases as 'latest'

### DIFF
--- a/.circleci/ci-docker-tag-op-geth-release.sh
+++ b/.circleci/ci-docker-tag-op-geth-release.sh
@@ -27,12 +27,11 @@ fi
 echo "Tagging $SOURCE_IMAGE_TAG with '$IMAGE_TAG'"
 gcloud container images add-tag -q "$SOURCE_IMAGE_TAG" "$TARGET_IMAGE_TAG"
 
-# Do not tag with latest if the release is a release candidate.
-if [[ "$IMAGE_TAG" == *"rc"* ]]; then
-  echo "Not tagging with 'latest' because the release is a release candidate."
+# Only tag finalized releases with 'latest'
+if ! [[ "$IMAGE_TAG" =~ ^v1\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Not tagging with 'latest' because the release is not finalized."
   exit 0
 fi
 
 echo "Tagging $SOURCE_IMAGE_TAG with 'latest'"
 gcloud container images add-tag -q "$SOURCE_IMAGE_TAG" "$TARGET_IMAGE_TAG_LATEST"
-


### PR DESCRIPTION
The old rule would tag all git tags but those containing `rc` as `latest`, which was wrong and dangerous. This PR changes to matching with a regexp so only vX.Y.Z style tags, without any suffixes, are used for updating `latest`.