### PR TITLE
eth: fix OP-Stack fee-history RPC

### DIFF
--- a/eth/gasprice/feehistory.go
+++ b/eth/gasprice/feehistory.go
@@ -108,7 +108,11 @@ func (oracle *Oracle) processBlock(bf *blockFees, percentiles []float64) {
 	bf.results.gasUsedRatio = float64(bf.header.GasUsed) / float64(bf.header.GasLimit)
 	if blobGasUsed := bf.header.BlobGasUsed; blobGasUsed != nil {
 		maxBlobs := eip4844.MaxBlobsPerBlock(config, bf.header.Time)
-		bf.results.blobGasUsedRatio = float64(*blobGasUsed) / float64(maxBlobs)
+		if maxBlobs != 0 {
+			bf.results.blobGasUsedRatio = float64(*blobGasUsed) / float64(maxBlobs)
+		} else { // avoid NaN values, these cannot be JSON-encoded in the fee-history RPC
+			bf.results.blobGasUsedRatio = 0
+		}
 	}
 
 	if len(percentiles) == 0 {


### PR DESCRIPTION
**Description**

There are 0 blobs, and so the `used blobs / max blobs` calculation resulted in `NaN`, which then caused the RPC to error.

**Tests**

Updated fee history test to cover op-stack and check for 0 values.

**Metadata**

Fix https://github.com/ethereum-optimism/op-geth/issues/542
