### PR TITLE
accounts/abi: estimate gas with access-list

### DIFF
--- a/accounts/abi/bind/base.go
+++ b/accounts/abi/bind/base.go
@@ -373,6 +373,8 @@ func (c *BoundContract) estimateGasLimit(opts *TransactOpts, contract *common.Ad
 		GasFeeCap: gasFeeCap,
 		Value:     value,
 		Data:      input,
+		// OP-Stack fix: important for CrossL2Inbox gas estimation
+		AccessList: opts.AccessList,
 	}
 	return c.transactor.EstimateGas(ensureContext(opts.Context), msg)
 }

--- a/fork.yaml
+++ b/fork.yaml
@@ -331,6 +331,9 @@ def:
           globs:
             - "accounts/abi/bind/backends/simulated.go"
             - "ethclient/simulated/backend.go"
+        - title: Fix ABI bindings gas-estimation to use access-list
+          globs:
+            - "accounts/abi/bind/base.go"
         - title: Live tracer update
           description: |
             Track L1-deposited native currency that is coming into the L2 supply.


### PR DESCRIPTION
**Description**

The access-list is needed for gas-estimation to not revert during interop CrossL2Inbox validateMessage calls.

**Tests**

Covered by a interop monorepo tests.

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
