### PR TITLE
core,params: Check implied fork times during genesis setup

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -375,6 +375,13 @@ func (o *ChainOverrides) apply(cfg *params.ChainConfig) error {
 		cfg.InteropTime = o.OverrideOptimismInterop
 	}
 
+	// We check for validity after applying the overrides, even if there weren't any.
+	// This has the added benefit that the check always happens when
+	// applying overrides, which is at the right places during genesis setup.
+	if verr := cfg.CheckOptimismValidity(); verr != nil {
+		return fmt.Errorf("OP-Stack invalidity after applying overrides: %w", verr)
+	}
+
 	return cfg.CheckConfigForkOrder()
 }
 


### PR DESCRIPTION
**Description**

The chain config must have consistent fork times set when OP Stack forks are active that imply Ethereum forks.
This is already guaranteed for chains in the superchain-registry which are loaded via the network flag, or when using the override flags. But checks were missing when a custom genesis.json file is used. So it could happen that a chain operator misconfigures to only set e.g. Isthmus but not the Prague time.

This implementation adds the checks to the genesis setup, where overrides are applied. This makes sense because the checks always need to run after applying overrides to any chain.

**Tests**

Added unit tests of the new config check function.

**Metadata**

Fixes #586