### PR TITLE
core: make gas estimate more accurate

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -272,17 +272,15 @@ func (st *stateTransition) buyGas() error {
 	mgval.Mul(mgval, st.msg.GasPrice)
 	var l1Cost *big.Int
 	var operatorCost *uint256.Int
-	if !st.msg.SkipNonceChecks && !st.msg.SkipFromEOACheck {
-		if st.evm.Context.L1CostFunc != nil {
-			l1Cost = st.evm.Context.L1CostFunc(st.msg.RollupCostData, st.evm.Context.Time)
-			if l1Cost != nil {
-				mgval = mgval.Add(mgval, l1Cost)
-			}
+	if st.evm.Context.L1CostFunc != nil {
+		l1Cost = st.evm.Context.L1CostFunc(st.msg.RollupCostData, st.evm.Context.Time)
+		if l1Cost != nil {
+			mgval = mgval.Add(mgval, l1Cost)
 		}
-		if st.evm.Context.OperatorCostFunc != nil {
-			operatorCost = st.evm.Context.OperatorCostFunc(st.msg.GasLimit, st.evm.Context.Time)
-			mgval = mgval.Add(mgval, operatorCost.ToBig())
-		}
+	}
+	if st.evm.Context.OperatorCostFunc != nil {
+		operatorCost = st.evm.Context.OperatorCostFunc(st.msg.GasLimit, st.evm.Context.Time)
+		mgval = mgval.Add(mgval, operatorCost.ToBig())
 	}
 	balanceCheck := new(big.Int).Set(mgval)
 	if st.msg.GasFeeCap != nil {


### PR DESCRIPTION
In `DoEstimateGas`, both skipNonceCheck and skipEoACheck are set to true ([source](https://github.com/ethereum-optimism/op-geth/blob/3d7afdc2701b74c5987e31521e2c336c4511afdf/internal/ethapi/api.go#L944)), so the gas cost doesn't include l1 cost and operator fee.

This PR makes it behave more accurately (e.g., it should return an error if user balance can't afford L2 fee + L1 fee + operator fee).

Besides, when `!st.msg.SkipNonceChecks && !st.msg.SkipFromEOACheck` is false, `operatorFee` is still being distributed [here](https://github.com/ethereum-optimism/op-geth/blob/3d7afdc2701b74c5987e31521e2c336c4511afdf/core/state_transition.go#L683-L689), which is not symmetrical.

Also semantically, skipNonceCheck/skipEoACheck should have nothing to do with skipping calculation of l1 cost and operator fee.