### PR TITLE
fix: solves eth_createAccessList unmarshaling error

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1283,7 +1283,7 @@ func (api *BlockChainAPI) CreateAccessList(ctx context.Context, args Transaction
 		bNrOrHash = *blockNrOrHash
 	}
 
-	state, header, err := api.b.StateAndHeaderByNumberOrHash(ctx, bNrOrHash)
+	header, err := headerByNumberOrHash(ctx, api.b, bNrOrHash)
 	if err == nil && header != nil && api.b.ChainConfig().IsOptimismPreBedrock(header.Number) {
 		if api.b.HistoricalRPCService() != nil {
 			var res accessListResult
@@ -1297,7 +1297,7 @@ func (api *BlockChainAPI) CreateAccessList(ctx context.Context, args Transaction
 		}
 	}
 
-	acl, gasUsed, vmerr, err := AccessList(ctx, api.b, bNrOrHash, args, state)
+	acl, gasUsed, vmerr, err := AccessList(ctx, api.b, bNrOrHash, args)
 	if err != nil {
 		return nil, err
 	}
@@ -1311,12 +1311,13 @@ func (api *BlockChainAPI) CreateAccessList(ctx context.Context, args Transaction
 // AccessList creates an access list for the given transaction.
 // If the accesslist creation fails an error is returned.
 // If the transaction itself fails, an vmErr is returned.
-func AccessList(ctx context.Context, b Backend, blockNrOrHash rpc.BlockNumberOrHash, args TransactionArgs, state *state.StateDB) (acl types.AccessList, gasUsed uint64, vmErr error, err error) {
+func AccessList(ctx context.Context, b Backend, blockNrOrHash rpc.BlockNumberOrHash, args TransactionArgs) (acl types.AccessList, gasUsed uint64, vmErr error, err error) {
 	// Retrieve the execution context
 	db, header, err := b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
 	if db == nil || err != nil {
 		return nil, 0, nil, err
 	}
+	state := db
 
 	// Ensure any missing fields are filled, extract the recipient and input data
 	if err = args.setFeeDefaults(ctx, b, header); err != nil {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1283,7 +1283,7 @@ func (api *BlockChainAPI) CreateAccessList(ctx context.Context, args Transaction
 		bNrOrHash = *blockNrOrHash
 	}
 
-	header, err := headerByNumberOrHash(ctx, api.b, bNrOrHash)
+	state, header, err := api.b.StateAndHeaderByNumberOrHash(ctx, bNrOrHash)
 	if err == nil && header != nil && api.b.ChainConfig().IsOptimismPreBedrock(header.Number) {
 		if api.b.HistoricalRPCService() != nil {
 			var res accessListResult
@@ -1297,7 +1297,7 @@ func (api *BlockChainAPI) CreateAccessList(ctx context.Context, args Transaction
 		}
 	}
 
-	acl, gasUsed, vmerr, err := AccessList(ctx, api.b, bNrOrHash, args, nil)
+	acl, gasUsed, vmerr, err := AccessList(ctx, api.b, bNrOrHash, args, state)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1277,7 +1277,7 @@ type accessListResult struct {
 
 // CreateAccessList creates an EIP-2930 type AccessList for the given transaction.
 // Reexec and BlockNrOrHash can be specified to create the accessList on top of a certain state.
-func (api *BlockChainAPI) CreateAccessList(ctx context.Context, args TransactionArgs, state *state.StateDB, blockNrOrHash *rpc.BlockNumberOrHash) (*accessListResult, error) {
+func (api *BlockChainAPI) CreateAccessList(ctx context.Context, args TransactionArgs, blockNrOrHash *rpc.BlockNumberOrHash) (*accessListResult, error) {
 	bNrOrHash := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
 	if blockNrOrHash != nil {
 		bNrOrHash = *blockNrOrHash
@@ -1297,7 +1297,7 @@ func (api *BlockChainAPI) CreateAccessList(ctx context.Context, args Transaction
 		}
 	}
 
-	acl, gasUsed, vmerr, err := AccessList(ctx, api.b, bNrOrHash, args, state)
+	acl, gasUsed, vmerr, err := AccessList(ctx, api.b, bNrOrHash, args, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Solves [#520](https://github.com/ethereum-optimism/op-geth/issues/520).

This is a fix for the unmarshaling error that was encountered on version 1.101500.0
The signature of the `CreateAccessList` method was modified and the state was removed.


**Tests**
The tests were executed and they have the same results as in the optimism branch.
<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

Fixes #520 
