### PR TITLE
superchain: add GetDepset() function

### DIFF
--- a/params/superchain.go
+++ b/params/superchain.go
@@ -56,6 +56,7 @@ func LoadOPStackChainConfig(chConfig *superchain.ChainConfig) (*ChainConfig, err
 		HoloceneTime:            hardforks.HoloceneTime,
 		IsthmusTime:             hardforks.IsthmusTime,
 		JovianTime:              hardforks.JovianTime,
+		InteropTime:             hardforks.InteropTime,
 		TerminalTotalDifficulty: common.Big0,
 		Ethash:                  nil,
 		Clique:                  nil,

--- a/superchain/chain_test.go
+++ b/superchain/chain_test.go
@@ -1,0 +1,128 @@
+package superchain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetDepset(t *testing.T) {
+	// Save BuiltInConfigs to restore later
+	originalConfigs := BuiltInConfigs
+	t.Cleanup(func() {
+		BuiltInConfigs = originalConfigs
+	})
+
+	t.Run("unknown chainID", func(t *testing.T) {
+		BuiltInConfigs = &ChainConfigLoader{
+			Chains: map[uint64]*Chain{},
+		}
+
+		depset, err := GetDepset(999999)
+		require.Nil(t, depset)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unknown chain ID")
+	})
+
+	t.Run("nil InteropTime", func(t *testing.T) {
+		mockChain := &Chain{
+			Name:    "test",
+			Network: "test",
+			config: &ChainConfig{
+				ChainID: 42,
+				Hardforks: HardforkConfig{
+					InteropTime: nil,
+				},
+			},
+		}
+
+		// Set configOnce as already done
+		mockChain.configOnce.Do(func() {})
+
+		// Replace chains map with our test chain
+		BuiltInConfigs = &ChainConfigLoader{
+			Chains: map[uint64]*Chain{42: mockChain},
+		}
+
+		depset, err := GetDepset(42)
+		require.Nil(t, depset)
+		require.NoError(t, err)
+	})
+
+	t.Run("nil Interop creates default depset", func(t *testing.T) {
+		// Create mock chain with InteropTime but nil Interop
+		activationTime := uint64(1234567890)
+		mockChain := &Chain{
+			Name:    "test",
+			Network: "test",
+			config: &ChainConfig{
+				ChainID: 42,
+				Hardforks: HardforkConfig{
+					InteropTime: &activationTime,
+				},
+				Interop: nil,
+			},
+		}
+
+		// Set configOnce as already done
+		mockChain.configOnce.Do(func() {})
+
+		// Replace chains map with our test chain
+		BuiltInConfigs = &ChainConfigLoader{
+			Chains: map[uint64]*Chain{42: mockChain},
+		}
+
+		depset, err := GetDepset(42)
+		require.NoError(t, err)
+		require.NotNil(t, depset)
+
+		// Verify the default dependency was created
+		selfDep, exists := depset["42"]
+		require.True(t, exists)
+		require.Equal(t, uint32(1), selfDep.ChainIndex)
+		require.Equal(t, activationTime, selfDep.ActivationTime)
+	})
+
+	t.Run("existing Interop depset returned", func(t *testing.T) {
+		// Create mock chain with existing Interop dependencies
+		activationTime := uint64(1234567890)
+		mockChain := &Chain{
+			Name:    "test",
+			Network: "test",
+			config: &ChainConfig{
+				ChainID: 42,
+				Hardforks: HardforkConfig{
+					InteropTime: &activationTime,
+				},
+				Interop: &Interop{
+					Dependencies: map[string]Dependency{
+						"42": {ChainIndex: 1, ActivationTime: activationTime},
+						"43": {ChainIndex: 2, ActivationTime: activationTime + 100},
+					},
+				},
+			},
+		}
+
+		// Set configOnce as already done
+		mockChain.configOnce.Do(func() {})
+
+		// Replace chains map with our test chain
+		BuiltInConfigs = &ChainConfigLoader{
+			Chains: map[uint64]*Chain{42: mockChain},
+		}
+
+		depset, err := GetDepset(42)
+		require.NoError(t, err)
+		require.NotNil(t, depset)
+		require.Equal(t, 2, len(depset))
+
+		selfDep, exists := depset["42"]
+		require.True(t, exists)
+		require.Equal(t, uint32(1), selfDep.ChainIndex)
+
+		otherDep, exists := depset["43"]
+		require.True(t, exists)
+		require.Equal(t, uint32(2), otherDep.ChainIndex)
+		require.Equal(t, activationTime+100, otherDep.ActivationTime)
+	})
+}

--- a/superchain/types.go
+++ b/superchain/types.go
@@ -22,6 +22,7 @@ type ChainConfig struct {
 	MaxSequencerDrift uint64          `toml:"max_sequencer_drift"`
 	GasPayingToken    *common.Address `toml:"gas_paying_token"`
 	Hardforks         HardforkConfig  `toml:"hardforks"`
+	Interop           *Interop        `toml:"interop,omitempty"`
 	Optimism          *OptimismConfig `toml:"optimism,omitempty"`
 
 	AltDA *AltDAConfig `toml:"alt_da,omitempty"`
@@ -33,6 +34,15 @@ type ChainConfig struct {
 	Addresses AddressesConfig `toml:"addresses"`
 }
 
+type Dependency struct {
+	ChainIndex     uint32 `json:"chainIndex" toml:"chain_index"`
+	ActivationTime uint64 `json:"activationTime" toml:"activation_time"`
+}
+
+type Interop struct {
+	Dependencies map[string]Dependency `json:"dependencies" toml:"dependencies"`
+}
+
 type HardforkConfig struct {
 	CanyonTime   *uint64 `toml:"canyon_time"`
 	DeltaTime    *uint64 `toml:"delta_time"`
@@ -42,7 +52,7 @@ type HardforkConfig struct {
 	HoloceneTime *uint64 `toml:"holocene_time"`
 	IsthmusTime  *uint64 `toml:"isthmus_time"`
 	JovianTime   *uint64 `toml:"jovian_time"`
-
+	InteropTime  *uint64 `toml:"interop_time"`
 	// Optional Forks
 	PectraBlobScheduleTime *uint64 `toml:"pectra_blob_schedule_time,omitempty"`
 }


### PR DESCRIPTION
# Overview

Adds a `GetDepset` function so that op-supervisor and op-program have a quick lookup. Related superchain-registry pr [here](https://github.com/ethereum-optimism/superchain-registry/pull/1013) shows how we will encode depsets in the chain config tomls

# Related Issues
Closes https://github.com/ethereum-optimism/optimism/issues/15880
