### PR TITLE
core,miner: check interop access-list with chainID in exec descriptor

### DIFF
--- a/core/txpool/ingress_filters_test.go
+++ b/core/txpool/ingress_filters_test.go
@@ -7,10 +7,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/types/interoptypes"
-	"github.com/stretchr/testify/require"
 )
 
 type mockInteropFilterAPI struct {
@@ -42,7 +44,7 @@ func (m *mockInteropFilterAPI) CheckAccessList(ctx context.Context, inboxEntries
 
 func TestInteropFilter(t *testing.T) {
 	api := &mockInteropFilterAPI{}
-	filter := NewInteropFilter(api)
+	filter := NewInteropFilter(api, *uint256.NewInt(123))
 	tx := types.NewTx(&types.DynamicFeeTx{})
 
 	t.Run("Tx has no access list", func(t *testing.T) {
@@ -137,7 +139,7 @@ func TestInteropFilterRPCFailures(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			api := &mockInteropFilterAPI{}
-			filter := NewInteropFilter(api)
+			filter := NewInteropFilter(api, *uint256.NewInt(123))
 			api.accessListFn = func(tx *types.Transaction) []common.Hash {
 				return []common.Hash{{0xaa}}
 			}

--- a/core/types/interoptypes/interop.go
+++ b/core/types/interoptypes/interop.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/holiman/uint256"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -53,17 +55,20 @@ const (
 )
 
 type ExecutingDescriptor struct {
+	ChainID   uint256.Int
 	Timestamp uint64
 	Timeout   uint64
 }
 
 type executingDescriptorMarshaling struct {
+	ChainID   uint256.Int    `json:"chainID"`
 	Timestamp hexutil.Uint64 `json:"timestamp"`
 	Timeout   hexutil.Uint64 `json:"timeout"`
 }
 
 func (ed ExecutingDescriptor) MarshalJSON() ([]byte, error) {
 	var enc executingDescriptorMarshaling
+	enc.ChainID = ed.ChainID
 	enc.Timestamp = hexutil.Uint64(ed.Timestamp)
 	enc.Timeout = hexutil.Uint64(ed.Timeout)
 	return json.Marshal(&enc)
@@ -74,6 +79,7 @@ func (ed *ExecutingDescriptor) UnmarshalJSON(input []byte) error {
 	if err := json.Unmarshal(input, &dec); err != nil {
 		return err
 	}
+	ed.ChainID = dec.ChainID
 	ed.Timestamp = uint64(dec.Timestamp)
 	ed.Timeout = uint64(dec.Timeout)
 	return nil

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -26,6 +26,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/holiman/uint256"
+
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -312,7 +314,8 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	// simulated logs and message safety check functions
 	poolFilters := []txpool.IngressFilter{}
 	if config.InteropMessageRPC != "" && config.InteropMempoolFiltering {
-		poolFilters = append(poolFilters, txpool.NewInteropFilter(eth))
+		chainID := uint256.MustFromBig(chainConfig.ChainID)
+		poolFilters = append(poolFilters, txpool.NewInteropFilter(eth, *chainID))
 	}
 	eth.txPool, err = txpool.New(config.TxPool.PriceLimit, eth.blockchain, txPools, poolFilters)
 	if err != nil {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -463,7 +463,12 @@ func (miner *Miner) checkInterop(ctx context.Context, tx *types.Transaction, log
 	if len(accessList) == 0 {
 		return nil // avoid an RPC check if there are no executing messages to verify.
 	}
-	if err := b.CheckAccessList(ctx, accessList, interoptypes.CrossUnsafe, interoptypes.ExecutingDescriptor{Timestamp: logTimestamp, Timeout: 0}); err != nil {
+	execDescr := interoptypes.ExecutingDescriptor{
+		Timestamp: logTimestamp,
+		Timeout:   0,
+		ChainID:   *uint256.MustFromBig(miner.chainConfig.ChainID),
+	}
+	if err := b.CheckAccessList(ctx, accessList, interoptypes.CrossUnsafe, execDescr); err != nil {
 		if ctx.Err() != nil { // don't reject transactions permanently on RPC timeouts etc.
 			log.Debug("CheckAccessList timed out", "err", ctx.Err())
 			return err


### PR DESCRIPTION
**Description**

This change is aimed at https://github.com/ethereum-optimism/optimism/pull/16220

This helps de-duplicate code on the op-supervisor side.

This adds the chainID of the executing descriptor. I.e. the executing side.
The timestamp check alone is meaningless when we don't know the chain it is meant to execute on (once we have chains that activate later).

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
