### PR TITLE
fix: remove requests queue processing

### DIFF
--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -349,9 +349,11 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig, 
 		statedb.AddBalance(w.Address, uint256.MustFromBig(amount), tracing.BalanceIncreaseWithdrawal)
 	}
 
+	isIsthmus := chainConfig.IsIsthmus(vmContext.Time)
+
 	// Gather the execution-layer triggered requests.
 	var requests [][]byte
-	if chainConfig.IsPrague(vmContext.BlockNumber, vmContext.Time) {
+	if chainConfig.IsPrague(vmContext.BlockNumber, vmContext.Time) && !isIsthmus {
 		requests = [][]byte{}
 		// EIP-6110
 		var allLogs []*types.Log
@@ -367,7 +369,7 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig, 
 		core.ProcessConsolidationQueue(&requests, evm)
 	}
 
-	if chainConfig.IsIsthmus(vmContext.Time) {
+	if isIsthmus {
 		requests = [][]byte{}
 	}
 

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -314,7 +314,9 @@ func (b *BlockGen) collectRequests(readonly bool) (requests [][]byte) {
 		statedb = statedb.Copy()
 	}
 
-	if b.cm.config.IsPrague(b.header.Number, b.header.Time) {
+	isIsthmus := b.cm.config.IsIsthmus(b.header.Time)
+
+	if b.cm.config.IsPrague(b.header.Number, b.header.Time) && !isIsthmus {
 		requests = [][]byte{}
 		// EIP-6110 deposits
 		var blockLogs []*types.Log
@@ -333,7 +335,7 @@ func (b *BlockGen) collectRequests(readonly bool) (requests [][]byte) {
 		ProcessConsolidationQueue(&requests, evm)
 	}
 
-	if b.cm.config.IsIsthmus(b.header.Time) {
+	if isIsthmus {
 		requests = [][]byte{}
 	}
 

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -104,9 +104,12 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 		receipts = append(receipts, receipt)
 		allLogs = append(allLogs, receipt.Logs...)
 	}
+
+	isIsthmus := p.config.IsIsthmus(block.Time())
+
 	// Read requests if Prague is enabled.
 	var requests [][]byte
-	if p.config.IsPrague(block.Number(), block.Time()) {
+	if p.config.IsPrague(block.Number(), block.Time()) && !isIsthmus {
 		requests = [][]byte{}
 		// EIP-6110
 		if err := ParseDepositLogs(&requests, allLogs, p.config); err != nil {
@@ -118,7 +121,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 		ProcessConsolidationQueue(&requests, evm)
 	}
 
-	if p.config.IsIsthmus(block.Time()) {
+	if isIsthmus {
 		requests = [][]byte{}
 	}
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -183,9 +183,11 @@ func (miner *Miner) generateWork(params *generateParams, witness bool) *newPaylo
 		allLogs = append(allLogs, r.Logs...)
 	}
 
+	isIsthmus := miner.chainConfig.IsIsthmus(work.header.Time)
+
 	// Collect consensus-layer requests if Prague is enabled.
 	var requests [][]byte
-	if miner.chainConfig.IsPrague(work.header.Number, work.header.Time) {
+	if miner.chainConfig.IsPrague(work.header.Number, work.header.Time) && !isIsthmus {
 		requests = [][]byte{}
 		// EIP-6110 deposits
 		if err := core.ParseDepositLogs(&requests, allLogs, miner.chainConfig); err != nil {
@@ -197,7 +199,7 @@ func (miner *Miner) generateWork(params *generateParams, witness bool) *newPaylo
 		core.ProcessConsolidationQueue(&requests, work.evm)
 	}
 
-	if miner.chainConfig.IsIsthmus(work.header.Time) {
+	if isIsthmus {
 		requests = [][]byte{}
 	}
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Remove requests queue processing steps from Isthmus. Requests still needs to be an empty initialized array instead of nil so we include the requests hash in the block.