### PR TITLE
superchain: Add optional fork PectraBlobSchedule

### DIFF
--- a/superchain/types.go
+++ b/superchain/types.go
@@ -42,6 +42,9 @@ type HardforkConfig struct {
 	HoloceneTime *uint64 `toml:"holocene_time"`
 	IsthmusTime  *uint64 `toml:"isthmus_time"`
 	JovianTime   *uint64 `toml:"jovian_time"`
+
+	// Optional Forks
+	PectraBlobScheduleTime *uint64 `toml:"pectra_blob_schedule_time,omitempty"`
 }
 
 type OptimismConfig struct {


### PR DESCRIPTION
**Description**

Adds an optional fork `PectraBlobSchedule` to the superchain types.
