### PR TITLE
log: support context-logging

### DIFF
--- a/cmd/geth/testdata/logging/logtest-json.txt
+++ b/cmd/geth/testdata/logging/logtest-json.txt
@@ -48,5 +48,5 @@
 {"t":"2023-11-22T15:42:00.40835+08:00","lvl":"info","msg":"raw nil","res":null}
 {"t":"2023-11-22T15:42:00.408354+08:00","lvl":"info","msg":"(*uint64)(nil)","res":null}
 {"t":"2023-11-22T15:42:00.408361+08:00","lvl":"info","msg":"Using keys 't', 'lvl', 'time', 'level' and 'msg'","t":"t","time":"time","lvl":"lvl","level":"level","msg":"msg"}
-{"t":"2023-11-29T15:13:00.195655931+01:00","lvl":"info","msg":"Odd pair (1 attr)","key":null,"LOG_ERROR":"Normalized odd number of arguments by adding nil"}
-{"t":"2023-11-29T15:13:00.195681832+01:00","lvl":"info","msg":"Odd pair (3 attr)","key":"value","key2":null,"LOG_ERROR":"Normalized odd number of arguments by adding nil"}
+{"t":"2023-11-29T15:13:00.195655931+01:00","lvl":"info","msg":"Odd pair (1 attr)","!BADKEY":"key"}
+{"t":"2023-11-29T15:13:00.195681832+01:00","lvl":"info","msg":"Odd pair (3 attr)","key":"value","!BADKEY":"key2"}

--- a/cmd/geth/testdata/logging/logtest-logfmt.txt
+++ b/cmd/geth/testdata/logging/logtest-logfmt.txt
@@ -48,5 +48,5 @@ t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg=nil-custom-struct res=<nil>
 t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg="raw nil" res=<nil>
 t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg=(*uint64)(nil) res=<nil>
 t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg="Using keys 't', 'lvl', 'time', 'level' and 'msg'" t=t time=time lvl=lvl level=level msg=msg
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg="Odd pair (1 attr)" key=<nil> LOG_ERROR="Normalized odd number of arguments by adding nil"
-t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg="Odd pair (3 attr)" key=value key2=<nil> LOG_ERROR="Normalized odd number of arguments by adding nil"
+t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg="Odd pair (1 attr)" !BADKEY=key
+t=xxxx-xx-xxTxx:xx:xx+xxxx lvl=info msg="Odd pair (3 attr)" key=value !BADKEY=key2

--- a/cmd/geth/testdata/logging/logtest-terminal.txt
+++ b/cmd/geth/testdata/logging/logtest-terminal.txt
@@ -49,5 +49,5 @@ INFO [xx-xx|xx:xx:xx.xxx] nil-custom-struct                        res=<nil>
 INFO [xx-xx|xx:xx:xx.xxx] raw nil                                  res=<nil>
 INFO [xx-xx|xx:xx:xx.xxx] (*uint64)(nil)                           res=<nil>
 INFO [xx-xx|xx:xx:xx.xxx] Using keys 't', 'lvl', 'time', 'level' and 'msg' t=t time=time lvl=lvl level=level msg=msg
-INFO [xx-xx|xx:xx:xx.xxx] Odd pair (1 attr)                        key=<nil>                  LOG_ERROR="Normalized odd number of arguments by adding nil"
-INFO [xx-xx|xx:xx:xx.xxx] Odd pair (3 attr)                        key=value                  key2=<nil> LOG_ERROR="Normalized odd number of arguments by adding nil"
+INFO [xx-xx|xx:xx:xx.xxx] Odd pair (1 attr)                        "!BADKEY"=key
+INFO [xx-xx|xx:xx:xx.xxx] Odd pair (3 attr)                        key=value                  "!BADKEY"=key2

--- a/fork.yaml
+++ b/fork.yaml
@@ -327,6 +327,13 @@ def:
     - title: "Geth extras"
       description: Extend the tools available in geth to improve external testing and tooling.
       sub:
+        - title: Logger improvements
+          description: |
+            Extend the logger with context-logging support. And improve testlog Crit handling.
+          globs:
+            - "log/logger.go"
+            - "log/root.go"
+            - "internal/testlog/testlog.go"
         - title: JSON-RPC recording
           description: |
             Extend server and client with configurable JSON-RPC message recording.

--- a/log/root.go
+++ b/log/root.go
@@ -12,7 +12,7 @@ var (
 )
 
 func init() {
-	root = &logger{slog.New(DiscardHandler())}
+	root = NewLogger(DiscardHandler())
 }
 
 // SetDefault sets the default global logger


### PR DESCRIPTION
**Description**

Changes:
- Support the context-logging interface of `slog.Logger`
  - Additionally includes `TraceContext`.
  - Intentionally does not include `CritContext` (crits are discouraged, and we would never want to filter from output based on context)
- Add `WriteCtx` to complement the existing `Write` method
- Allow it to set a default context on the logger, to use in case none is specified
- Support `slog.Attr` in regular log calls
- Fix test-logger to actually handle `Write`
- Fix test-logger to handle `Crit` more nicely

**Tests**

- Test context is preserved in logging, so that the handler can use it
- Test that testlog Crit does work nicely
- Test that `slog.Attr` can be used in regular log calls
- Vmodule test still works (call-site detection)

**Additional context**

This helps us remove a big logging hack in our monorepo testing, so that we can do context-logging and test tracing properly.

We can also attach the devtest test-scope context to our loggers, so logs can be attributed to scopes with context.

And we can attach attributes like service-ID to package-level loggers, so we can make the log-handler easily filter down to only logs with relevant context.


**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
