### PR TITLE
internal/ethapi: apply effective gas limit to eth_estimateGas

### DIFF
--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -32,9 +32,9 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 )
 
-// L1 Info Gas Overhead is the amount of gas the the L1 info deposit consumes.
+// L1 Info Gas Overhead is the amount of gas the L1 info deposit consumes.
 // It is removed from the tx pool max gas to better indicate that L2 transactions
-// are not able to consume all of the gas in a L2 block as the L1 info deposit is always present.
+// are not able to consume all the gas in a L2 block as the L1 info deposit is always present.
 const l1InfoGasOverhead = uint64(70_000)
 
 var (

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -36,6 +36,7 @@ import (
 	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -923,6 +924,10 @@ func DoEstimateGas(ctx context.Context, b Backend, args TransactionArgs, blockNr
 	}
 	if err := overrides.Apply(state, nil); err != nil {
 		return 0, err
+	}
+	if b.ChainConfig().IsOptimism() {
+		// Reduce the gas-gap to account for system transactions
+		gasCap = txpool.EffectiveGasLimit(b.ChainConfig(), header.GasLimit, gasCap)
 	}
 	// Construct the gas estimator option from the user input
 	opts := &gasestimator.Options{


### PR DESCRIPTION
**Description**

Gas-estimation should be limited to the effective limit, not the full limit, due to system transaction gas margin.

Fix https://github.com/ethereum-optimism/optimism/issues/5435
