### PR TITLE
params: fix comment for `DefaultBlobSchedule`

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -360,7 +360,7 @@ var (
 		Max:            9,
 		UpdateFraction: 5007716,
 	}
-	// DefaultBlobSchedule is the latest configured blob schedule for test chains.
+	// DefaultBlobSchedule is the latest configured blob schedule for Ethereum prod.
 	DefaultBlobSchedule = &BlobScheduleConfig{
 		Cancun: DefaultCancunBlobConfig,
 		Prague: DefaultPragueBlobConfig,


### PR DESCRIPTION
`DefaultBlobSchedule` is actually used by op-batcher to calculate blob fee, so it's not only for test chains, instead it's the latest blob schedule for Ethereum prod.