### PR TITLE
eth/tracers: add txHash to pre-bedrock historical trace results

### DIFF
--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -455,6 +455,9 @@ func (api *API) TraceBlockByNumber(ctx context.Context, number rpc.BlockNumber, 
 			if err != nil {
 				return nil, fmt.Errorf("historical backend error: %w", err)
 			}
+			for i, tx := range block.Transactions() {
+				histResult[i].TxHash = tx.Hash()
+			}
 			return histResult, nil
 		} else {
 			return nil, rpc.ErrNoHistoricalFallback
@@ -478,6 +481,9 @@ func (api *API) TraceBlockByHash(ctx context.Context, hash common.Hash, config *
 			err = api.backend.HistoricalRPCService().CallContext(ctx, &histResult, "debug_traceBlockByHash", hash, config)
 			if err != nil {
 				return nil, fmt.Errorf("historical backend error: %w", err)
+			}
+			for i, tx := range block.Transactions() {
+				histResult[i].TxHash = tx.Hash()
 			}
 			return histResult, nil
 		} else {


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

When querying debug_traceBlockXXX RPC methods on **pre-Bedrock** blocks, the txHash field is missing in the results.
Below is an example from block number 4, using `debug_traceBlockByNumber` with the `callTracer`:
```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": [
    {
      "txHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
      "result": {
        "from": "0x7107142636c85c549690b1aca12bdb8052d26ae6",
        "gas": "0x2130",
        "gasUsed": "0x2130",
        "input": "0xbede39b500000000000000000000000000000000000000000000000000000029a05f69e1",
        "output": "0x",
        "time": "1.804646ms",
        "to": "0x420000000000000000000000000000000000000f",
        "type": "CALL",
        "value": "0x0"
      }
    }
  ]
}
```
As you can see, txHash is set to a zero hash.
This PR initializes the txHash field using the corresponding transaction from the block that was traced.

real result:
```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": [
    {
      "txHash": "0xc1d20abbdd2a63df8dcd8eba2bdcf850d067109dd626964a9987747a154b8fdb",
      "result": {
        "from": "0x7107142636c85c549690b1aca12bdb8052d26ae6",
        "gas": "0x2130",
        "gasUsed": "0x2130",
        "input": "0xbede39b500000000000000000000000000000000000000000000000000000029a05f69e1",
        "output": "0x",
        "time": "34.258333ms",
        "to": "0x420000000000000000000000000000000000000f",
        "type": "CALL",
        "value": "0x0"
      }
    }
  ]
}
```


<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
