### PR TITLE
p2p/enode: add back DNS hostname resolution at parsing time

### DIFF
--- a/p2p/enode/urlv4_test.go
+++ b/p2p/enode/urlv4_test.go
@@ -18,6 +18,7 @@ package enode
 
 import (
 	"crypto/ecdsa"
+	"errors"
 	"net"
 	"reflect"
 	"strings"
@@ -26,6 +27,15 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/p2p/enr"
 )
+
+func init() {
+	lookupIPFunc = func(name string) ([]net.IP, error) {
+		if name == "valid." {
+			return []net.IP{{33, 44, 55, 66}}, nil
+		}
+		return nil, errors.New("no such host")
+	}
+}
 
 var parseNodeTests = []struct {
 	input      string
@@ -81,7 +91,7 @@ var parseNodeTests = []struct {
 		input: "enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@valid.:3",
 		wantResult: NewV4(
 			hexPubkey("1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439"),
-			nil,
+			net.IP{33, 44, 55, 66}, // OP-Stack adds back DNS resolution at parsing time
 			3,
 			3,
 		).WithHostname("valid."),


### PR DESCRIPTION
**Description**

- removed in https://github.com/ethereum/go-ethereum/pull/30822 in favor of on-demand runtime dialling
- reported to have removed bootnodes DNS resolution at https://github.com/ethereum/go-ethereum/issues/31208
- possibly broke DNS resolution for other methods of adding peers

This is a quick fix until upstream has implemented a proper fix.

**Tests**

None added, code copied from https://github.com/ethereum/go-ethereum/pull/30822


