### PR TITLE
interop: use the pending time instead of the unsafe time for executing descriptors

### DIFF
--- a/eth/interop.go
+++ b/eth/interop.go
@@ -3,6 +3,7 @@ package eth
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -17,6 +18,19 @@ func (s *Ethereum) CheckAccessList(ctx context.Context, inboxEntries []common.Ha
 	return s.interopRPC.CheckAccessList(ctx, inboxEntries, minSafety, execDesc)
 }
 
+func (s *Ethereum) inferBlockTime(current *types.Header) (uint64, error) {
+	if current.Number.Uint64() == 0 {
+		return 0, errors.New("current head is at genesis: penultimate header is nil")
+	}
+	penultimate := s.BlockChain().GetHeaderByHash(current.ParentHash)
+	if penultimate == nil {
+		// We could use a for loop and retry, but this function is used
+		// in the ingress filters, which should fail fast to maintain uptime.
+		return 0, errors.New("penultimate header is nil")
+	}
+	return current.Time - penultimate.Time, nil
+}
+
 // CurrentInteropBlockTime returns the current block time,
 // or an error if Interop is not enabled.
 func (s *Ethereum) CurrentInteropBlockTime() (uint64, error) {
@@ -27,7 +41,13 @@ func (s *Ethereum) CurrentInteropBlockTime() (uint64, error) {
 	if chainConfig.InteropTime == nil {
 		return 0, errors.New("interop time not set in chain config")
 	}
-	return s.BlockChain().CurrentBlock().Time, nil
+	// The pending block may be aliased to the current block in op-geth. Infer the pending time instead.
+	currentHeader := s.BlockChain().CurrentHeader()
+	blockTime, err := s.inferBlockTime(currentHeader)
+	if err != nil {
+		return 0, fmt.Errorf("infer block time: %v", err)
+	}
+	return currentHeader.Time + blockTime, nil
 }
 
 // TxToInteropAccessList returns the interop specific access list storage keys for a transaction.


### PR DESCRIPTION
# Description

Previously, the ingress filter [assigned] the [latest timestamp] to exec descriptors.

This unnecessarily delayed executing messages by one block when the supervisor used a stringent [access list policy], as in the [reference implementation].

This commit fixes the issue by using the pending timestamp instead of the unsafe timestamp.

[assigned]: https://github.com/ethereum-optimism/op-geth/blob/e605d07bde55b02f9e0309c330fb87500d80d06f/core/txpool/ingress_filters.go#L48-L58
[latest timestamp]: https://github.com/ethereum-optimism/op-geth/blob/e605d07bde55b02f9e0309c330fb87500d80d06f/eth/interop.go#L20-L31
[access list policy]: https://specs.optimism.io/interop/supervisor.html#access-list-checks
[reference implementation]: https://github.com/ethereum-optimism/optimism/blob/23c1fef1f0fe6b626c987eecbfa91fd5e0b66fb0/op-supervisor/supervisor/types/types.go#L344-L346

Fixes #603 

# Testing

I didn't add a regression test. If one is desired, please let me know where the best place for one might be and I'll happily add it.