### PR TITLE
ci: Update eest release fix

### DIFF
--- a/build/checksums.txt
+++ b/build/checksums.txt
@@ -1,9 +1,9 @@
 # This file contains sha256 checksums of optional build dependencies.
 
-# version:spec-tests pectra-devnet-6@v1.0.0
+# version:spec-tests v4.5.0
 # https://github.com/ethereum/execution-spec-tests/releases
-# https://github.com/ethereum/execution-spec-tests/releases/download/pectra-devnet-6%40v1.0.0/
-b69211752a3029083c020dc635fe12156ca1a6725a08559da540a0337586a77e  fixtures_pectra-devnet-6.tar.gz
+# https://github.com/ethereum/execution-spec-tests/releases/download/v4.5.0/
+58afb92a0075a2cb7c4dec1281f7cb88b21b02afbedad096b580f3f8cc14c54c  fixtures_develop.tar.gz
 
 # version:golang 1.24.2
 # https://go.dev/dl/

--- a/build/ci.go
+++ b/build/ci.go
@@ -338,7 +338,7 @@ func downloadSpecTestFixtures(csdb *build.ChecksumDB, cachedir string) string {
 		log.Fatal(err)
 	}
 	ext := ".tar.gz"
-	base := "fixtures_pectra-devnet-6" // TODO(s1na) rename once the version becomes part of the filename
+	base := "fixtures_develop"
 	url := fmt.Sprintf("https://github.com/ethereum/execution-spec-tests/releases/download/%s/%s%s", executionSpecTestsVersion, base, ext)
 	archivePath := filepath.Join(cachedir, base+ext)
 	if err := csdb.DownloadFile(url, archivePath); err != nil {

--- a/tests/block_test.go
+++ b/tests/block_test.go
@@ -81,6 +81,9 @@ func TestExecutionSpecBlocktests(t *testing.T) {
 	}
 	bt := new(testMatcher)
 
+	bt.skipLoad(".*prague/eip7251_consolidations/contract_deployment/system_contract_deployment.json")
+	bt.skipLoad(".*prague/eip7002_el_triggerable_withdrawals/contract_deployment/system_contract_deployment.json")
+
 	bt.walk(t, executionSpecBlockchainTestDir, func(t *testing.T, name string, test *BlockTest) {
 		execBlockTest(t, bt, test)
 	})


### PR DESCRIPTION
**Description**

This PR cherry-picks the test/ci changes from upstream to fix CI.
There was some kind of mistake in the EEST release process, and it broke test artifact downloading.

See https://github.com/ethereum/go-ethereum/pull/31880

https://github.com/ethereum/go-ethereum/commit/29a87e442645bc34d08e5c8709c619411c6c3624


Cherry-picked:
```bash
git cherry-pick -S 29a87e442645bc34d08e5c8709c619411c6c3624
```

This cherry-pick was updated to fix the conflict, which was introduced by the CI downloader change in https://github.com/ethereum/go-ethereum/pull/31823

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
