### PR TITLE
core: don't refund operator fee for deposits

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -641,13 +641,6 @@ func (st *stateTransition) innerExecute() (*ExecutionResult, error) {
 		}, nil
 	}
 
-	// Operator Fee refunds are only applied if isthmus is active and the transaction is *not* a deposit.
-	if rules.IsOptimismIsthmus {
-		// Calling st.refundOperatorCost() after st.gasRemaining is updated above,
-		// so that state refunds are taken into account when calculating operator fees.
-		st.refundIsthmusOperatorCost()
-	}
-
 	effectiveTip := msg.GasPrice
 	if rules.IsLondon {
 		effectiveTip = new(big.Int).Sub(msg.GasFeeCap, st.evm.Context.BaseFee)
@@ -690,6 +683,11 @@ func (st *stateTransition) innerExecute() (*ExecutionResult, error) {
 			if rules.IsOptimismIsthmus {
 				operatorFeeCost := st.evm.Context.OperatorCostFunc(st.gasUsed(), st.evm.Context.Time)
 				st.state.AddBalance(params.OptimismOperatorFeeRecipient, operatorFeeCost, tracing.BalanceIncreaseRewardTransactionFee)
+
+				// Calling st.refundOperatorCost() after st.gasRemaining is updated above,
+				// so that state refunds are taken into account when calculating operator fees.
+				// Operator Fee refunds are only applied if isthmus is active and the transaction is *not* a deposit.
+				st.refundIsthmusOperatorCost()
 			}
 		}
 	}

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -641,6 +641,7 @@ func (st *stateTransition) innerExecute() (*ExecutionResult, error) {
 		}, nil
 	}
 
+	// Operator Fee refunds are only applied if isthmus is active and the transaction is *not* a deposit.
 	if rules.IsOptimismIsthmus {
 		// Calling st.refundOperatorCost() after st.gasRemaining is updated above,
 		// so that state refunds are taken into account when calculating operator fees.

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -626,11 +626,6 @@ func (st *stateTransition) innerExecute() (*ExecutionResult, error) {
 			}
 		}
 	}
-	if rules.IsOptimismIsthmus {
-		// Calling st.refundOperatorCost() after st.gasRemaining is updated above,
-		// so that state refunds are taken into account when calculating operator fees.
-		st.refundIsthmusOperatorCost()
-	}
 	st.returnGas()
 
 	// OP-Stack: Note for deposit tx there is no ETH refunded for unused gas, but that's taken care of by the fact that gasPrice
@@ -644,6 +639,12 @@ func (st *stateTransition) innerExecute() (*ExecutionResult, error) {
 			Err:         vmerr,
 			ReturnData:  ret,
 		}, nil
+	}
+
+	if rules.IsOptimismIsthmus {
+		// Calling st.refundOperatorCost() after st.gasRemaining is updated above,
+		// so that state refunds are taken into account when calculating operator fees.
+		st.refundIsthmusOperatorCost()
 	}
 
 	effectiveTip := msg.GasPrice


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Move the operator fee refund logic after the early return for deposits.

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
