### PR TITLE
Update latest signer for optimism to prague

### DIFF
--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -254,7 +254,7 @@ func (s pragueSigner) Hash(tx *Transaction) common.Hash {
 }
 
 // isthmusSigner skips cancun because blob txs are not supported on OP
-type isthmusSigner struct{ londonSigner }
+type isthmusSigner struct{ pragueSigner }
 
 // NewIsthmusSigner returns a signer that accepts
 // - EIP-7702 set code transactions
@@ -264,23 +264,16 @@ type isthmusSigner struct{ londonSigner }
 // - EIP-155 replay protected transactions, and
 // - legacy Homestead transactions.
 func NewIsthmusSigner(chainId *big.Int) Signer {
-	signer, _ := NewLondonSigner(chainId).(londonSigner)
+	signer, _ := NewPragueSigner(chainId).(pragueSigner)
 	return isthmusSigner{signer}
 }
 
 func (s isthmusSigner) Sender(tx *Transaction) (common.Address, error) {
-	if tx.Type() != SetCodeTxType {
-		return s.londonSigner.Sender(tx)
+	if tx.Type() == BlobTxType {
+		return common.Address{}, fmt.Errorf("isthmus does not support blob txs: %w", ErrTxTypeNotSupported)
 	}
-	V, R, S := tx.RawSignatureValues()
 
-	// Set code txs are defined to use 0 and 1 as their recovery
-	// id, add 27 to become equivalent to unprotected Homestead signatures.
-	V = new(big.Int).Add(V, big.NewInt(27))
-	if tx.ChainId().Cmp(s.chainId) != 0 {
-		return common.Address{}, fmt.Errorf("%w: have %d want %d", ErrInvalidChainId, tx.ChainId(), s.chainId)
-	}
-	return recoverPlain(s.Hash(tx), R, S, V, true)
+	return s.pragueSigner.Sender(tx)
 }
 
 func (s isthmusSigner) Equal(s2 Signer) bool {

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -40,9 +40,11 @@ type sigCache struct {
 func MakeSigner(config *params.ChainConfig, blockNumber *big.Int, blockTime uint64) Signer {
 	var signer Signer
 	switch {
-	case config.IsPrague(blockNumber, blockTime) && !config.IsOptimism():
+	case config.IsIsthmus(blockTime):
+		signer = NewIsthmusSigner(config.ChainID)
+	case config.IsPrague(blockNumber, blockTime):
 		signer = NewPragueSigner(config.ChainID)
-	case config.IsCancun(blockNumber, blockTime) && !config.IsOptimism():
+	case config.IsCancun(blockNumber, blockTime):
 		signer = NewCancunSigner(config.ChainID)
 	case config.IsLondon(blockNumber):
 		signer = NewLondonSigner(config.ChainID)
@@ -69,9 +71,11 @@ func LatestSigner(config *params.ChainConfig) Signer {
 	var signer Signer
 	if config.ChainID != nil {
 		switch {
-		case config.PragueTime != nil && !config.IsOptimism():
+		case config.IsthmusTime != nil:
+			signer = NewIsthmusSigner(config.ChainID)
+		case config.PragueTime != nil:
 			signer = NewPragueSigner(config.ChainID)
-		case config.CancunTime != nil && !config.IsOptimism():
+		case config.CancunTime != nil:
 			signer = NewCancunSigner(config.ChainID)
 		case config.LondonBlock != nil:
 			signer = NewLondonSigner(config.ChainID)
@@ -232,6 +236,78 @@ func (s pragueSigner) SignatureValues(tx *Transaction, sig []byte) (R, S, V *big
 func (s pragueSigner) Hash(tx *Transaction) common.Hash {
 	if tx.Type() != SetCodeTxType {
 		return s.cancunSigner.Hash(tx)
+	}
+	return prefixedRlpHash(
+		tx.Type(),
+		[]interface{}{
+			s.chainId,
+			tx.Nonce(),
+			tx.GasTipCap(),
+			tx.GasFeeCap(),
+			tx.Gas(),
+			tx.To(),
+			tx.Value(),
+			tx.Data(),
+			tx.AccessList(),
+			tx.SetCodeAuthorizations(),
+		})
+}
+
+// isthmusSigner skips cancun because blob txs are not supported on OP
+type isthmusSigner struct{ londonSigner }
+
+// NewIsthmusSigner returns a signer that accepts
+// - EIP-7702 set code transactions
+// - NOT EIP-4844 blob transactions
+// - EIP-1559 dynamic fee transactions
+// - EIP-2930 access list transactions,
+// - EIP-155 replay protected transactions, and
+// - legacy Homestead transactions.
+func NewIsthmusSigner(chainId *big.Int) Signer {
+	signer, _ := NewLondonSigner(chainId).(londonSigner)
+	return isthmusSigner{signer}
+}
+
+func (s isthmusSigner) Sender(tx *Transaction) (common.Address, error) {
+	if tx.Type() != SetCodeTxType {
+		return s.londonSigner.Sender(tx)
+	}
+	V, R, S := tx.RawSignatureValues()
+
+	// Set code txs are defined to use 0 and 1 as their recovery
+	// id, add 27 to become equivalent to unprotected Homestead signatures.
+	V = new(big.Int).Add(V, big.NewInt(27))
+	if tx.ChainId().Cmp(s.chainId) != 0 {
+		return common.Address{}, fmt.Errorf("%w: have %d want %d", ErrInvalidChainId, tx.ChainId(), s.chainId)
+	}
+	return recoverPlain(s.Hash(tx), R, S, V, true)
+}
+
+func (s isthmusSigner) Equal(s2 Signer) bool {
+	x, ok := s2.(pragueSigner)
+	return ok && x.chainId.Cmp(s.chainId) == 0
+}
+
+func (s isthmusSigner) SignatureValues(tx *Transaction, sig []byte) (R, S, V *big.Int, err error) {
+	txdata, ok := tx.inner.(*SetCodeTx)
+	if !ok {
+		return s.londonSigner.SignatureValues(tx, sig)
+	}
+	// Check that chain ID of tx matches the signer. We also accept ID zero here,
+	// because it indicates that the chain ID was not specified in the tx.
+	if txdata.ChainID.Sign() != 0 && txdata.ChainID.CmpBig(s.chainId) != 0 {
+		return nil, nil, nil, fmt.Errorf("%w: have %d want %d", ErrInvalidChainId, txdata.ChainID, s.chainId)
+	}
+	R, S, _ = decodeSignature(sig)
+	V = big.NewInt(int64(sig[64]))
+	return R, S, V, nil
+}
+
+// Hash returns the hash to be signed by the sender.
+// It does not uniquely identify the transaction.
+func (s isthmusSigner) Hash(tx *Transaction) common.Hash {
+	if tx.Type() != SetCodeTxType {
+		return s.londonSigner.Hash(tx)
 	}
 	return prefixedRlpHash(
 		tx.Type(),

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -282,40 +282,17 @@ func (s isthmusSigner) Equal(s2 Signer) bool {
 }
 
 func (s isthmusSigner) SignatureValues(tx *Transaction, sig []byte) (R, S, V *big.Int, err error) {
-	txdata, ok := tx.inner.(*SetCodeTx)
-	if !ok {
-		return s.londonSigner.SignatureValues(tx, sig)
+	if tx.Type() == BlobTxType {
+		return nil, nil, nil, fmt.Errorf("isthmus does not support blob txs: %w", ErrTxTypeNotSupported)
 	}
-	// Check that chain ID of tx matches the signer. We also accept ID zero here,
-	// because it indicates that the chain ID was not specified in the tx.
-	if txdata.ChainID.Sign() != 0 && txdata.ChainID.CmpBig(s.chainId) != 0 {
-		return nil, nil, nil, fmt.Errorf("%w: have %d want %d", ErrInvalidChainId, txdata.ChainID, s.chainId)
-	}
-	R, S, _ = decodeSignature(sig)
-	V = big.NewInt(int64(sig[64]))
-	return R, S, V, nil
+
+	return s.pragueSigner.SignatureValues(tx, sig)
 }
 
 // Hash returns the hash to be signed by the sender.
 // It does not uniquely identify the transaction.
 func (s isthmusSigner) Hash(tx *Transaction) common.Hash {
-	if tx.Type() != SetCodeTxType {
-		return s.londonSigner.Hash(tx)
-	}
-	return prefixedRlpHash(
-		tx.Type(),
-		[]interface{}{
-			s.chainId,
-			tx.Nonce(),
-			tx.GasTipCap(),
-			tx.GasFeeCap(),
-			tx.Gas(),
-			tx.To(),
-			tx.Value(),
-			tx.Data(),
-			tx.AccessList(),
-			tx.SetCodeAuthorizations(),
-		})
+	return s.pragueSigner.Hash(tx)
 }
 
 type cancunSigner struct{ londonSigner }

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -42,9 +42,9 @@ func MakeSigner(config *params.ChainConfig, blockNumber *big.Int, blockTime uint
 	switch {
 	case config.IsIsthmus(blockTime):
 		signer = NewIsthmusSigner(config.ChainID)
-	case config.IsPrague(blockNumber, blockTime):
+	case config.IsPrague(blockNumber, blockTime) && !config.IsOptimism():
 		signer = NewPragueSigner(config.ChainID)
-	case config.IsCancun(blockNumber, blockTime):
+	case config.IsCancun(blockNumber, blockTime) && !config.IsOptimism():
 		signer = NewCancunSigner(config.ChainID)
 	case config.IsLondon(blockNumber):
 		signer = NewLondonSigner(config.ChainID)
@@ -73,9 +73,9 @@ func LatestSigner(config *params.ChainConfig) Signer {
 		switch {
 		case config.IsthmusTime != nil:
 			signer = NewIsthmusSigner(config.ChainID)
-		case config.PragueTime != nil:
+		case config.PragueTime != nil && !config.IsOptimism():
 			signer = NewPragueSigner(config.ChainID)
-		case config.CancunTime != nil:
+		case config.CancunTime != nil && !config.IsOptimism():
 			signer = NewCancunSigner(config.ChainID)
 		case config.LondonBlock != nil:
 			signer = NewLondonSigner(config.ChainID)
@@ -284,7 +284,7 @@ func (s isthmusSigner) Sender(tx *Transaction) (common.Address, error) {
 }
 
 func (s isthmusSigner) Equal(s2 Signer) bool {
-	x, ok := s2.(pragueSigner)
+	x, ok := s2.(isthmusSigner)
 	return ok && x.chainId.Cmp(s.chainId) == 0
 }
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

These should be returning the most permissive signer available for the given chain config. For Isthmus, we need to make sure SetCodeTx transactions are supported.

This logic probably originally existed because Cancun signer only supports blob txs.