### PR TITLE
p2p: remove redundant discv5 dialer resource

### DIFF
--- a/p2p/server.go
+++ b/p2p/server.go
@@ -492,7 +492,6 @@ func (srv *Server) setupDiscovery() error {
 		if err != nil {
 			return err
 		}
-		srv.discmix.AddSource(srv.discv5.RandomNodes())
 	}
 
 	// Add protocol-specific discovery sources.


### PR DESCRIPTION
It was added at https://github.com/ethereum-optimism/op-geth/commit/5fcc6e0393b9381f96561609ef38157b507a2a62

but since op-geth has merged the geth 1.15.x, this line is not necessary anymore

https://github.com/ethereum-optimism/op-geth/blob/28ddc5e77079a983ec75c7956956013c8564c3b7/eth/backend.go#L499-L503

https://github.com/ethereum-optimism/op-geth/blob/28ddc5e77079a983ec75c7956956013c8564c3b7/p2p/server.go#L500-L505