### PR TITLE
fix(typo): fork.yaml.

### DIFF
--- a/fork.yaml
+++ b/fork.yaml
@@ -363,7 +363,7 @@ def:
         - title: EVM t8ntool
           description: |
             The EVM `t8ntool` has not been updated with most op-stack features and does not
-            use the same sealer logic as used in Geth consensus. Isthumus hard fork adds
+            use the same sealer logic as used in Geth consensus. Isthmus hard fork adds
             a `withdrawalsRoot` field in the block header. We note that the `t8ntool` is
             not updated to handle the newly added `withdrawalsRoot` field in the block header.
           globs:


### PR DESCRIPTION
**Description**

Corrected a tiny typo; "Isthumus" should read "Isthmus".
