### PR TITLE
core/txpool: Take total rollup cost into account (L1 + operator fee)

### DIFF
--- a/core/rlp_test.go
+++ b/core/rlp_test.go
@@ -201,14 +201,9 @@ func BenchmarkHashing(b *testing.B) {
 }
 
 func TestBlockRlpEncodeDecode(t *testing.T) {
-	zeroTime := uint64(0)
-
 	// create a config where Isthmus upgrade is active
 	config := *params.OptimismTestConfig
-	config.ShanghaiTime = &zeroTime
-	config.IsthmusTime = &zeroTime
-	config.CancunTime = &zeroTime
-	require.True(t, config.IsOptimismIsthmus(zeroTime))
+	require.True(t, config.IsOptimismIsthmus(0))
 
 	block := getBlock(&config, 10, 2, 50)
 

--- a/core/rlp_test.go
+++ b/core/rlp_test.go
@@ -201,9 +201,14 @@ func BenchmarkHashing(b *testing.B) {
 }
 
 func TestBlockRlpEncodeDecode(t *testing.T) {
+	zeroTime := uint64(0)
+
 	// create a config where Isthmus upgrade is active
-	config := *params.OptimismTestConfig
-	require.True(t, config.IsOptimismIsthmus(0))
+	config := *params.OptimismTestCliqueConfig
+	config.ShanghaiTime = &zeroTime
+	config.IsthmusTime = &zeroTime
+	config.CancunTime = &zeroTime
+	require.True(t, config.IsOptimismIsthmus(zeroTime))
 
 	block := getBlock(&config, 10, 2, 50)
 

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -637,13 +637,10 @@ func (pool *LegacyPool) validateTx(tx *types.Transaction) error {
 		ExistingCost: func(addr common.Address, nonce uint64) *big.Int {
 			if list := pool.pending[addr]; list != nil {
 				if tx := list.txs.Get(nonce); tx != nil {
-					cost := tx.Cost()
-					if pool.rollupCostFn != nil {
-						if rollupCost := pool.rollupCostFn(tx); rollupCost != nil { // add rollup cost
-							cost = cost.Add(cost, rollupCost.ToBig())
-						}
-					}
-					return cost
+					// The total cost is guaranteed to not overflow because it got already
+					// successfully added to the list.
+					cost, _ := txpool.TotalTxCost(tx, pool.rollupCostFn)
+					return cost.ToBig()
 				}
 			}
 			return nil

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -260,7 +260,7 @@ type LegacyPool struct {
 
 	changesSinceReorg int // A counter for how many drops we've performed in-between reorg.
 
-	l1CostFn txpool.L1CostFunc // To apply L1 costs as rollup, optional field, may be nil.
+	rollupCostFn txpool.RollupCostFunc // Additional rollup cost function, optional field, may be nil.
 }
 
 type txpoolResetRequest struct {
@@ -638,9 +638,9 @@ func (pool *LegacyPool) validateTx(tx *types.Transaction) error {
 			if list := pool.pending[addr]; list != nil {
 				if tx := list.txs.Get(nonce); tx != nil {
 					cost := tx.Cost()
-					if pool.l1CostFn != nil {
-						if l1Cost := pool.l1CostFn(tx.RollupCostData()); l1Cost != nil { // add rollup cost
-							cost = cost.Add(cost, l1Cost)
+					if pool.rollupCostFn != nil {
+						if rollupCost := pool.rollupCostFn(tx); rollupCost != nil { // add rollup cost
+							cost = cost.Add(cost, rollupCost.ToBig())
 						}
 					}
 					return cost
@@ -648,7 +648,7 @@ func (pool *LegacyPool) validateTx(tx *types.Transaction) error {
 			}
 			return nil
 		},
-		L1CostFn: pool.l1CostFn,
+		RollupCostFn: pool.rollupCostFn,
 	}
 	if err := txpool.ValidateTransactionWithState(tx, pool.signer, opts); err != nil {
 		return err
@@ -802,7 +802,7 @@ func (pool *LegacyPool) add(tx *types.Transaction) (replaced bool, err error) {
 	// Try to replace an existing transaction in the pending pool
 	if list := pool.pending[from]; list != nil && list.Contains(tx.Nonce()) {
 		// Nonce already pending, check if required price bump is met
-		inserted, old := list.Add(tx, pool.config.PriceBump, pool.l1CostFn)
+		inserted, old := list.Add(tx, pool.config.PriceBump, pool.rollupCostFn)
 		if !inserted {
 			pendingDiscardMeter.Mark(1)
 			return false, txpool.ErrReplaceUnderpriced
@@ -865,7 +865,7 @@ func (pool *LegacyPool) enqueueTx(hash common.Hash, tx *types.Transaction, addAl
 	if pool.queue[from] == nil {
 		pool.queue[from] = newList(false)
 	}
-	inserted, old := pool.queue[from].Add(tx, pool.config.PriceBump, pool.l1CostFn)
+	inserted, old := pool.queue[from].Add(tx, pool.config.PriceBump, pool.rollupCostFn)
 	if !inserted {
 		// An older transaction was better, discard this
 		queuedDiscardMeter.Mark(1)
@@ -907,7 +907,7 @@ func (pool *LegacyPool) promoteTx(addr common.Address, hash common.Hash, tx *typ
 	}
 	list := pool.pending[addr]
 
-	inserted, old := list.Add(tx, pool.config.PriceBump, pool.l1CostFn)
+	inserted, old := list.Add(tx, pool.config.PriceBump, pool.rollupCostFn)
 	if !inserted {
 		// An older transaction was better, discard this
 		pool.all.Remove(hash)
@@ -1418,9 +1418,9 @@ func (pool *LegacyPool) reset(oldHead, newHead *types.Header) {
 	pool.currentState = statedb
 	pool.pendingNonces = newNoncer(statedb)
 
-	if costFn := types.NewL1CostFunc(pool.chainconfig, statedb); costFn != nil {
-		pool.l1CostFn = func(rollupCostData types.RollupCostData) *big.Int {
-			return costFn(rollupCostData, newHead.Time)
+	if costFn := types.NewTotalRollupCostFunc(pool.chainconfig, statedb); costFn != nil {
+		pool.rollupCostFn = func(tx types.RollupTransaction) *uint256.Int {
+			return costFn(tx, newHead.Time)
 		}
 	}
 
@@ -1430,18 +1430,18 @@ func (pool *LegacyPool) reset(oldHead, newHead *types.Header) {
 	pool.addTxsLocked(reinject)
 }
 
-// reduceBalanceByL1Cost returns the given balance, reduced by the L1Cost of the first transaction in list if applicable
+// reduceBalanceByRollupCost returns the given balance, reduced by the total
+// rollup cost of the first transaction in list if applicable.
 // Other txs will get filtered out necessary.
-func (pool *LegacyPool) reduceBalanceByL1Cost(list *list, balance *uint256.Int) *uint256.Int {
-	if !list.Empty() && pool.l1CostFn != nil {
+func (pool *LegacyPool) reduceBalanceByRollupCost(list *list, balance *uint256.Int) *uint256.Int {
+	if !list.Empty() && pool.rollupCostFn != nil {
 		el := list.txs.FirstElement()
-		if l1Cost := pool.l1CostFn(el.RollupCostData()); l1Cost != nil {
-			l1Cost256 := uint256.MustFromBig(l1Cost)
-			if l1Cost256.Cmp(balance) >= 0 {
+		if rollupCost := pool.rollupCostFn(el); rollupCost != nil {
+			if rollupCost.Cmp(balance) >= 0 {
 				// Avoid underflow
 				balance = uint256.NewInt(0)
 			} else {
-				balance = new(uint256.Int).Sub(balance, l1Cost256)
+				balance = new(uint256.Int).Sub(balance, rollupCost)
 			}
 		}
 	}
@@ -1469,7 +1469,7 @@ func (pool *LegacyPool) promoteExecutables(accounts []common.Address) []*types.T
 		}
 		log.Trace("Removed old queued transactions", "count", len(forwards))
 		balance := pool.currentState.GetBalance(addr)
-		balance = pool.reduceBalanceByL1Cost(list, balance)
+		balance = pool.reduceBalanceByRollupCost(list, balance)
 		// Drop all transactions that are too costly (low balance or out of gas)
 		drops, _ := list.Filter(balance, gasLimit)
 		for _, tx := range drops {
@@ -1659,7 +1659,7 @@ func (pool *LegacyPool) demoteUnexecutables() {
 			log.Trace("Removed old pending transaction", "hash", hash)
 		}
 		balance := pool.currentState.GetBalance(addr)
-		balance = pool.reduceBalanceByL1Cost(list, balance)
+		balance = pool.reduceBalanceByRollupCost(list, balance)
 		// Drop all transactions that are too costly (low balance or out of gas), and queue any invalids back for later
 		drops, invalids := list.Filter(balance, gasLimit)
 		for _, tx := range drops {

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -799,7 +799,7 @@ func (pool *LegacyPool) add(tx *types.Transaction) (replaced bool, err error) {
 	// Try to replace an existing transaction in the pending pool
 	if list := pool.pending[from]; list != nil && list.Contains(tx.Nonce()) {
 		// Nonce already pending, check if required price bump is met
-		inserted, old := list.Add(tx, pool.config.PriceBump, pool.rollupCostFn)
+		inserted, old := list.Add(tx, pool.config.PriceBump)
 		if !inserted {
 			pendingDiscardMeter.Mark(1)
 			return false, txpool.ErrReplaceUnderpriced
@@ -860,9 +860,9 @@ func (pool *LegacyPool) enqueueTx(hash common.Hash, tx *types.Transaction, addAl
 	// Try to insert the transaction into the future queue
 	from, _ := types.Sender(pool.signer, tx) // already validated
 	if pool.queue[from] == nil {
-		pool.queue[from] = newList(false)
+		pool.queue[from] = newRollupList(false, &pool.rollupCostFn)
 	}
-	inserted, old := pool.queue[from].Add(tx, pool.config.PriceBump, pool.rollupCostFn)
+	inserted, old := pool.queue[from].Add(tx, pool.config.PriceBump)
 	if !inserted {
 		// An older transaction was better, discard this
 		queuedDiscardMeter.Mark(1)
@@ -900,11 +900,11 @@ func (pool *LegacyPool) enqueueTx(hash common.Hash, tx *types.Transaction, addAl
 func (pool *LegacyPool) promoteTx(addr common.Address, hash common.Hash, tx *types.Transaction) bool {
 	// Try to insert the transaction into the pending queue
 	if pool.pending[addr] == nil {
-		pool.pending[addr] = newList(true)
+		pool.pending[addr] = newRollupList(true, &pool.rollupCostFn)
 	}
 	list := pool.pending[addr]
 
-	inserted, old := list.Add(tx, pool.config.PriceBump, pool.rollupCostFn)
+	inserted, old := list.Add(tx, pool.config.PriceBump)
 	if !inserted {
 		// An older transaction was better, discard this
 		pool.all.Remove(hash)
@@ -1427,24 +1427,6 @@ func (pool *LegacyPool) reset(oldHead, newHead *types.Header) {
 	pool.addTxsLocked(reinject)
 }
 
-// reduceBalanceByRollupCost returns the given balance, reduced by the total
-// rollup cost of the first transaction in list if applicable.
-// Other txs will get filtered out necessary.
-func (pool *LegacyPool) reduceBalanceByRollupCost(list *list, balance *uint256.Int) *uint256.Int {
-	if !list.Empty() && pool.rollupCostFn != nil {
-		el := list.txs.FirstElement()
-		if rollupCost := pool.rollupCostFn(el); rollupCost != nil {
-			if rollupCost.Cmp(balance) >= 0 {
-				// Avoid underflow
-				balance = uint256.NewInt(0)
-			} else {
-				balance = new(uint256.Int).Sub(balance, rollupCost)
-			}
-		}
-	}
-	return balance
-}
-
 // promoteExecutables moves transactions that have become processable from the
 // future queue to the set of pending transactions. During this process, all
 // invalidated transactions (low nonce, low balance) are deleted.
@@ -1466,7 +1448,6 @@ func (pool *LegacyPool) promoteExecutables(accounts []common.Address) []*types.T
 		}
 		log.Trace("Removed old queued transactions", "count", len(forwards))
 		balance := pool.currentState.GetBalance(addr)
-		balance = pool.reduceBalanceByRollupCost(list, balance)
 		// Drop all transactions that are too costly (low balance or out of gas)
 		drops, _ := list.Filter(balance, gasLimit)
 		for _, tx := range drops {
@@ -1656,7 +1637,6 @@ func (pool *LegacyPool) demoteUnexecutables() {
 			log.Trace("Removed old pending transaction", "hash", hash)
 		}
 		balance := pool.currentState.GetBalance(addr)
-		balance = pool.reduceBalanceByRollupCost(list, balance)
 		// Drop all transactions that are too costly (low balance or out of gas), and queue any invalids back for later
 		drops, invalids := list.Filter(balance, gasLimit)
 		for _, tx := range drops {

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -330,6 +330,9 @@ func (pool *LegacyPool) Init(gasTip uint64, head *types.Header, reserve txpool.A
 	pool.currentState = statedb
 	pool.pendingNonces = newNoncer(statedb)
 
+	// OP-Stack addition
+	pool.resetRollupCostFn(head.Time, statedb)
+
 	pool.wg.Add(1)
 	go pool.scheduleReorgLoop()
 
@@ -523,6 +526,10 @@ func (pool *LegacyPool) ToJournal() map[common.Address]types.Transactions {
 		txs[addr] = append(txs[addr], queued.Flatten()...)
 	}
 	return txs
+}
+
+func (pool *LegacyPool) RollupCostFunc() txpool.RollupCostFunc {
+	return pool.rollupCostFn
 }
 
 // Pending retrieves all currently processable transactions, grouped by origin
@@ -860,7 +867,7 @@ func (pool *LegacyPool) enqueueTx(hash common.Hash, tx *types.Transaction, addAl
 	// Try to insert the transaction into the future queue
 	from, _ := types.Sender(pool.signer, tx) // already validated
 	if pool.queue[from] == nil {
-		pool.queue[from] = newRollupList(false, &pool.rollupCostFn)
+		pool.queue[from] = newRollupList(false, pool)
 	}
 	inserted, old := pool.queue[from].Add(tx, pool.config.PriceBump)
 	if !inserted {
@@ -900,7 +907,7 @@ func (pool *LegacyPool) enqueueTx(hash common.Hash, tx *types.Transaction, addAl
 func (pool *LegacyPool) promoteTx(addr common.Address, hash common.Hash, tx *types.Transaction) bool {
 	// Try to insert the transaction into the pending queue
 	if pool.pending[addr] == nil {
-		pool.pending[addr] = newRollupList(true, &pool.rollupCostFn)
+		pool.pending[addr] = newRollupList(true, pool)
 	}
 	list := pool.pending[addr]
 
@@ -1415,16 +1422,21 @@ func (pool *LegacyPool) reset(oldHead, newHead *types.Header) {
 	pool.currentState = statedb
 	pool.pendingNonces = newNoncer(statedb)
 
-	if costFn := types.NewTotalRollupCostFunc(pool.chainconfig, statedb); costFn != nil {
-		pool.rollupCostFn = func(tx types.RollupTransaction) *uint256.Int {
-			return costFn(tx, newHead.Time)
-		}
-	}
+	// OP-Stack addition
+	pool.resetRollupCostFn(newHead.Time, statedb)
 
 	// Inject any transactions discarded due to reorgs
 	log.Debug("Reinjecting stale transactions", "count", len(reinject))
 	core.SenderCacher().Recover(pool.signer, reinject)
 	pool.addTxsLocked(reinject)
+}
+
+func (pool *LegacyPool) resetRollupCostFn(ts uint64, statedb *state.StateDB) {
+	if costFn := types.NewTotalRollupCostFunc(pool.chainconfig, statedb); costFn != nil {
+		pool.rollupCostFn = func(tx types.RollupTransaction) *uint256.Int {
+			return costFn(tx, ts)
+		}
+	}
 }
 
 // promoteExecutables moves transactions that have become processable from the

--- a/core/txpool/legacypool/legacypool_opstack_test.go
+++ b/core/txpool/legacypool/legacypool_opstack_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
@@ -32,36 +33,40 @@ func setupOPStackPool() (*LegacyPool, *ecdsa.PrivateKey) {
 	return setupPoolWithConfig(params.OptimismTestConfig)
 }
 
+func setupTestL1FeeParams(t *testing.T, pool *LegacyPool) {
+	l1FeeScalars := common.Hash{19: 1} // smallest possible base fee scalar
+	// sanity check
+	l1BaseFeeScalar, l1BlobBaseFeeScalar := types.ExtractEcotoneFeeParams(l1FeeScalars[:])
+	require.EqualValues(t, 1, l1BaseFeeScalar.Uint64())
+	require.Zero(t, l1BlobBaseFeeScalar.Sign())
+	pool.currentState.SetState(types.L1BlockAddr, types.L1FeeScalarsSlot, l1FeeScalars)
+	l1BaseFee := big.NewInt(1e6) // to account for division by 1e12 in L1 cost
+	pool.currentState.SetState(types.L1BlockAddr, types.L1BaseFeeSlot, common.BigToHash(l1BaseFee))
+	// sanity checks
+	require.Equal(t, l1BaseFee, pool.currentState.GetState(types.L1BlockAddr, types.L1BaseFeeSlot).Big())
+}
+
+func setupTestOperatorFeeParams(t *testing.T, pool *LegacyPool) {
+	const opFeeConst = 1                       // smallest possible operator fee constant
+	opFeeParams := common.Hash{31: opFeeConst} // const of 1, scalar of 0
+	// sanity check
+	s, c := types.ExtractOperatorFeeParams(opFeeParams)
+	require.Zero(t, s.Sign())
+	require.EqualValues(t, opFeeConst, c.Uint64())
+	pool.currentState.SetState(types.L1BlockAddr, types.OperatorFeeParamsSlot, opFeeParams)
+}
+
 func TestInvalidRollupTransactions(t *testing.T) {
 	t.Run("zero-rollup-cost", func(t *testing.T) {
 		testInvalidRollupTransactions(t, nil)
 	})
 
 	t.Run("l1-cost", func(t *testing.T) {
-		testInvalidRollupTransactions(t, func(t *testing.T, pool *LegacyPool) {
-			l1FeeScalars := common.Hash{19: 1} // smallest possible base fee scalar
-			// sanity check
-			l1BaseFeeScalar, l1BlobBaseFeeScalar := types.ExtractEcotoneFeeParams(l1FeeScalars[:])
-			require.EqualValues(t, 1, l1BaseFeeScalar.Uint64())
-			require.Zero(t, l1BlobBaseFeeScalar.Sign())
-			pool.currentState.SetState(types.L1BlockAddr, types.L1FeeScalarsSlot, l1FeeScalars)
-			l1BaseFee := big.NewInt(1e6) // to account for division by 1e12 in L1 cost
-			pool.currentState.SetState(types.L1BlockAddr, types.L1BaseFeeSlot, common.BigToHash(l1BaseFee))
-			// sanity checks
-			require.Equal(t, l1BaseFee, pool.currentState.GetState(types.L1BlockAddr, types.L1BaseFeeSlot).Big())
-		})
+		testInvalidRollupTransactions(t, setupTestL1FeeParams)
 	})
 
 	t.Run("operator-cost", func(t *testing.T) {
-		testInvalidRollupTransactions(t, func(t *testing.T, pool *LegacyPool) {
-			const opFeeConst = 1                       // smallest possible operator fee constant
-			opFeeParams := common.Hash{31: opFeeConst} // const of 1, scalar of 0
-			// sanity check
-			s, c := types.ExtractOperatorFeeParams(opFeeParams)
-			require.Zero(t, s.Sign())
-			require.EqualValues(t, opFeeConst, c.Uint64())
-			pool.currentState.SetState(types.L1BlockAddr, types.OperatorFeeParamsSlot, opFeeParams)
-		})
+		testInvalidRollupTransactions(t, setupTestOperatorFeeParams)
 	})
 }
 
@@ -77,7 +82,7 @@ func testInvalidRollupTransactions(t *testing.T, stateMod func(t *testing.T, poo
 
 	// base fee is 1
 	testAddBalance(pool, from, new(big.Int).Add(big.NewInt(gasLimit), tx.Value()))
-	pool.reset(nil, nil)
+	pool.reset(nil, nil) // initiates rollup cost func
 	// we add the test variant with zero rollup cost as a sanity check that the tx would indeed be valid
 	if stateMod == nil {
 		require.NoError(t, pool.addRemote(tx))
@@ -91,4 +96,64 @@ func testInvalidRollupTransactions(t *testing.T, stateMod func(t *testing.T, poo
 	require.Equal(t, 1, rcost.Sign(), "rollup cost must be >0")
 
 	require.ErrorIs(t, pool.addRemote(tx), core.ErrInsufficientFunds)
+}
+
+func TestRollupTransactionCostAccounting(t *testing.T) {
+	t.Run("zero-rollup-cost", func(t *testing.T) {
+		testRollupTransactionCostAccounting(t, nil)
+	})
+
+	t.Run("l1-cost", func(t *testing.T) {
+		testRollupTransactionCostAccounting(t, setupTestL1FeeParams)
+	})
+
+	t.Run("operator-cost", func(t *testing.T) {
+		testRollupTransactionCostAccounting(t, setupTestOperatorFeeParams)
+	})
+}
+
+func testRollupTransactionCostAccounting(t *testing.T, stateMod func(t *testing.T, pool *LegacyPool)) {
+	t.Parallel()
+
+	pool, key := setupOPStackPool()
+	defer pool.Close()
+
+	const gasLimit = 100_000
+	gasPrice0, gasPrice1 := big.NewInt(100), big.NewInt(110)
+	tx0 := pricedTransaction(0, gasLimit, gasPrice0, key)
+	tx1 := pricedTransaction(0, gasLimit, gasPrice1, key)
+	from, _ := deriveSender(tx0)
+
+	pool.reset(nil, nil) // initiates rollup cost func
+	require.NotNil(t, pool.rollupCostFn)
+
+	if stateMod != nil {
+		stateMod(t, pool)
+	}
+
+	cost0, of := txpool.TotalTxCost(tx0, pool.rollupCostFn)
+	require.False(t, of)
+	cost1, of := txpool.TotalTxCost(tx1, pool.rollupCostFn)
+	require.False(t, of)
+
+	if stateMod != nil {
+		require.Greater(t, cost0.Uint64(), tx0.Cost().Uint64(), "tx0 total cost should be greater than regular cost")
+	}
+
+	// we add the initial tx to the pool
+	testAddBalance(pool, from, cost1.ToBig()) // already give enough funds for tx1
+	require.NoError(t, pool.addRemoteSync(tx0))
+	_, ok := pool.queue[from]
+	require.False(t, ok, "tx0 should not be in queue, but pending")
+	pending, ok := pool.pending[from]
+	require.True(t, ok, "tx0 should be pending")
+	require.Equal(t, cost0, pending.totalcost, "tx0 total pending cost should match")
+
+	// now we add a replacement and check the accounting
+	require.NoError(t, pool.addRemoteSync(tx1))
+	_, ok = pool.queue[from]
+	require.False(t, ok, "tx1 should not be in queue, but pending")
+	pending, ok = pool.pending[from]
+	require.True(t, ok, "tx1 should be pending")
+	require.Equal(t, cost1, pending.totalcost, "tx1 total pending cost should match")
 }

--- a/core/txpool/legacypool/legacypool_opstack_test.go
+++ b/core/txpool/legacypool/legacypool_opstack_test.go
@@ -1,0 +1,94 @@
+// Copyright 2025 The op-geth Authors
+// This file is part of the op-geth library.
+//
+// The op-geth library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The op-geth library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the op-geth library. If not, see <http://www.gnu.org/licenses/>.
+
+package legacypool
+
+import (
+	"crypto/ecdsa"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/stretchr/testify/require"
+)
+
+func setupOPStackPool() (*LegacyPool, *ecdsa.PrivateKey) {
+	return setupPoolWithConfig(params.OptimismTestConfig)
+}
+
+func TestInvalidRollupTransactions(t *testing.T) {
+	t.Run("zero-rollup-cost", func(t *testing.T) {
+		testInvalidRollupTransactions(t, nil)
+	})
+
+	t.Run("l1-cost", func(t *testing.T) {
+		testInvalidRollupTransactions(t, func(t *testing.T, pool *LegacyPool) {
+			l1FeeScalars := common.Hash{19: 1} // smallest possible base fee scalar
+			// sanity check
+			l1BaseFeeScalar, l1BlobBaseFeeScalar := types.ExtractEcotoneFeeParams(l1FeeScalars[:])
+			require.EqualValues(t, 1, l1BaseFeeScalar.Uint64())
+			require.Zero(t, l1BlobBaseFeeScalar.Sign())
+			pool.currentState.SetState(types.L1BlockAddr, types.L1FeeScalarsSlot, l1FeeScalars)
+			l1BaseFee := big.NewInt(1e6) // to account for division by 1e12 in L1 cost
+			pool.currentState.SetState(types.L1BlockAddr, types.L1BaseFeeSlot, common.BigToHash(l1BaseFee))
+			// sanity checks
+			require.Equal(t, l1BaseFee, pool.currentState.GetState(types.L1BlockAddr, types.L1BaseFeeSlot).Big())
+		})
+	})
+
+	t.Run("operator-cost", func(t *testing.T) {
+		testInvalidRollupTransactions(t, func(t *testing.T, pool *LegacyPool) {
+			const opFeeConst = 1                       // smallest possible operator fee constant
+			opFeeParams := common.Hash{31: opFeeConst} // const of 1, scalar of 0
+			// sanity check
+			s, c := types.ExtractOperatorFeeParams(opFeeParams)
+			require.Zero(t, s.Sign())
+			require.EqualValues(t, opFeeConst, c.Uint64())
+			pool.currentState.SetState(types.L1BlockAddr, types.OperatorFeeParamsSlot, opFeeParams)
+		})
+	})
+}
+
+func testInvalidRollupTransactions(t *testing.T, stateMod func(t *testing.T, pool *LegacyPool)) {
+	t.Parallel()
+
+	pool, key := setupOPStackPool()
+	defer pool.Close()
+
+	const gasLimit = 100_000
+	tx := transaction(0, gasLimit, key)
+	from, _ := deriveSender(tx)
+
+	// base fee is 1
+	testAddBalance(pool, from, new(big.Int).Add(big.NewInt(gasLimit), tx.Value()))
+	pool.reset(nil, nil)
+	// we add the test variant with zero rollup cost as a sanity check that the tx would indeed be valid
+	if stateMod == nil {
+		require.NoError(t, pool.addRemote(tx))
+		return
+	}
+
+	// Now we cause insufficient funds error due to rollup cost
+	stateMod(t, pool)
+
+	rcost := pool.rollupCostFn(tx)
+	require.Equal(t, 1, rcost.Sign(), "rollup cost must be >0")
+
+	require.ErrorIs(t, pool.addRemote(tx), core.ErrInsufficientFunds)
+}

--- a/core/txpool/legacypool/legacypool_opstack_test.go
+++ b/core/txpool/legacypool/legacypool_opstack_test.go
@@ -46,14 +46,15 @@ func setupTestL1FeeParams(t *testing.T, pool *LegacyPool) {
 	require.Equal(t, l1BaseFee, pool.currentState.GetState(types.L1BlockAddr, types.L1BaseFeeSlot).Big())
 }
 
-func setupTestOperatorFeeParams(t *testing.T, pool *LegacyPool) {
-	const opFeeConst = 1                       // smallest possible operator fee constant
-	opFeeParams := common.Hash{31: opFeeConst} // const of 1, scalar of 0
-	// sanity check
-	s, c := types.ExtractOperatorFeeParams(opFeeParams)
-	require.Zero(t, s.Sign())
-	require.EqualValues(t, opFeeConst, c.Uint64())
-	pool.currentState.SetState(types.L1BlockAddr, types.OperatorFeeParamsSlot, opFeeParams)
+func setupTestOperatorFeeParams(opFeeConst byte) func(t *testing.T, pool *LegacyPool) {
+	return func(t *testing.T, pool *LegacyPool) {
+		opFeeParams := common.Hash{31: opFeeConst} // 0 scalar
+		// sanity check
+		s, c := types.ExtractOperatorFeeParams(opFeeParams)
+		require.Zero(t, s.Sign())
+		require.EqualValues(t, opFeeConst, c.Uint64())
+		pool.currentState.SetState(types.L1BlockAddr, types.OperatorFeeParamsSlot, opFeeParams)
+	}
 }
 
 func TestInvalidRollupTransactions(t *testing.T) {
@@ -66,7 +67,7 @@ func TestInvalidRollupTransactions(t *testing.T) {
 	})
 
 	t.Run("operator-cost", func(t *testing.T) {
-		testInvalidRollupTransactions(t, setupTestOperatorFeeParams)
+		testInvalidRollupTransactions(t, setupTestOperatorFeeParams(1))
 	})
 }
 
@@ -107,7 +108,7 @@ func TestRollupTransactionCostAccounting(t *testing.T) {
 	})
 
 	t.Run("operator-cost", func(t *testing.T) {
-		testRollupTransactionCostAccounting(t, setupTestOperatorFeeParams)
+		testRollupTransactionCostAccounting(t, setupTestOperatorFeeParams(1))
 	})
 }
 
@@ -154,4 +155,41 @@ func testRollupTransactionCostAccounting(t *testing.T, stateMod func(t *testing.
 	pending, ok = pool.pending[from]
 	require.True(t, ok, "tx1 should be pending")
 	require.Equal(t, cost1, pending.totalcost, "tx1 total pending cost should match")
+}
+
+// TestRollupCostFuncChange tests that changes in the underlying rollup cost parameters
+// are correctly picked up by the transaction pool and the underlying list implementation.
+func TestRollupCostFuncChange(t *testing.T) {
+	t.Parallel()
+
+	pool, key := setupOPStackPool()
+	defer pool.Close()
+
+	const gasLimit = 100_000
+	gasPrice := big.NewInt(100)
+	tx0 := pricedTransaction(0, gasLimit, gasPrice, key)
+	tx1 := pricedTransaction(1, gasLimit, gasPrice, key)
+	from, _ := deriveSender(tx0)
+
+	require.NotNil(t, pool.rollupCostFn)
+
+	setupTestOperatorFeeParams(10)(t, pool)
+
+	cost0, of := txpool.TotalTxCost(tx0, pool.rollupCostFn)
+	require.False(t, of)
+
+	// 1st add tx0, consuming all balance
+	testAddBalance(pool, from, cost0.ToBig())
+	require.NoError(t, pool.addRemoteSync(tx0))
+
+	// 2nd add same balance but increase op fee const by 10
+	// so adding 2nd tx should fail with 10 missing.
+	testAddBalance(pool, from, cost0.ToBig())
+	pool.reset(nil, nil) // reset the rollup cost function, simulates a head change
+	setupTestOperatorFeeParams(20)(t, pool)
+	require.ErrorContains(t, pool.addRemoteSync(tx1), "overshot 10")
+
+	// 3rd now add missing 10, adding tx1 should succeed
+	testAddBalance(pool, from, big.NewInt(10))
+	require.NoError(t, pool.addRemoteSync(tx1))
 }

--- a/core/txpool/legacypool/legacypool_opstack_test.go
+++ b/core/txpool/legacypool/legacypool_opstack_test.go
@@ -82,7 +82,6 @@ func testInvalidRollupTransactions(t *testing.T, stateMod func(t *testing.T, poo
 
 	// base fee is 1
 	testAddBalance(pool, from, new(big.Int).Add(big.NewInt(gasLimit), tx.Value()))
-	pool.reset(nil, nil) // initiates rollup cost func
 	// we add the test variant with zero rollup cost as a sanity check that the tx would indeed be valid
 	if stateMod == nil {
 		require.NoError(t, pool.addRemote(tx))
@@ -124,7 +123,6 @@ func testRollupTransactionCostAccounting(t *testing.T, stateMod func(t *testing.
 	tx1 := pricedTransaction(0, gasLimit, gasPrice1, key)
 	from, _ := deriveSender(tx0)
 
-	pool.reset(nil, nil) // initiates rollup cost func
 	require.NotNil(t, pool.rollupCostFn)
 
 	if stateMod != nil {

--- a/core/txpool/legacypool/list.go
+++ b/core/txpool/legacypool/list.go
@@ -286,6 +286,11 @@ type list struct {
 	costcap   *uint256.Int // Price of the highest costing transaction (reset only if exceeds balance)
 	gascap    uint64       // Gas limit of the highest spending transaction (reset only if exceeds block limit)
 	totalcost *uint256.Int // Total cost of all transactions in the list
+
+	// OP-Stack adds a backpointer to the pool's rollup cost function.
+	// A list always belongs to a fixed pool, so it's ok to use a reference instead of
+	// always passing the rollup cost function as an argument to every function.
+	rollupCostFn *txpool.RollupCostFunc
 }
 
 // newList creates a new transaction list for maintaining nonce-indexable fast,
@@ -299,6 +304,14 @@ func newList(strict bool) *list {
 	}
 }
 
+// newRollupList creates a new transaction list with a rollup cost function pointer
+// that must point back to the pool's rollup cost function this list belongs to.
+func newRollupList(strict bool, rollupCostFn *txpool.RollupCostFunc) *list {
+	l := newList(strict)
+	l.rollupCostFn = rollupCostFn
+	return l
+}
+
 // Contains returns whether the  list contains a transaction
 // with the provided nonce.
 func (l *list) Contains(nonce uint64) bool {
@@ -310,7 +323,7 @@ func (l *list) Contains(nonce uint64) bool {
 //
 // If the new transaction is accepted into the list, the lists' cost and gas
 // thresholds are also potentially updated.
-func (l *list) Add(tx *types.Transaction, priceBump uint64, rollupCostFn txpool.RollupCostFunc) (bool, *types.Transaction) {
+func (l *list) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Transaction) {
 	// If there's an older better transaction, abort
 	old := l.txs.Get(tx.Nonce())
 	if old != nil {
@@ -337,7 +350,7 @@ func (l *list) Add(tx *types.Transaction, priceBump uint64, rollupCostFn txpool.
 		l.subTotalCost([]*types.Transaction{old})
 	}
 	// Add new tx cost to totalcost
-	cost, overflow := txpool.TotalTxCost(tx, rollupCostFn)
+	cost, overflow := txpool.TotalTxCost(tx, *l.rollupCostFn)
 	if overflow {
 		return false, nil
 	}
@@ -472,7 +485,11 @@ func (l *list) LastElement() *types.Transaction {
 // total cost of all transactions.
 func (l *list) subTotalCost(txs []*types.Transaction) {
 	for _, tx := range txs {
-		_, underflow := l.totalcost.SubOverflow(l.totalcost, uint256.MustFromBig(tx.Cost()))
+		cost, overflow := txpool.TotalTxCost(tx, *l.rollupCostFn)
+		if overflow {
+			panic("tx total cost overflow")
+		}
+		_, underflow := l.totalcost.SubOverflow(l.totalcost, cost)
 		if underflow {
 			panic("totalcost underflow")
 		}

--- a/core/txpool/legacypool/list.go
+++ b/core/txpool/legacypool/list.go
@@ -290,7 +290,8 @@ type list struct {
 	// OP-Stack adds a backpointer to the pool's rollup cost function.
 	// A list always belongs to a fixed pool, so it's ok to use a reference instead of
 	// always passing the rollup cost function as an argument to every function.
-	rollupCostFn *txpool.RollupCostFunc
+	// It should not be accessed directly, but through the rollupCostFn method.
+	rollupCostFnPtr *txpool.RollupCostFunc
 }
 
 // newList creates a new transaction list for maintaining nonce-indexable fast,
@@ -308,8 +309,17 @@ func newList(strict bool) *list {
 // that must point back to the pool's rollup cost function this list belongs to.
 func newRollupList(strict bool, rollupCostFn *txpool.RollupCostFunc) *list {
 	l := newList(strict)
-	l.rollupCostFn = rollupCostFn
+	l.rollupCostFnPtr = rollupCostFn
 	return l
+}
+
+func (l *list) rollupCostFn() txpool.RollupCostFunc {
+	if l.rollupCostFnPtr == nil {
+		return nil
+	}
+	// This can still return nil, but we won't dereference a nil pointer of lists
+	// that got regularly created using newList instead of newRollupList.
+	return *l.rollupCostFnPtr
 }
 
 // Contains returns whether the  list contains a transaction
@@ -350,7 +360,7 @@ func (l *list) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Transa
 		l.subTotalCost([]*types.Transaction{old})
 	}
 	// Add new tx cost to totalcost
-	cost, overflow := txpool.TotalTxCost(tx, *l.rollupCostFn)
+	cost, overflow := txpool.TotalTxCost(tx, l.rollupCostFn())
 	if overflow {
 		return false, nil
 	}
@@ -394,7 +404,7 @@ func (l *list) Filter(costLimit *uint256.Int, gasLimit uint64) (types.Transactio
 
 	// Filter out all the transactions above the account's funds
 	removed := l.txs.Filter(func(tx *types.Transaction) bool {
-		cost, of := txpool.TotalTxCost(tx, *l.rollupCostFn)
+		cost, of := txpool.TotalTxCost(tx, l.rollupCostFn())
 		if of {
 			panic("Filter: tx total cost overflow")
 		}
@@ -489,7 +499,7 @@ func (l *list) LastElement() *types.Transaction {
 // total cost of all transactions.
 func (l *list) subTotalCost(txs []*types.Transaction) {
 	for _, tx := range txs {
-		cost, overflow := txpool.TotalTxCost(tx, *l.rollupCostFn)
+		cost, overflow := txpool.TotalTxCost(tx, l.rollupCostFn())
 		if overflow {
 			panic("tx total cost overflow")
 		}

--- a/core/txpool/legacypool/list.go
+++ b/core/txpool/legacypool/list.go
@@ -310,7 +310,7 @@ func (l *list) Contains(nonce uint64) bool {
 //
 // If the new transaction is accepted into the list, the lists' cost and gas
 // thresholds are also potentially updated.
-func (l *list) Add(tx *types.Transaction, priceBump uint64, l1CostFn txpool.L1CostFunc) (bool, *types.Transaction) {
+func (l *list) Add(tx *types.Transaction, priceBump uint64, rollupCostFn txpool.RollupCostFunc) (bool, *types.Transaction) {
 	// If there's an older better transaction, abort
 	old := l.txs.Get(tx.Nonce())
 	if old != nil {
@@ -342,9 +342,12 @@ func (l *list) Add(tx *types.Transaction, priceBump uint64, l1CostFn txpool.L1Co
 		return false, nil
 	}
 	l.totalcost.Add(l.totalcost, cost)
-	if l1CostFn != nil {
-		if l1Cost := l1CostFn(tx.RollupCostData()); l1Cost != nil { // add rollup cost
-			l.totalcost.Add(l.totalcost, cost)
+	if rollupCostFn != nil {
+		if rollupCost := rollupCostFn(tx); rollupCost != nil { // add rollup cost
+			_, overflow = l.totalcost.AddOverflow(l.totalcost, rollupCost)
+			if overflow {
+				return false, nil
+			}
 		}
 	}
 	// Otherwise overwrite the old transaction with the current one

--- a/core/txpool/legacypool/list.go
+++ b/core/txpool/legacypool/list.go
@@ -337,19 +337,11 @@ func (l *list) Add(tx *types.Transaction, priceBump uint64, rollupCostFn txpool.
 		l.subTotalCost([]*types.Transaction{old})
 	}
 	// Add new tx cost to totalcost
-	cost, overflow := uint256.FromBig(tx.Cost())
+	cost, overflow := txpool.TotalTxCost(tx, rollupCostFn)
 	if overflow {
 		return false, nil
 	}
 	l.totalcost.Add(l.totalcost, cost)
-	if rollupCostFn != nil {
-		if rollupCost := rollupCostFn(tx); rollupCost != nil { // add rollup cost
-			_, overflow = l.totalcost.AddOverflow(l.totalcost, rollupCost)
-			if overflow {
-				return false, nil
-			}
-		}
-	}
 	// Otherwise overwrite the old transaction with the current one
 	l.txs.Put(tx)
 	if l.costcap.Cmp(cost) < 0 {

--- a/core/txpool/legacypool/list.go
+++ b/core/txpool/legacypool/list.go
@@ -394,7 +394,11 @@ func (l *list) Filter(costLimit *uint256.Int, gasLimit uint64) (types.Transactio
 
 	// Filter out all the transactions above the account's funds
 	removed := l.txs.Filter(func(tx *types.Transaction) bool {
-		return tx.Gas() > gasLimit || tx.Cost().Cmp(costLimit.ToBig()) > 0
+		cost, of := txpool.TotalTxCost(tx, *l.rollupCostFn)
+		if of {
+			panic("Filter: tx total cost overflow")
+		}
+		return tx.Gas() > gasLimit || cost.Cmp(costLimit) > 0
 	})
 
 	if len(removed) == 0 {

--- a/core/txpool/legacypool/list.go
+++ b/core/txpool/legacypool/list.go
@@ -291,7 +291,7 @@ type list struct {
 	// A list always belongs to a fixed pool, so it's ok to use a reference instead of
 	// always passing the rollup cost function as an argument to every function.
 	// It should not be accessed directly, but through the rollupCostFn method.
-	rollupCostFnPtr *txpool.RollupCostFunc
+	rollupCostFnPrv rollupCostFuncProvider
 }
 
 // newList creates a new transaction list for maintaining nonce-indexable fast,
@@ -305,21 +305,25 @@ func newList(strict bool) *list {
 	}
 }
 
+type rollupCostFuncProvider interface {
+	RollupCostFunc() txpool.RollupCostFunc
+}
+
 // newRollupList creates a new transaction list with a rollup cost function pointer
 // that must point back to the pool's rollup cost function this list belongs to.
-func newRollupList(strict bool, rollupCostFn *txpool.RollupCostFunc) *list {
+func newRollupList(strict bool, rollupCostFnPrv rollupCostFuncProvider) *list {
 	l := newList(strict)
-	l.rollupCostFnPtr = rollupCostFn
+	l.rollupCostFnPrv = rollupCostFnPrv
 	return l
 }
 
 func (l *list) rollupCostFn() txpool.RollupCostFunc {
-	if l.rollupCostFnPtr == nil {
+	if l.rollupCostFnPrv == nil {
 		return nil
 	}
 	// This can still return nil, but we won't dereference a nil pointer of lists
 	// that got regularly created using newList instead of newRollupList.
-	return *l.rollupCostFnPtr
+	return l.rollupCostFnPrv.RollupCostFunc()
 }
 
 // Contains returns whether the  list contains a transaction

--- a/core/txpool/legacypool/list_test.go
+++ b/core/txpool/legacypool/list_test.go
@@ -40,7 +40,7 @@ func TestStrictListAdd(t *testing.T) {
 	// Insert the transactions in a random order
 	list := newList(true)
 	for _, v := range rand.Perm(len(txs)) {
-		list.Add(txs[v], DefaultConfig.PriceBump, nil)
+		list.Add(txs[v], DefaultConfig.PriceBump)
 	}
 	// Verify internal state
 	if len(list.txs.items) != len(txs) {
@@ -64,7 +64,7 @@ func TestListAddVeryExpensive(t *testing.T) {
 		gaslimit := uint64(i)
 		tx, _ := types.SignTx(types.NewTransaction(uint64(i), common.Address{}, value, gaslimit, gasprice, nil), types.HomesteadSigner{}, key)
 		t.Logf("cost: %x bitlen: %d\n", tx.Cost(), tx.Cost().BitLen())
-		list.Add(tx, DefaultConfig.PriceBump, nil)
+		list.Add(tx, DefaultConfig.PriceBump)
 	}
 }
 
@@ -82,7 +82,7 @@ func BenchmarkListAdd(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		list := newList(true)
 		for _, v := range rand.Perm(len(txs)) {
-			list.Add(txs[v], DefaultConfig.PriceBump, nil)
+			list.Add(txs[v], DefaultConfig.PriceBump)
 			list.Filter(priceLimit, DefaultConfig.PriceBump)
 		}
 	}
@@ -102,7 +102,7 @@ func BenchmarkListCapOneTx(b *testing.B) {
 		list := newList(true)
 		// Insert the transactions in a random order
 		for _, v := range rand.Perm(len(txs)) {
-			list.Add(txs[v], DefaultConfig.PriceBump, nil)
+			list.Add(txs[v], DefaultConfig.PriceBump)
 		}
 		b.StartTimer()
 		list.Cap(list.Len() - 1)

--- a/core/txpool/rollup.go
+++ b/core/txpool/rollup.go
@@ -1,0 +1,49 @@
+// Copyright 2025 The op-geth Authors
+// This file is part of the op-geth library.
+//
+// The op-geth library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The op-geth library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the op-geth library. If not, see <http://www.gnu.org/licenses/>.
+
+package txpool
+
+import (
+	"math/big"
+
+	"github.com/holiman/uint256"
+
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+type RollupCostFunc func(tx types.RollupTransaction) *uint256.Int
+
+type RollupTransaction interface {
+	types.RollupTransaction
+	Cost() *big.Int
+}
+
+// TotalTxCost returns the transaction's total cost, including the regular execution cost and
+// the rollup costs (L1 costs and operator costs).
+func TotalTxCost(tx RollupTransaction, rollupCostFn RollupCostFunc) (*uint256.Int, bool) {
+	cost, overflow := uint256.FromBig(tx.Cost())
+	if overflow {
+		return nil, true
+	} else if rollupCostFn == nil {
+		return cost, false
+	}
+
+	rollupCost := rollupCostFn(tx)
+	if rollupCost == nil {
+		return cost, false
+	}
+	return cost.AddOverflow(cost, rollupCost)
+}

--- a/core/txpool/rollup.go
+++ b/core/txpool/rollup.go
@@ -33,6 +33,7 @@ type RollupTransaction interface {
 
 // TotalTxCost returns the transaction's total cost, including the regular execution cost and
 // the rollup costs (L1 costs and operator costs).
+// Only regular costs apply if rollupCostFn is nil.
 func TotalTxCost(tx RollupTransaction, rollupCostFn RollupCostFunc) (*uint256.Int, bool) {
 	cost, overflow := uint256.FromBig(tx.Cost())
 	if overflow {

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -23,6 +23,8 @@ import (
 	"math/big"
 	"sync"
 
+	"github.com/holiman/uint256"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -32,7 +34,7 @@ import (
 	"github.com/ethereum/go-ethereum/metrics"
 )
 
-type L1CostFunc func(dataGas types.RollupCostData) *big.Int
+type RollupCostFunc func(tx types.RollupTransaction) *uint256.Int
 
 // TxStatus is the current status of a transaction as seen by the pool.
 type TxStatus uint
@@ -44,14 +46,12 @@ const (
 	TxStatusIncluded
 )
 
-var (
-	// reservationsGaugeName is the prefix of a per-subpool address reservation
-	// metric.
-	//
-	// This is mostly a sanity metric to ensure there's no bug that would make
-	// some subpool hog all the reservations due to mis-accounting.
-	reservationsGaugeName = "txpool/reservations"
-)
+// reservationsGaugeName is the prefix of a per-subpool address reservation
+// metric.
+//
+// This is mostly a sanity metric to ensure there's no bug that would make
+// some subpool hog all the reservations due to mis-accounting.
+var reservationsGaugeName = "txpool/reservations"
 
 // BlockChain defines the minimal set of methods needed to back a tx pool with
 // a chain. Exists to allow mocking the live chain out of tests.

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -23,8 +23,6 @@ import (
 	"math/big"
 	"sync"
 
-	"github.com/holiman/uint256"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -33,8 +31,6 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
 )
-
-type RollupCostFunc func(tx types.RollupTransaction) *uint256.Int
 
 // TxStatus is the current status of a transaction as seen by the pool.
 type TxStatus uint

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -46,12 +46,14 @@ const (
 	TxStatusIncluded
 )
 
-// reservationsGaugeName is the prefix of a per-subpool address reservation
-// metric.
-//
-// This is mostly a sanity metric to ensure there's no bug that would make
-// some subpool hog all the reservations due to mis-accounting.
-var reservationsGaugeName = "txpool/reservations"
+var (
+	// reservationsGaugeName is the prefix of a per-subpool address reservation
+	// metric.
+	//
+	// This is mostly a sanity metric to ensure there's no bug that would make
+	// some subpool hog all the reservations due to mis-accounting.
+	reservationsGaugeName = "txpool/reservations"
+)
 
 // BlockChain defines the minimal set of methods needed to back a tx pool with
 // a chain. Exists to allow mocking the live chain out of tests.

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -37,11 +37,9 @@ import (
 // are not able to consume all of the gas in a L2 block as the L1 info deposit is always present.
 const l1InfoGasOverhead = uint64(70_000)
 
-var (
-	// blobTxMinBlobGasPrice is the big.Int version of the configured protocol
-	// parameter to avoid constructing a new big integer for every transaction.
-	blobTxMinBlobGasPrice = big.NewInt(params.BlobTxMinBlobGasprice)
-)
+// blobTxMinBlobGasPrice is the big.Int version of the configured protocol
+// parameter to avoid constructing a new big integer for every transaction.
+var blobTxMinBlobGasPrice = big.NewInt(params.BlobTxMinBlobGasprice)
 
 func EffectiveGasLimit(chainConfig *params.ChainConfig, gasLimit uint64, effectiveLimit uint64) uint64 {
 	if effectiveLimit != 0 && effectiveLimit < gasLimit {
@@ -249,8 +247,8 @@ type ValidationOptionsWithState struct {
 	// transaction's cost with the given nonce to check for overdrafts.
 	ExistingCost func(addr common.Address, nonce uint64) *big.Int
 
-	// L1CostFn is an optional extension, to validate L1 rollup costs of a tx
-	L1CostFn L1CostFunc
+	// RollupCostFn is an optional extension, to validate total rollup costs of a tx
+	RollupCostFn RollupCostFunc
 }
 
 // ValidateTransactionWithState is a helper method to check whether a transaction
@@ -281,9 +279,9 @@ func ValidateTransactionWithState(tx *types.Transaction, signer types.Signer, op
 		balance = opts.State.GetBalance(from).ToBig()
 		cost    = tx.Cost()
 	)
-	if opts.L1CostFn != nil {
-		if l1Cost := opts.L1CostFn(tx.RollupCostData()); l1Cost != nil { // add rollup cost
-			cost = cost.Add(cost, l1Cost)
+	if opts.RollupCostFn != nil {
+		if rollupCost := opts.RollupCostFn(tx); rollupCost != nil { // add rollup cost
+			cost = cost.Add(cost, rollupCost.ToBig())
 		}
 	}
 	if balance.Cmp(cost) < 0 {

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -278,14 +278,13 @@ func ValidateTransactionWithState(tx *types.Transaction, signer types.Signer, op
 	}
 	// Ensure the transactor has enough funds to cover the transaction costs
 	var (
-		balance = opts.State.GetBalance(from).ToBig()
-		cost    = tx.Cost()
+		balance           = opts.State.GetBalance(from).ToBig()
+		cost256, overflow = TotalTxCost(tx, opts.RollupCostFn)
 	)
-	if opts.RollupCostFn != nil {
-		if rollupCost := opts.RollupCostFn(tx); rollupCost != nil { // add rollup cost
-			cost = cost.Add(cost, rollupCost.ToBig())
-		}
+	if overflow {
+		return fmt.Errorf("%w: total tx cost overflow", core.ErrInsufficientFunds)
 	}
+	cost := cost256.ToBig()
 	if balance.Cmp(cost) < 0 {
 		return fmt.Errorf("%w: balance %v, tx cost %v, overshot %v", core.ErrInsufficientFunds, balance, cost, new(big.Int).Sub(cost, balance))
 	}

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -37,9 +37,11 @@ import (
 // are not able to consume all of the gas in a L2 block as the L1 info deposit is always present.
 const l1InfoGasOverhead = uint64(70_000)
 
-// blobTxMinBlobGasPrice is the big.Int version of the configured protocol
-// parameter to avoid constructing a new big integer for every transaction.
-var blobTxMinBlobGasPrice = big.NewInt(params.BlobTxMinBlobGasprice)
+var (
+	// blobTxMinBlobGasPrice is the big.Int version of the configured protocol
+	// parameter to avoid constructing a new big integer for every transaction.
+	blobTxMinBlobGasPrice = big.NewInt(params.BlobTxMinBlobGasprice)
+)
 
 func EffectiveGasLimit(chainConfig *params.ChainConfig, gasLimit uint64, effectiveLimit uint64) uint64 {
 	if effectiveLimit != 0 && effectiveLimit < gasLimit {

--- a/core/types/rollup_cost.go
+++ b/core/types/rollup_cost.go
@@ -321,6 +321,9 @@ func newL1CostFuncEcotone(l1BaseFee, l1BlobBaseFee, l1BaseFeeScalar, l1BlobBaseF
 // NewTotalRollupCostFunc return a TotalRollupCostFunc that computes the total rollup cost, consisting
 // of both, the data availability cost and the operator cost.
 func NewTotalRollupCostFunc(config *params.ChainConfig, statedb StateGetter) TotalRollupCostFunc {
+	if !config.IsOptimism() {
+		return nil
+	}
 	l1CostFunc := NewL1CostFunc(config, statedb)
 	operatorCostFunc := NewOperatorCostFunc(config, statedb)
 

--- a/core/types/rollup_cost.go
+++ b/core/types/rollup_cost.go
@@ -110,6 +110,16 @@ type L1CostFunc func(rcd RollupCostData, blockTime uint64) *big.Int
 // sender of non-Deposit transactions. It returns 0 if no operator fee is charged.
 type OperatorCostFunc func(gasUsed uint64, blockTime uint64) *uint256.Int
 
+// A RollupTransaction provides all the input data needed to compute the total rollup cost.
+type RollupTransaction interface {
+	RollupCostData() RollupCostData
+	Gas() uint64
+}
+
+// TotalRollupCostFunc is used in the transaction pool to determine the total rollup cost,
+// including both the data availability fee and the operator fee. It returns nil if both costs are nil.
+type TotalRollupCostFunc func(tx RollupTransaction, blockTime uint64) *uint256.Int
+
 // l1CostFunc is an internal version of L1CostFunc that also returns the gasUsed for use in
 // receipts.
 type l1CostFunc func(rcd RollupCostData) (fee, gasUsed *big.Int)
@@ -308,6 +318,43 @@ func newL1CostFuncEcotone(l1BaseFee, l1BlobBaseFee, l1BaseFeeScalar, l1BlobBaseF
 	}
 }
 
+// NewTotalRollupCostFunc return a TotalRollupCostFunc that computes the total rollup cost, consisting
+// of both, the data availability cost and the operator cost.
+func NewTotalRollupCostFunc(config *params.ChainConfig, statedb StateGetter) TotalRollupCostFunc {
+	l1CostFunc := NewL1CostFunc(config, statedb)
+	operatorCostFunc := NewOperatorCostFunc(config, statedb)
+
+	return func(tx RollupTransaction, blockTime uint64) *uint256.Int {
+		// proper caching is happening inside the individual cost functions
+		l1Cost := l1CostFunc(tx.RollupCostData(), blockTime)
+		operatorCost := operatorCostFunc(tx.Gas(), blockTime)
+		if l1Cost == nil && operatorCost == nil {
+			return nil
+		}
+
+		var totalCost *uint256.Int
+		var overflow bool
+		if l1Cost != nil {
+			totalCost, overflow = uint256.FromBig(l1Cost)
+			if overflow {
+				panic("overflow in total rollup cost: l1Cost")
+			}
+		} else {
+			totalCost = new(uint256.Int)
+		}
+
+		// Note, the operator cost currently always returns a non-nil value, so we wouldn't
+		// need the nil-check here. But we keep it for future-proofing.
+		if operatorCost != nil {
+			_, overflow = totalCost.AddOverflow(totalCost, operatorCost)
+			if overflow {
+				panic("overflow in total rollup cost: operatorCost")
+			}
+		}
+		return totalCost
+	}
+}
+
 type gasParams struct {
 	l1BaseFee           *big.Int
 	l1BlobBaseFee       *big.Int
@@ -477,9 +524,9 @@ func l1CostHelper(gasWithOverhead, l1BaseFee, scalar *big.Int) *big.Int {
 func NewL1CostFuncFjord(l1BaseFee, l1BlobBaseFee, baseFeeScalar, blobFeeScalar *big.Int) l1CostFunc {
 	return func(costData RollupCostData) (fee, calldataGasUsed *big.Int) {
 		// Fjord L1 cost function:
-		//l1FeeScaled = baseFeeScalar*l1BaseFee*16 + blobFeeScalar*l1BlobBaseFee
-		//estimatedSize = max(minTransactionSize, intercept + fastlzCoef*fastlzSize)
-		//l1Cost = estimatedSize * l1FeeScaled / 1e12
+		// l1FeeScaled = baseFeeScalar*l1BaseFee*16 + blobFeeScalar*l1BlobBaseFee
+		// estimatedSize = max(minTransactionSize, intercept + fastlzCoef*fastlzSize)
+		// l1Cost = estimatedSize * l1FeeScaled / 1e12
 
 		scaledL1BaseFee := new(big.Int).Mul(baseFeeScalar, l1BaseFee)
 		calldataCostPerByte := new(big.Int).Mul(scaledL1BaseFee, sixteen)

--- a/core/types/rollup_cost.go
+++ b/core/types/rollup_cost.go
@@ -171,7 +171,7 @@ func NewL1CostFunc(config *params.ChainConfig, statedb StateGetter) L1CostFunc {
 			return newL1CostFuncBedrock(config, statedb, blockTime)
 		}
 
-		l1BaseFeeScalar, l1BlobBaseFeeScalar := extractEcotoneFeeParams(l1FeeScalars)
+		l1BaseFeeScalar, l1BlobBaseFeeScalar := ExtractEcotoneFeeParams(l1FeeScalars)
 
 		if config.IsOptimismFjord(blockTime) {
 			return NewL1CostFuncFjord(
@@ -224,7 +224,7 @@ func NewOperatorCostFunc(config *params.ChainConfig, statedb StateGetter) Operat
 				return uint256.NewInt(0)
 			}
 		}
-		operatorFeeScalar, operatorFeeConstant := extractOperatorFeeParams(operatorFeeParams)
+		operatorFeeScalar, operatorFeeConstant := ExtractOperatorFeeParams(operatorFeeParams)
 
 		return newOperatorCostFunc(operatorFeeScalar, operatorFeeConstant)
 	}
@@ -565,14 +565,14 @@ func (cd RollupCostData) EstimatedDASize() *big.Int {
 	return b.Div(b, big.NewInt(1e6))
 }
 
-func extractEcotoneFeeParams(l1FeeParams []byte) (l1BaseFeeScalar, l1BlobBaseFeeScalar *big.Int) {
+func ExtractEcotoneFeeParams(l1FeeParams []byte) (l1BaseFeeScalar, l1BlobBaseFeeScalar *big.Int) {
 	offset := scalarSectionStart
 	l1BaseFeeScalar = new(big.Int).SetBytes(l1FeeParams[offset : offset+4])
 	l1BlobBaseFeeScalar = new(big.Int).SetBytes(l1FeeParams[offset+4 : offset+8])
 	return
 }
 
-func extractOperatorFeeParams(operatorFeeParams common.Hash) (operatorFeeScalar, operatorFeeConstant *big.Int) {
+func ExtractOperatorFeeParams(operatorFeeParams common.Hash) (operatorFeeScalar, operatorFeeConstant *big.Int) {
 	operatorFeeScalar = new(big.Int).SetBytes(operatorFeeParams[20:24])
 	operatorFeeConstant = new(big.Int).SetBytes(operatorFeeParams[24:32])
 	return

--- a/core/types/rollup_cost_test.go
+++ b/core/types/rollup_cost_test.go
@@ -503,3 +503,47 @@ func TestFlzCompressLen(t *testing.T) {
 		require.Equal(t, tc.expectedLen, output)
 	}
 }
+
+// copy of emptyTx with non-zero gas
+var emptyTxWithGas = NewTransaction(
+	0,
+	common.HexToAddress("095e7baea6a6c7c4c2dfeb977efac326af552d87"),
+	big.NewInt(0), bedrockGas.Uint64(), big.NewInt(0),
+	nil,
+)
+
+// TestTotalRollupCostFunc tests that the total rollup cost function correctly
+// combines the L1 cost and operator cost.
+func TestTotalRollupCostFunc(t *testing.T) {
+	zero := uint64(0)
+	later := uint64(10)
+	config := &params.ChainConfig{
+		Optimism:     params.OptimismTestConfig.Optimism,
+		RegolithTime: &zero,
+		EcotoneTime:  &zero,
+		FjordTime:    &zero,
+		HoloceneTime: &zero,
+		IsthmusTime:  &later,
+	}
+	statedb := &testStateGetter{
+		baseFee:             baseFee,
+		overhead:            overhead,
+		scalar:              scalar,
+		blobBaseFee:         blobBaseFee,
+		baseFeeScalar:       uint32(baseFeeScalar.Uint64()),
+		blobBaseFeeScalar:   uint32(blobBaseFeeScalar.Uint64()),
+		operatorFeeScalar:   uint32(operatorFeeScalar.Uint64()),
+		operatorFeeConstant: operatorFeeConstant.Uint64(),
+	}
+
+	costFunc := NewTotalRollupCostFunc(config, statedb)
+	cost := costFunc(emptyTxWithGas, later/2)
+	require.NotNil(t, cost)
+	expCost := uint256.MustFromBig(fjordFee)
+	require.Equal(t, expCost, cost, "pre-Isthmus total rollup cost should only contain L1 cost")
+
+	cost = costFunc(emptyTxWithGas, later*2)
+	require.NotNil(t, cost)
+	expCost.Add(expCost, ithmusOperatorFee)
+	require.Equal(t, expCost, cost, "Isthmus total rollup cost should contain L1 cost and operator cost")
+}

--- a/core/types/rollup_cost_test.go
+++ b/core/types/rollup_cost_test.go
@@ -537,12 +537,12 @@ func TestTotalRollupCostFunc(t *testing.T) {
 	}
 
 	costFunc := NewTotalRollupCostFunc(config, statedb)
-	cost := costFunc(emptyTxWithGas, later/2)
+	cost := costFunc(emptyTxWithGas, later-1)
 	require.NotNil(t, cost)
 	expCost := uint256.MustFromBig(fjordFee)
 	require.Equal(t, expCost, cost, "pre-Isthmus total rollup cost should only contain L1 cost")
 
-	cost = costFunc(emptyTxWithGas, later*2)
+	cost = costFunc(emptyTxWithGas, later+1)
 	require.NotNil(t, cost)
 	expCost.Add(expCost, ithmusOperatorFee)
 	require.Equal(t, expCost, cost, "Isthmus total rollup cost should contain L1 cost and operator cost")

--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -1548,7 +1548,7 @@ func TestBlockToPayloadWithBlobs(t *testing.T) {
 	if got := len(envelope.BlobsBundle.Blobs); got != want {
 		t.Fatalf("invalid number of blobs: got %v, want %v", got, want)
 	}
-	_, err := engine.ExecutableDataToBlock(*envelope.ExecutionPayload, make([]common.Hash, 1), nil, nil, params.OptimismTestConfig)
+	_, err := engine.ExecutableDataToBlock(*envelope.ExecutionPayload, make([]common.Hash, 1), nil, nil, types.DefaultBlockConfig)
 	if err != nil {
 		t.Error(err)
 	}

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -635,7 +635,7 @@ func TestTraceTransactionHistorical(t *testing.T) {
 	// Initialize test accounts
 	accounts := newAccounts(2)
 	genesis := &core.Genesis{
-		Config: params.OptimismTestConfig,
+		Config: params.OptimismTestCliqueConfig,
 		Alloc: types.GenesisAlloc{
 			accounts[0].addr: {Balance: big.NewInt(params.Ether)},
 			accounts[1].addr: {Balance: big.NewInt(params.Ether)},
@@ -780,7 +780,7 @@ func TestTraceBlockHistorical(t *testing.T) {
 	// Initialize test accounts
 	accounts := newAccounts(3)
 	genesis := &core.Genesis{
-		Config: params.OptimismTestConfig,
+		Config: params.OptimismTestCliqueConfig,
 		Alloc: types.GenesisAlloc{
 			accounts[0].addr: {Balance: big.NewInt(params.Ether)},
 			accounts[1].addr: {Balance: big.NewInt(params.Ether)},

--- a/ethclient/ethclient_test.go
+++ b/ethclient/ethclient_test.go
@@ -83,7 +83,7 @@ var genesis = &core.Genesis{
 }
 
 var genesisForHistorical = &core.Genesis{
-	Config:    params.OptimismTestConfig,
+	Config:    params.OptimismTestCliqueConfig,
 	Alloc:     types.GenesisAlloc{testAddr: {Balance: testBalance}},
 	ExtraData: []byte("test genesis"),
 	Timestamp: 9000,

--- a/params/config.go
+++ b/params/config.go
@@ -313,11 +313,30 @@ var (
 	TestRules = TestChainConfig.Rules(new(big.Int), false, 0)
 
 	// OP-Stack chain config with bedrock starting a block 5, introduced for historical endpoint testing, largely based on the clique config
-	OptimismTestConfig = func() *ChainConfig {
+	OptimismTestCliqueConfig = func() *ChainConfig {
 		conf := *AllCliqueProtocolChanges // copy the config
 		conf.Clique = nil
 		conf.BedrockBlock = big.NewInt(5)
 		conf.Optimism = &OptimismConfig{EIP1559Elasticity: 50, EIP1559Denominator: 10}
+		return &conf
+	}()
+
+	// OP-Stack chain config with all production forks activated, based on the MergedTestChainConfig
+	OptimismTestConfig = func() *ChainConfig {
+		conf := *MergedTestChainConfig // copy the config
+		conf.BlobScheduleConfig = nil
+		conf.BedrockBlock = big.NewInt(0)
+		zero := uint64(0)
+		conf.RegolithTime = &zero
+		conf.CanyonTime = &zero
+		conf.EcotoneTime = &zero
+		conf.FjordTime = &zero
+		conf.GraniteTime = &zero
+		conf.HoloceneTime = &zero
+		conf.IsthmusTime = &zero
+		conf.InteropTime = nil
+		conf.JovianTime = nil
+		conf.Optimism = &OptimismConfig{EIP1559Elasticity: 50, EIP1559Denominator: 10, EIP1559DenominatorCanyon: uint64ptr(250)}
 		return &conf
 	}()
 )


### PR DESCRIPTION
**Description**
 
Switches the txpool to take the total rollup (L1 + operator fee) cost into account when determining whether to insert a transaction into the txpool. So far, it only took the L1 cost into account.

Also fixes total tx cost accounting in the txpool and tx list.

Credits to @kustrun who already partially fixed this problem in https://github.com/ethereum-optimism/op-geth/pull/324 a couple months ago. We unfortunately forgot to follow up there. This PR supersedes it.

**Tests**

Added unit tests to check that accounting is right.

**Metadata**

Fixes https://github.com/ethereum-optimism/op-geth/issues/553
