### PR TITLE
chore: make big.Int code style consistent in `buyGas`

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -276,12 +276,12 @@ func (st *stateTransition) buyGas() error {
 		if st.evm.Context.L1CostFunc != nil {
 			l1Cost = st.evm.Context.L1CostFunc(st.msg.RollupCostData, st.evm.Context.Time)
 			if l1Cost != nil {
-				mgval = mgval.Add(mgval, l1Cost)
+				mgval.Add(mgval, l1Cost)
 			}
 		}
 		if st.evm.Context.OperatorCostFunc != nil {
 			operatorCost = st.evm.Context.OperatorCostFunc(st.msg.GasLimit, st.evm.Context.Time)
-			mgval = mgval.Add(mgval, operatorCost.ToBig())
+			mgval.Add(mgval, operatorCost.ToBig())
 		}
 	}
 	balanceCheck := new(big.Int).Set(mgval)


### PR DESCRIPTION
Currently all other codes in `buyGas` use the side-effect style. This PR makes the code in `buyGas` consistent by replacing the two assignment style(added by OP) with the side-effect style.