### PR TITLE
Add support for async RPC verification of the supervisor_checkAccessList's access checks

### DIFF
--- a/core/txpool/ingress_filters.go
+++ b/core/txpool/ingress_filters.go
@@ -19,7 +19,7 @@ type IngressFilter interface {
 type interopFilterAPI interface {
 	CurrentInteropBlockTime() (uint64, error)
 	TxToInteropAccessList(tx *types.Transaction) []common.Hash
-	CheckAccessList(ctx context.Context, inboxEntries []common.Hash, minSafety interoptypes.SafetyLevel, execDesc interoptypes.ExecutingDescriptor) error
+	CheckAccessList(ctx context.Context, inboxEntries []common.Hash, minSafety interoptypes.SafetyLevel, execDesc interoptypes.ExecutingDescriptor, rpcVerifyAccess bool) error
 }
 
 type interopAccessFilter struct {
@@ -57,5 +57,5 @@ func (f *interopAccessFilter) FilterTx(ctx context.Context, tx *types.Transactio
 	}
 	exDesc := interoptypes.ExecutingDescriptor{Timestamp: t, Timeout: f.timeout}
 	// perform the interop check
-	return f.api.CheckAccessList(ctx, hashes, interoptypes.CrossUnsafe, exDesc) == nil
+	return f.api.CheckAccessList(ctx, hashes, interoptypes.CrossUnsafe, exDesc, true) == nil
 }

--- a/eth/interop.go
+++ b/eth/interop.go
@@ -10,11 +10,11 @@ import (
 	"github.com/ethereum/go-ethereum/miner"
 )
 
-func (s *Ethereum) CheckAccessList(ctx context.Context, inboxEntries []common.Hash, minSafety interoptypes.SafetyLevel, execDesc interoptypes.ExecutingDescriptor) error {
+func (s *Ethereum) CheckAccessList(ctx context.Context, inboxEntries []common.Hash, minSafety interoptypes.SafetyLevel, execDesc interoptypes.ExecutingDescriptor, rpcVerifyAccess bool) error {
 	if s.interopRPC == nil {
 		return errors.New("cannot check interop access list, no RPC available")
 	}
-	return s.interopRPC.CheckAccessList(ctx, inboxEntries, minSafety, execDesc)
+	return s.interopRPC.CheckAccessList(ctx, inboxEntries, minSafety, execDesc, rpcVerifyAccess)
 }
 
 // CurrentInteropBlockTime returns the current block time,

--- a/eth/interop/interop.go
+++ b/eth/interop/interop.go
@@ -48,10 +48,10 @@ func NewInteropClient(rpcEndpoint string) *InteropClient {
 	return &InteropClient{endpoint: rpcEndpoint}
 }
 
-func (cl *InteropClient) CheckAccessList(ctx context.Context, inboxEntries []common.Hash, minSafety interoptypes.SafetyLevel, executingDescriptor interoptypes.ExecutingDescriptor) error {
+func (cl *InteropClient) CheckAccessList(ctx context.Context, inboxEntries []common.Hash, minSafety interoptypes.SafetyLevel, executingDescriptor interoptypes.ExecutingDescriptor, rpcVerifyAccess bool) error {
 	if err := cl.maybeDial(ctx); err != nil {
 		return err
 	}
-	err := cl.client.CallContext(ctx, nil, "supervisor_checkAccessList", inboxEntries, minSafety, executingDescriptor)
+	err := cl.client.CallContext(ctx, nil, "supervisor_checkAccessList", inboxEntries, minSafety, executingDescriptor, rpcVerifyAccess)
 	return err
 }

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -47,7 +47,7 @@ type BackendWithHistoricalState interface {
 }
 
 type BackendWithInterop interface {
-	CheckAccessList(ctx context.Context, inboxEntries []common.Hash, minSafety interoptypes.SafetyLevel, executingDescriptor interoptypes.ExecutingDescriptor) error
+	CheckAccessList(ctx context.Context, inboxEntries []common.Hash, minSafety interoptypes.SafetyLevel, executingDescriptor interoptypes.ExecutingDescriptor, rpcVerifyAccess bool) error
 }
 
 // Config is the configuration parameters of mining.

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -459,7 +459,7 @@ func (miner *Miner) checkInterop(ctx context.Context, tx *types.Transaction, log
 	if len(accessList) == 0 {
 		return nil // avoid an RPC check if there are no executing messages to verify.
 	}
-	if err := b.CheckAccessList(ctx, accessList, interoptypes.CrossUnsafe, interoptypes.ExecutingDescriptor{Timestamp: logTimestamp, Timeout: 0}); err != nil {
+	if err := b.CheckAccessList(ctx, accessList, interoptypes.CrossUnsafe, interoptypes.ExecutingDescriptor{Timestamp: logTimestamp, Timeout: 0}, false); err != nil {
 		if ctx.Err() != nil { // don't reject transactions permanently on RPC timeouts etc.
 			log.Debug("CheckAccessList timed out", "err", ctx.Err())
 			return err


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->
Resolves: https://github.com/ethereum-optimism/optimism/issues/15157
**Depends On:** https://github.com/ethereum-optimism/optimism/pull/15278

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

In accordance with the following tickets:
* https://github.com/ethereum-optimism/optimism/issues/15128 (parent)
* https://github.com/ethereum-optimism/optimism/issues/15157 (task)

This PR updates calls to the supervisor's checkAccessList API to provide the rpcVerifyAccess boolean param. The ticket description goes into detail as to what this param controls.

**Tests**

* [op-e2e/interop/interop_test.go](https://github.com/ethereum-optimism/optimism/blob/6cce18ec658eb06eaf59f54d851aeaf6a1684d0f/op-e2e/interop/interop_test.go#L268)
