### PR TITLE
sync-superchain: remove use of declare -A for ancient bash compatibility

### DIFF
--- a/sync-superchain.sh
+++ b/sync-superchain.sh
@@ -32,10 +32,6 @@ echo "Generating index of configs..."
 
 echo "{}" >chains.json
 
-# List of chain IDs to exclude
-declare -A EXCLUDE_CHAIN_IDS
-EXCLUDE_CHAIN_IDS=(["28882"]=1) # Boba
-
 # Function to process each network directory
 process_network_dir() {
     local network_dir="$1"
@@ -54,8 +50,8 @@ process_network_dir() {
         chain_id=$(dasel -f "$toml_file" -r toml "chain_id" | tr -d '"')
         chain_name="$(basename "${toml_file%.*}")"
 
-        # Skip if chain_id is empty or in the exclusion list
-        if [[ -z "$chain_id" || -v EXCLUDE_CHAIN_IDS["$chain_id"] ]]; then
+        # Skip if chain_id is empty or Boba's (28882)
+        if [[ -z "$chain_id" || "$chain_id" -eq 28882 ]]; then
             echo "Skipping $network_name/$chain_name ($chain_id)"
             rm "$toml_file"
             rm "genesis/$network_name/$chain_name.json.zst"


### PR DESCRIPTION

**Description**

The ancient bash version that ships with Apple doesn't now `declare -A`, so removing its use...

**Tests**

Will run in CI and confirm that the generated zip archive isn't changed.

**Metadata**

Fixes #581
