### PR TITLE
rpc: RPC recording functions

### DIFF
--- a/fork.yaml
+++ b/fork.yaml
@@ -327,6 +327,18 @@ def:
     - title: "Geth extras"
       description: Extend the tools available in geth to improve external testing and tooling.
       sub:
+        - title: JSON-RPC recording
+          description: |
+            Extend server and client with configurable JSON-RPC message recording.
+            This enables loggers and advanced metrics to be attached to server and client sides.
+          globs:
+            - "rpc/client.go"
+            - "rpc/client_opt.go"
+            - "rpc/handler.go"
+            - "rpc/inproc.go"
+            - "rpc/recording.go"
+            - "rpc/server.go"
+            - "rpc/subscription.go"
         - title: Simulated Backend
           globs:
             - "accounts/abi/bind/backends/simulated.go"

--- a/rpc/client_opt.go
+++ b/rpc/client_opt.go
@@ -41,6 +41,8 @@ type clientConfig struct {
 	idgen              func() ID
 	batchItemLimit     int
 	batchResponseLimit int
+
+	recorder Recorder
 }
 
 func (cfg *clientConfig) initHeaders() {

--- a/rpc/inproc.go
+++ b/rpc/inproc.go
@@ -22,9 +22,12 @@ import (
 )
 
 // DialInProc attaches an in-process connection to the given RPC server.
-func DialInProc(handler *Server) *Client {
+func DialInProc(handler *Server, options ...ClientOption) *Client {
 	initctx := context.Background()
 	cfg := new(clientConfig)
+	for _, opt := range options {
+		opt.applyOption(cfg)
+	}
 	c, _ := newClient(initctx, cfg, func(context.Context) (ServerCodec, error) {
 		p1, p2 := net.Pipe()
 		go handler.ServeCodec(NewCodec(p1), 0)

--- a/rpc/recording.go
+++ b/rpc/recording.go
@@ -1,0 +1,98 @@
+package rpc
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// RecordDone is called after an incoming input (request or notification) has successfully been processed,
+// and captures the output (nil or response).
+type RecordDone func(ctx context.Context, input, output RecordedMsg)
+
+// Recorder captures RPC traffic
+type Recorder interface {
+	// RecordIncoming records an incoming message (request or notification), before it has been processed.
+	// It may optionally return a function to capture the result of the processing (response or nil).
+	RecordIncoming(ctx context.Context, msg RecordedMsg) RecordDone
+
+	// RecordOutgoing records an outgoing message (request or notification), before it has been sent.
+	// It may optionally return a function to capture the result of the request (response or nil).
+	RecordOutgoing(ctx context.Context, msg RecordedMsg) RecordDone
+}
+
+// RecordedMsg wraps around the internal jsonrpcMessage type,
+// to provide a public read-only interface for recording of RPC activity.
+// Every method name is prefixed with "Msg", to avoid conflict with internal methods and future geth changes.
+type RecordedMsg interface {
+	MsgIsNotification() bool
+	MsgIsResponse() bool
+	MsgID() json.RawMessage
+	MsgMethod() string
+	MsgParams() json.RawMessage
+	MsgError() Error
+	MsgResult() json.RawMessage
+}
+
+var _ RecordedMsg = (*jsonrpcMessage)(nil)
+
+func (msg *jsonrpcMessage) MsgIsNotification() bool {
+	return msg.isNotification()
+}
+
+func (msg *jsonrpcMessage) MsgIsResponse() bool {
+	return msg.isResponse()
+}
+
+func (msg *jsonrpcMessage) MsgID() json.RawMessage {
+	return msg.ID
+}
+func (msg *jsonrpcMessage) MsgMethod() string {
+	return msg.Method
+}
+func (msg *jsonrpcMessage) MsgParams() json.RawMessage {
+	return msg.Params
+}
+func (msg *jsonrpcMessage) MsgError() Error {
+	return msg.Error
+}
+func (msg *jsonrpcMessage) MsgResult() json.RawMessage {
+	return msg.Result
+}
+
+var _ RecordedMsg = (*jsonrpcSubscriptionNotification)(nil)
+
+func (notif *jsonrpcSubscriptionNotification) MsgIsNotification() bool {
+	return true
+}
+
+func (notif *jsonrpcSubscriptionNotification) MsgIsResponse() bool {
+	return false
+}
+
+func (notif *jsonrpcSubscriptionNotification) MsgID() json.RawMessage {
+	return json.RawMessage{} // notifications do not have an ID
+}
+
+func (notif *jsonrpcSubscriptionNotification) MsgMethod() string {
+	return notif.Method
+}
+
+func (notif *jsonrpcSubscriptionNotification) MsgParams() json.RawMessage {
+	data, _ := json.Marshal(notif.Params)
+	return data
+}
+
+func (notif *jsonrpcSubscriptionNotification) MsgError() Error {
+	return nil
+}
+
+func (notif *jsonrpcSubscriptionNotification) MsgResult() json.RawMessage {
+	return nil
+}
+
+// WithRecorder attaches a recorder to an RPC client, useful when it is serving bidirectional RPC
+func WithRecorder(r Recorder) ClientOption {
+	return optionFunc(func(cfg *clientConfig) {
+		cfg.recorder = r
+	})
+}

--- a/rpc/recording.go
+++ b/rpc/recording.go
@@ -29,7 +29,7 @@ type RecordedMsg interface {
 	MsgID() json.RawMessage
 	MsgMethod() string
 	MsgParams() json.RawMessage
-	MsgError() Error
+	MsgError() *JsonError
 	MsgResult() json.RawMessage
 }
 
@@ -52,7 +52,7 @@ func (msg *jsonrpcMessage) MsgMethod() string {
 func (msg *jsonrpcMessage) MsgParams() json.RawMessage {
 	return msg.Params
 }
-func (msg *jsonrpcMessage) MsgError() Error {
+func (msg *jsonrpcMessage) MsgError() *JsonError {
 	return msg.Error
 }
 func (msg *jsonrpcMessage) MsgResult() json.RawMessage {
@@ -82,7 +82,7 @@ func (notif *jsonrpcSubscriptionNotification) MsgParams() json.RawMessage {
 	return data
 }
 
-func (notif *jsonrpcSubscriptionNotification) MsgError() Error {
+func (notif *jsonrpcSubscriptionNotification) MsgError() *JsonError {
 	return nil
 }
 

--- a/rpc/recording_test.go
+++ b/rpc/recording_test.go
@@ -1,0 +1,138 @@
+package rpc
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/internal/testlog"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type testRecorder struct {
+	t   require.TestingT
+	log log.Logger
+
+	inReq   int // number of incoming requests
+	inResp  int // response count to incoming requests
+	inNotif int // number of incoming notifications
+
+	outReq   int // number of outgoing requests
+	outResp  int // response count of outgoing requests
+	outNotif int // number of sent notifications
+}
+
+var _ Recorder = (*testRecorder)(nil)
+
+func newTestRecorder(t *testing.T, log log.Logger) *testRecorder {
+	return &testRecorder{
+		t:   t,
+		log: log,
+	}
+}
+
+func (tr *testRecorder) RecordIncoming(ctx1 context.Context, msg RecordedMsg) RecordDone {
+	tr.log.Info("Handling incoming message", "id", msg.MsgID(),
+		"method", msg.MsgMethod(), "notif", msg.MsgIsNotification())
+	require.False(tr.t, msg.MsgIsResponse())
+	if msg.MsgIsNotification() {
+		tr.inNotif += 1
+	} else {
+		tr.inReq += 1
+	}
+	return func(ctx2 context.Context, input, output RecordedMsg) {
+		require.Equal(tr.t, ctx1, ctx2)
+		require.Equal(tr.t, msg, input)
+		if output == nil {
+			require.True(tr.t, input.MsgIsNotification())
+			tr.log.Info("Received notification", "method", input.MsgMethod())
+		} else if output != nil {
+			require.True(tr.t, output.MsgIsResponse())
+			require.Equal(tr.t, input.MsgID(), output.MsgID())
+			tr.inResp += 1
+			tr.log.Info("Received response", "id", input.MsgID(), "errObj", output.MsgError())
+		}
+	}
+}
+
+func (tr *testRecorder) RecordOutgoing(ctx1 context.Context, msg RecordedMsg) RecordDone {
+	tr.log.Info("Handling outgoing message", "id", msg.MsgID(), "method", msg.MsgMethod())
+	require.False(tr.t, msg.MsgIsResponse())
+	tr.outReq += 1
+	return func(ctx2 context.Context, input, output RecordedMsg) {
+		tr.outResp += 1
+		require.Equal(tr.t, msg, input)
+		require.Equal(tr.t, ctx1, ctx2)
+		if output == nil {
+			require.True(tr.t, input.MsgIsNotification())
+			tr.log.Info("Sent notification", "method", msg.MsgMethod())
+			tr.outNotif += 1
+		} else {
+			require.NotNil(tr.t, output)
+			require.False(tr.t, input.MsgIsResponse())
+			require.True(tr.t, output.MsgIsResponse())
+			require.Equal(tr.t, input.MsgID(), output.MsgID())
+			tr.log.Info("Received response", "id", input.MsgID(), "errObj", output.MsgError())
+		}
+	}
+}
+
+func TestRecording(t *testing.T) {
+	t.Parallel()
+
+	server := newTestServer()
+	defer server.Stop()
+	logger := testlog.Logger(t, log.LevelError)
+	srvRec := newTestRecorder(t, logger)
+	server.SetRecorder(srvRec)
+	clRec := newTestRecorder(t, logger)
+	client := DialInProc(server, WithRecorder(clRec))
+	defer client.Close()
+
+	var resp echoResult
+	if err := client.Call(&resp, "test_echo", "hello", 10, &echoArgs{"world"}); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(resp, echoResult{"hello", 10, &echoArgs{"world"}}) {
+		t.Errorf("incorrect result %#v", resp)
+	}
+	require.Equal(t, 1, clRec.outReq)
+	require.Equal(t, 1, clRec.outResp)
+	require.Equal(t, 0, clRec.inReq)
+	require.Equal(t, 0, clRec.inNotif)
+
+	require.Equal(t, 0, srvRec.outReq)
+	require.Equal(t, 0, srvRec.outResp)
+	require.Equal(t, 1, srvRec.inReq)
+	require.Equal(t, 0, srvRec.inNotif)
+
+	nc := make(chan int)
+	count := 10
+	sub, err := client.Subscribe(context.Background(), "nftest", nc, "someSubscription", count, 0)
+	if err != nil {
+		t.Fatal("can't subscribe:", err)
+	}
+	for i := 0; i < count; i++ {
+		if val := <-nc; val != i {
+			t.Fatalf("value mismatch: got %d, want %d", val, i)
+		}
+	}
+
+	sub.Unsubscribe()
+	select {
+	case v := <-nc:
+		t.Fatal("received value after unsubscribe:", v)
+	case err := <-sub.Err():
+		if err != nil {
+			t.Fatalf("Err returned a non-nil error after explicit unsubscribe: %q", err)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatalf("subscription not closed within 1s after unsubscribe")
+	}
+
+	require.Equal(t, 10, srvRec.outNotif, "must have sent 10 notifications")
+	require.Equal(t, 10, clRec.inNotif, "must have received 10 notifications")
+}

--- a/rpc/subscription.go
+++ b/rpc/subscription.go
@@ -171,7 +171,7 @@ func (n *Notifier) activate() error {
 }
 
 func (n *Notifier) send(sub *Subscription, data any) error {
-	msg := jsonrpcSubscriptionNotification{
+	msg := &jsonrpcSubscriptionNotification{
 		Version: vsn,
 		Method:  n.namespace + notificationMethodSuffix,
 		Params: subscriptionResultEnc{
@@ -179,7 +179,14 @@ func (n *Notifier) send(sub *Subscription, data any) error {
 			Result: data,
 		},
 	}
-	return n.h.conn.writeJSON(context.Background(), &msg, false)
+	ctx := context.Background()
+	if n.h.recorder != nil {
+		onDone := n.h.recorder.RecordOutgoing(ctx, msg)
+		if onDone != nil {
+			defer onDone(ctx, msg, nil)
+		}
+	}
+	return n.h.conn.writeJSON(ctx, msg, false)
 }
 
 // A Subscription is created by a notifier and tied to that notifier. The client can use


### PR DESCRIPTION
**Description**

Decorating every single RPC client / request in application code with metrics is no fun, and discourages metrics.
Instead, we can generalize RPC metering (and logging etc.) by allowing the user of the RPC library to plug in a recorder.

The recorder records incoming and outgoing RPC messages, with a call before the processing, and after (to capture response, keep track of error-codes in metrics, etc.)

Something like this may be possible to upstream, and I'll probably open an issue/PR to do exactly that, but we need it now in op-geth and the op-stack, so I'm opening the PR here first.

Draft.

TODO:
- [x] unit-test
- [x] monorepo integration, make sure API works well for what we need
- [x] `fork.yaml` update

**Tests**

Added unit test of recorder attachment to client/server. And opened monorepo PR to integrate it for metrics collection.

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
