### PR TITLE
eth/catalyst: return `InvalidParams` error if non-empty withdrawals post-isthmus

### DIFF
--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -661,8 +661,8 @@ func (api *ConsensusAPI) NewPayloadV4(params engine.ExecutableData, versionedHas
 	}
 
 	if api.eth.BlockChain().Config().IsIsthmus(params.Timestamp) {
-		if len(params.Withdrawals) != 0 {
-			return engine.PayloadStatusV1{Status: engine.INVALID}, engine.InvalidParams.With(errors.New("non-empty withdrawals post-isthmus"))
+		if params.Withdrawals == nil || len(params.Withdrawals) != 0 {
+			return engine.PayloadStatusV1{Status: engine.INVALID}, engine.InvalidParams.With(errors.New("non-empty or nil withdrawals post-isthmus"))
 		}
 		if params.WithdrawalsRoot == nil {
 			return engine.PayloadStatusV1{Status: engine.INVALID}, engine.InvalidParams.With(errors.New("nil withdrawalsRoot post-isthmus"))

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -660,12 +660,13 @@ func (api *ConsensusAPI) NewPayloadV4(params engine.ExecutableData, versionedHas
 		return engine.PayloadStatusV1{Status: engine.INVALID}, engine.UnsupportedFork.With(errors.New("newPayloadV4 must only be called for prague payloads"))
 	}
 
-	if api.eth.BlockChain().Config().IsIsthmus(params.Timestamp) && len(params.Withdrawals) != 0 {
-		return engine.PayloadStatusV1{Status: engine.INVALID}, engine.InvalidParams.With(errors.New("non-empty withdrawals post-isthmus"))
-	}
-
-	if api.eth.BlockChain().Config().IsIsthmus(params.Timestamp) && params.WithdrawalsRoot == nil {
-		return engine.PayloadStatusV1{Status: engine.INVALID}, engine.InvalidParams.With(errors.New("nil withdrawalsRoot post-isthmus"))
+	if api.eth.BlockChain().Config().IsIsthmus(params.Timestamp) {
+		if len(params.Withdrawals) != 0 {
+			return engine.PayloadStatusV1{Status: engine.INVALID}, engine.InvalidParams.With(errors.New("non-empty withdrawals post-isthmus"))
+		}
+		if params.WithdrawalsRoot == nil {
+			return engine.PayloadStatusV1{Status: engine.INVALID}, engine.InvalidParams.With(errors.New("nil withdrawalsRoot post-isthmus"))
+		}
 	}
 
 	requests := convertRequests(executionRequests)

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -660,6 +660,10 @@ func (api *ConsensusAPI) NewPayloadV4(params engine.ExecutableData, versionedHas
 		return engine.PayloadStatusV1{Status: engine.INVALID}, engine.UnsupportedFork.With(errors.New("newPayloadV4 must only be called for prague payloads"))
 	}
 
+	if api.eth.BlockChain().Config().IsIsthmus(params.Timestamp) && len(params.Withdrawals) != 0 {
+		return engine.PayloadStatusV1{Status: engine.INVALID}, engine.InvalidParams.With(errors.New("non-empty withdrawals post-isthmus"))
+	}
+
 	if api.eth.BlockChain().Config().IsIsthmus(params.Timestamp) && params.WithdrawalsRoot == nil {
 		return engine.PayloadStatusV1{Status: engine.INVALID}, engine.InvalidParams.With(errors.New("nil withdrawalsRoot post-isthmus"))
 	}


### PR DESCRIPTION
Closes #568 