### PR TITLE
Remove unsupported formatters from golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,17 +8,13 @@ run:
 linters:
   disable-all: true
   enable:
-    - goimports
-    - gosimple
     - govet
     - ineffassign
     - misspell
     - unconvert
-    - typecheck
     - unused
     - staticcheck
     - bidichk
-    - durationcheck
     - copyloopvar
     - whitespace
     - revive # only certain checks enabled


### PR DESCRIPTION
**Description**
Removed the following tools from the enable section, since in new versions of golangci-lint they are either considered formatters or not supported at all:

- `goimports` (a formatter, not a linter)
- `gosimple` (deprecated and not supported)
- `typecheck` (no longer exists as a linter)

Also removed the repeating line - `durationcheck` and left it only once.
Without these changes, golangci-lint fails with errors. Locally tested per the [official migration guide](https://golangci-lint.run/product/migration-guide/).
