### PR TITLE
fix: Handle RPC connection error properly

### DIFF
--- a/rpc/client_example_test.go
+++ b/rpc/client_example_test.go
@@ -40,7 +40,12 @@ type Block struct {
 
 func ExampleClientSubscription() {
 	// Connect the client.
-	client, _ := rpc.Dial("ws://127.0.0.1:8545")
+	client, err := rpc.Dial("ws://127.0.0.1:8545")
+	if err != nil {
+   	    fmt.Println("failed to connect:", err)
+   	    return
+}
+
 	subch := make(chan Block)
 
 	// Ensure that subch receives the latest block.


### PR DESCRIPTION
**Description**  
Fixed an issue where the RPC connection error was ignored, which could lead to a panic if the connection failed. Now, the error is properly handled by logging a message and safely exiting.  

**Tests**  
Manually tested by attempting to connect to an invalid WebSocket URL and verifying that the error is logged instead of causing a panic.  

**Additional context**  
Ignoring connection errors can lead to unexpected crashes, especially in environments where network stability is not guaranteed. This change ensures that failures are handled gracefully.  

**Metadata**  
- Affected component: RPC connection handling  
- Type: Bug fix  
- Severity: Potential crash prevention  