### PR TITLE
miner: add `miner/maxDATxSize` and `miner/maxDABlockSize` gauge metrics and update when `setMaxDASize` is called

### DIFF
--- a/miner/miner.go
+++ b/miner/miner.go
@@ -181,29 +181,26 @@ func (miner *Miner) SetGasTip(tip *big.Int) error {
 
 // SetMaxDASize sets the maximum data availability size currently allowed for inclusion. 0 means no maximum.
 func (miner *Miner) SetMaxDASize(maxTxSize, maxBlockSize *big.Int) {
+	convertZeroToNil := func(v *big.Int) *big.Int {
+		if v != nil && v.BitLen() == 0 {
+			return nil
+		}
+		return v
+	}
+	convertNilToZero := func(v *big.Int) int64 {
+		if v == nil {
+			return 0
+		}
+		return v.Int64()
+	}
+
 	miner.confMu.Lock()
-	if maxTxSize == nil || maxTxSize.BitLen() == 0 {
-		miner.config.MaxDATxSize = nil
-	} else {
-		miner.config.MaxDATxSize = new(big.Int).Set(maxTxSize)
-	}
-	if maxBlockSize == nil || maxBlockSize.BitLen() == 0 {
-		miner.config.MaxDABlockSize = nil
-	} else {
-		miner.config.MaxDABlockSize = new(big.Int).Set(maxBlockSize)
-	}
+	miner.config.MaxDATxSize = convertZeroToNil(maxTxSize)
+	miner.config.MaxDABlockSize = convertZeroToNil(maxBlockSize)
 	miner.confMu.Unlock()
 
-	if maxTxSize == nil || maxTxSize.BitLen() == 0 {
-		maxDATxSizeGuage.Update(0)
-	} else {
-		maxDATxSizeGuage.Update(maxTxSize.Int64())
-	}
-	if maxBlockSize == nil || maxBlockSize.BitLen() == 0 {
-		maxDABlockSizeGuage.Update(0)
-	} else {
-		maxDABlockSizeGuage.Update(maxBlockSize.Int64())
-	}
+	maxDATxSizeGuage.Update(convertNilToZero(maxTxSize))
+	maxDABlockSizeGuage.Update(convertNilToZero(maxBlockSize))
 }
 
 // BuildPayload builds the payload according to the provided parameters.

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -193,8 +193,17 @@ func (miner *Miner) SetMaxDASize(maxTxSize, maxBlockSize *big.Int) {
 		miner.config.MaxDABlockSize = new(big.Int).Set(maxBlockSize)
 	}
 	miner.confMu.Unlock()
-	maxDABlockSizeGuage.Update(miner.config.MaxDABlockSize.Int64())
-	maxDATxSizeGuage.Update(miner.config.MaxDATxSize.Int64())
+
+	if maxTxSize == nil || maxTxSize.BitLen() == 0 {
+		maxDATxSizeGuage.Update(0)
+	} else {
+		maxDATxSizeGuage.Update(maxTxSize.Int64())
+	}
+	if maxBlockSize == nil || maxBlockSize.BitLen() == 0 {
+		maxDABlockSizeGuage.Update(0)
+	} else {
+		maxDABlockSizeGuage.Update(maxBlockSize.Int64())
+	}
 }
 
 // BuildPayload builds the payload according to the provided parameters.

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -33,7 +33,13 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/types/interoptypes"
 	"github.com/ethereum/go-ethereum/eth/tracers"
+	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/params"
+)
+
+var (
+	maxDATxSizeGuage    = metrics.NewRegisteredGauge("miner/maxDATxSize", nil)
+	maxDABlockSizeGuage = metrics.NewRegisteredGauge("miner/maxDABlockSize", nil)
 )
 
 // Backend wraps all methods required for mining. Only full node is capable
@@ -187,6 +193,8 @@ func (miner *Miner) SetMaxDASize(maxTxSize, maxBlockSize *big.Int) {
 		miner.config.MaxDABlockSize = new(big.Int).Set(maxBlockSize)
 	}
 	miner.confMu.Unlock()
+	maxDABlockSizeGuage.Update(miner.config.MaxDABlockSize.Int64())
+	maxDATxSizeGuage.Update(miner.config.MaxDATxSize.Int64())
 }
 
 // BuildPayload builds the payload according to the provided parameters.

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -38,8 +38,8 @@ import (
 )
 
 var (
-	maxDATxSizeGuage    = metrics.NewRegisteredGauge("miner/maxDATxSize", nil)
-	maxDABlockSizeGuage = metrics.NewRegisteredGauge("miner/maxDABlockSize", nil)
+	maxDATxSizeGauge    = metrics.NewRegisteredGauge("miner/maxDATxSize", nil)
+	maxDABlockSizeGauge = metrics.NewRegisteredGauge("miner/maxDABlockSize", nil)
 )
 
 // Backend wraps all methods required for mining. Only full node is capable
@@ -199,8 +199,8 @@ func (miner *Miner) SetMaxDASize(maxTxSize, maxBlockSize *big.Int) {
 	miner.config.MaxDABlockSize = convertZeroToNil(maxBlockSize)
 	miner.confMu.Unlock()
 
-	maxDATxSizeGuage.Update(convertNilToZero(maxTxSize))
-	maxDABlockSizeGuage.Update(convertNilToZero(maxBlockSize))
+	maxDATxSizeGauge.Update(convertNilToZero(maxTxSize))
+	maxDABlockSizeGauge.Update(convertNilToZero(maxBlockSize))
 }
 
 // BuildPayload builds the payload according to the provided parameters.


### PR DESCRIPTION
**Description**

Introduces a couple new guages - `miner/maxDATxSize` and `miner/maxDABlockSize` - which get updated every time the miner gets a `miner_setMaxDASize` call.

NOTE: I update the guages outside of the configuration lock to avoid blocking config changes by observability updates.

**Tests**

No additional tests required, just a couple new metrics.

**Additional context**

We would like to know for Base how often our sequencer is being throttled by the batcher, and what values are being set.

**Metadata**
