### PR TITLE
core: add `BlockTime` to chain config

### DIFF
--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -415,7 +415,7 @@ func (p *BlobPool) Init(gasTip uint64, head *types.Header, reserve txpool.Addres
 		p.recheck(addr, nil)
 	}
 	var (
-		basefee = uint256.MustFromBig(eip1559.CalcBaseFee(p.chain.Config(), p.head, p.head.Time+1))
+		basefee = uint256.MustFromBig(eip1559.CalcBaseFee(p.chain.Config(), p.head, p.chain.Config().NextBlockTime(p.head.Time)))
 		blobfee = uint256.NewInt(params.BlobTxMinBlobGasprice)
 	)
 	if p.head.ExcessBlobGas != nil {
@@ -835,7 +835,7 @@ func (p *BlobPool) Reset(oldHead, newHead *types.Header) {
 	}
 	// Reset the price heap for the new set of basefee/blobfee pairs
 	var (
-		basefee = uint256.MustFromBig(eip1559.CalcBaseFee(p.chain.Config(), newHead, newHead.Time+1))
+		basefee = uint256.MustFromBig(eip1559.CalcBaseFee(p.chain.Config(), newHead, p.chain.Config().NextBlockTime(newHead.Time)))
 		blobfee = uint256.MustFromBig(big.NewInt(params.BlobTxMinBlobGasprice))
 	)
 	if newHead.ExcessBlobGas != nil {

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -1320,7 +1320,7 @@ func (pool *LegacyPool) runReorg(done chan struct{}, reset *txpoolResetRequest, 
 		pool.demoteUnexecutables()
 		if reset.newHead != nil {
 			if pool.chainconfig.IsLondon(new(big.Int).Add(reset.newHead.Number, big.NewInt(1))) {
-				pendingBaseFee := eip1559.CalcBaseFee(pool.chainconfig, reset.newHead, reset.newHead.Time+1)
+				pendingBaseFee := eip1559.CalcBaseFee(pool.chainconfig, reset.newHead, pool.chainconfig.NextBlockTime(reset.newHead.Time))
 				pool.priced.SetBaseFee(pendingBaseFee)
 			} else {
 				pool.priced.Reheap()

--- a/eth/gasprice/feehistory.go
+++ b/eth/gasprice/feehistory.go
@@ -90,7 +90,7 @@ func (oracle *Oracle) processBlock(bf *blockFees, percentiles []float64) {
 		bf.results.baseFee = new(big.Int)
 	}
 	if config.IsLondon(big.NewInt(int64(bf.blockNumber + 1))) {
-		bf.results.nextBaseFee = eip1559.CalcBaseFee(config, bf.header, bf.header.Time+1)
+		bf.results.nextBaseFee = eip1559.CalcBaseFee(config, bf.header, config.NextBlockTime(bf.header.Time))
 	} else {
 		bf.results.nextBaseFee = new(big.Int)
 	}

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -780,7 +780,7 @@ func (b *Block) NextBaseFeePerGas(ctx context.Context) (*hexutil.Big, error) {
 			return nil, nil
 		}
 	}
-	nextBaseFee := eip1559.CalcBaseFee(chaincfg, header, header.Time+1)
+	nextBaseFee := eip1559.CalcBaseFee(chaincfg, header, chaincfg.NextBlockTime(header.Time))
 	return (*hexutil.Big)(nextBaseFee), nil
 }
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1229,7 +1229,7 @@ func NewRPCPendingTransaction(tx *types.Transaction, current *types.Header, conf
 		blockTime   = uint64(0)
 	)
 	if current != nil {
-		baseFee = eip1559.CalcBaseFee(config, current, current.Time+1)
+		baseFee = eip1559.CalcBaseFee(config, current, config.NextBlockTime(current.Time))
 		blockNumber = current.Number.Uint64()
 		blockTime = current.Time
 	}

--- a/params/config.go
+++ b/params/config.go
@@ -451,6 +451,9 @@ type ChainConfig struct {
 
 	// Optimism config, nil if not active
 	Optimism *OptimismConfig `json:"optimism,omitempty"`
+
+	// Seconds per L2 block
+	BlockTime uint64 `json:"blockTime,omitempty"`
 }
 
 // EthashConfig is the consensus engine configs for proof-of-work based sealing.
@@ -1348,4 +1351,13 @@ func ptrValueString[T any](t *T) string {
 		return "<nil>"
 	}
 	return fmt.Sprintf("%v", *t)
+}
+
+func (c *ChainConfig) NextBlockTime(currentBlockTime uint64) uint64 {
+	if c.BlockTime != 0 {
+		return currentBlockTime + c.BlockTime
+	}
+
+	// to be compatible with existing call sites
+	return currentBlockTime + 1
 }

--- a/params/config.go
+++ b/params/config.go
@@ -452,7 +452,7 @@ type ChainConfig struct {
 	// Optimism config, nil if not active
 	Optimism *OptimismConfig `json:"optimism,omitempty"`
 
-	// Seconds per L2 block
+	// OP-Stack diff: Seconds per L2 block
 	BlockTime uint64 `json:"blockTime,omitempty"`
 }
 

--- a/params/superchain.go
+++ b/params/superchain.go
@@ -59,6 +59,7 @@ func LoadOPStackChainConfig(chConfig *superchain.ChainConfig) (*ChainConfig, err
 		TerminalTotalDifficulty: common.Big0,
 		Ethash:                  nil,
 		Clique:                  nil,
+		BlockTime:               chConfig.BlockTime,
 	}
 
 	if chConfig.Optimism != nil {


### PR DESCRIPTION
Currently L2 block time is available in op-node [here](https://github.com/ethereum-optimism/optimism/blob/d474182026cb0a56874c1c2658849f7a1951b55d/op-node/rollup/types.go#L71), but sadly not available in op-geth.

In the codebase there're many places that actually want the next block time, but it's computed as `parentHead.Time+1`, which is not accurate.

This PR introduces a `BlockTime` field to chain config and replaces all those places that want the next block time with `config.NextBlockTime(parentHead.Time)`.