### PR TITLE
superchain: update depset schema

### DIFF
--- a/superchain/chain.go
+++ b/superchain/chain.go
@@ -100,7 +100,7 @@ func GetChain(chainID uint64) (*Chain, error) {
 	return BuiltInConfigs.GetChain(chainID)
 }
 
-func GetDepset(chainID uint64) (map[string]Dependency, error) {
+func GetDepset(chainID uint64) (map[string]StaticConfigDependency, error) {
 	chain, err := BuiltInConfigs.GetChain(chainID)
 	if err != nil {
 		return nil, err
@@ -117,14 +117,9 @@ func GetDepset(chainID uint64) (map[string]Dependency, error) {
 	// depset of 1 (self) is the default when no dependencies are specified but interop_time is set
 	if cfg.Interop == nil {
 		cfg.Interop = &Interop{
-			Dependencies: make(map[string]Dependency),
+			Dependencies: make(map[string]StaticConfigDependency),
 		}
-		self := Dependency{
-			ChainIndex:     1,
-			ActivationTime: *cfg.Hardforks.InteropTime,
-		}
-
-		cfg.Interop.Dependencies[fmt.Sprintf("%d", cfg.ChainID)] = self
+		cfg.Interop.Dependencies[fmt.Sprintf("%d", cfg.ChainID)] = StaticConfigDependency{}
 	}
 
 	return cfg.Interop.Dependencies, nil

--- a/superchain/chain.go
+++ b/superchain/chain.go
@@ -100,7 +100,7 @@ func GetChain(chainID uint64) (*Chain, error) {
 	return BuiltInConfigs.GetChain(chainID)
 }
 
-func GetDepset(chainID uint64) (map[string]StaticConfigDependency, error) {
+func GetDepset(chainID uint64) (map[string]Dependency, error) {
 	chain, err := BuiltInConfigs.GetChain(chainID)
 	if err != nil {
 		return nil, err
@@ -117,9 +117,9 @@ func GetDepset(chainID uint64) (map[string]StaticConfigDependency, error) {
 	// depset of 1 (self) is the default when no dependencies are specified but interop_time is set
 	if cfg.Interop == nil {
 		cfg.Interop = &Interop{
-			Dependencies: make(map[string]StaticConfigDependency),
+			Dependencies: make(map[string]Dependency),
 		}
-		cfg.Interop.Dependencies[fmt.Sprintf("%d", cfg.ChainID)] = StaticConfigDependency{}
+		cfg.Interop.Dependencies[fmt.Sprintf("%d", cfg.ChainID)] = Dependency{}
 	}
 
 	return cfg.Interop.Dependencies, nil

--- a/superchain/chain_test.go
+++ b/superchain/chain_test.go
@@ -79,7 +79,7 @@ func TestGetDepset(t *testing.T) {
 		// Verify the default dependency was created
 		selfDep, exists := depset["42"]
 		require.True(t, exists)
-		require.Equal(t, selfDep, StaticConfigDependency{})
+		require.Equal(t, selfDep, Dependency{})
 	})
 
 	t.Run("existing Interop depset returned", func(t *testing.T) {
@@ -94,7 +94,7 @@ func TestGetDepset(t *testing.T) {
 					InteropTime: &activationTime,
 				},
 				Interop: &Interop{
-					Dependencies: map[string]StaticConfigDependency{
+					Dependencies: map[string]Dependency{
 						"42": {},
 						"43": {},
 					},
@@ -117,10 +117,10 @@ func TestGetDepset(t *testing.T) {
 
 		selfDep, exists := depset["42"]
 		require.True(t, exists)
-		require.Equal(t, selfDep, StaticConfigDependency{})
+		require.Equal(t, selfDep, Dependency{})
 
 		otherDep, exists := depset["43"]
 		require.True(t, exists)
-		require.Equal(t, otherDep, StaticConfigDependency{})
+		require.Equal(t, otherDep, Dependency{})
 	})
 }

--- a/superchain/chain_test.go
+++ b/superchain/chain_test.go
@@ -79,8 +79,7 @@ func TestGetDepset(t *testing.T) {
 		// Verify the default dependency was created
 		selfDep, exists := depset["42"]
 		require.True(t, exists)
-		require.Equal(t, uint32(1), selfDep.ChainIndex)
-		require.Equal(t, activationTime, selfDep.ActivationTime)
+		require.Equal(t, selfDep, StaticConfigDependency{})
 	})
 
 	t.Run("existing Interop depset returned", func(t *testing.T) {
@@ -95,9 +94,9 @@ func TestGetDepset(t *testing.T) {
 					InteropTime: &activationTime,
 				},
 				Interop: &Interop{
-					Dependencies: map[string]Dependency{
-						"42": {ChainIndex: 1, ActivationTime: activationTime},
-						"43": {ChainIndex: 2, ActivationTime: activationTime + 100},
+					Dependencies: map[string]StaticConfigDependency{
+						"42": {},
+						"43": {},
 					},
 				},
 			},
@@ -118,11 +117,10 @@ func TestGetDepset(t *testing.T) {
 
 		selfDep, exists := depset["42"]
 		require.True(t, exists)
-		require.Equal(t, uint32(1), selfDep.ChainIndex)
+		require.Equal(t, selfDep, StaticConfigDependency{})
 
 		otherDep, exists := depset["43"]
 		require.True(t, exists)
-		require.Equal(t, uint32(2), otherDep.ChainIndex)
-		require.Equal(t, activationTime+100, otherDep.ActivationTime)
+		require.Equal(t, otherDep, StaticConfigDependency{})
 	})
 }

--- a/superchain/types.go
+++ b/superchain/types.go
@@ -34,13 +34,10 @@ type ChainConfig struct {
 	Addresses AddressesConfig `toml:"addresses"`
 }
 
-type Dependency struct {
-	ChainIndex     uint32 `json:"chainIndex" toml:"chain_index"`
-	ActivationTime uint64 `json:"activationTime" toml:"activation_time"`
-}
+type StaticConfigDependency struct{}
 
 type Interop struct {
-	Dependencies map[string]Dependency `json:"dependencies" toml:"dependencies"`
+	Dependencies map[string]StaticConfigDependency `json:"dependencies" toml:"dependencies"`
 }
 
 type HardforkConfig struct {

--- a/superchain/types.go
+++ b/superchain/types.go
@@ -34,10 +34,10 @@ type ChainConfig struct {
 	Addresses AddressesConfig `toml:"addresses"`
 }
 
-type StaticConfigDependency struct{}
+type Dependency struct{}
 
 type Interop struct {
-	Dependencies map[string]StaticConfigDependency `json:"dependencies" toml:"dependencies"`
+	Dependencies map[string]Dependency `json:"dependencies" toml:"dependencies"`
 }
 
 type HardforkConfig struct {


### PR DESCRIPTION
# Overview
Updates depset schema to align with the new depset schema introduced by https://github.com/ethereum-optimism/optimism/pull/16123

# Related Issues
Closes https://github.com/ethereum-optimism/optimism/issues/16145