### PR TITLE
refactor(vm): use `PrecompiledContracts` type alias for consistency

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -144,7 +144,7 @@ var PrecompiledContractsVerkle = PrecompiledContractsPrague
 
 // PrecompiledContractsFjord contains the default set of pre-compiled Ethereum
 // contracts used in the Fjord release.
-var PrecompiledContractsFjord = map[common.Address]PrecompiledContract{
+var PrecompiledContractsFjord = PrecompiledContracts{
 	common.BytesToAddress([]byte{1}):          &ecrecover{},
 	common.BytesToAddress([]byte{2}):          &sha256hash{},
 	common.BytesToAddress([]byte{3}):          &ripemd160hash{},
@@ -160,7 +160,7 @@ var PrecompiledContractsFjord = map[common.Address]PrecompiledContract{
 
 // PrecompiledContractsGranite contains the default set of pre-compiled Ethereum
 // contracts used in the Granite release.
-var PrecompiledContractsGranite = map[common.Address]PrecompiledContract{
+var PrecompiledContractsGranite = PrecompiledContracts{
 	common.BytesToAddress([]byte{1}):          &ecrecover{},
 	common.BytesToAddress([]byte{2}):          &sha256hash{},
 	common.BytesToAddress([]byte{3}):          &ripemd160hash{},
@@ -174,7 +174,7 @@ var PrecompiledContractsGranite = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{0x01, 0x00}): &p256Verify{},
 }
 
-var PrecompiledContractsIsthmus = map[common.Address]PrecompiledContract{
+var PrecompiledContractsIsthmus = PrecompiledContracts{
 	common.BytesToAddress([]byte{1}):          &ecrecover{},
 	common.BytesToAddress([]byte{2}):          &sha256hash{},
 	common.BytesToAddress([]byte{3}):          &ripemd160hash{},

--- a/core/vm/contracts_test.go
+++ b/core/vm/contracts_test.go
@@ -46,7 +46,7 @@ type precompiledFailureTest struct {
 
 // allPrecompiles does not map to the actual set of precompiles, as it also contains
 // repriced versions of precompiles at certain slots
-var allPrecompiles = map[common.Address]PrecompiledContract{
+var allPrecompiles = PrecompiledContracts{
 	common.BytesToAddress([]byte{1}):    &ecrecover{},
 	common.BytesToAddress([]byte{2}):    &sha256hash{},
 	common.BytesToAddress([]byte{3}):    &ripemd160hash{},

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -128,7 +128,7 @@ type EVM struct {
 	callGasTemp uint64
 
 	// precompiles holds the precompiled contracts for the current epoch
-	precompiles map[common.Address]PrecompiledContract
+	precompiles PrecompiledContracts
 
 	// jumpDests is the aggregated result of JUMPDEST analysis made through
 	// the life cycle of EVM.


### PR DESCRIPTION
**Description**

Refactor VM package to consistently use `PrecompiledContracts` type alias instead of raw `map[common.Address]PrecompiledContract` type declarations.

**Additional context**

Improves code consistency and readability by using the established type alias throughout the codebase.
