### PR TITLE
Fix broken Execution APIs documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ accessible from the outside.
 
 As a developer, sooner rather than later you'll want to start interacting with `geth` and the
 Ethereum network via your own programs and not manually through the console. To aid
-this, `geth` has built-in support for a JSON-RPC based APIs ([standard APIs](https://ethereum.github.io/execution-apis/api-documentation/)
+this, `geth` has built-in support for a JSON-RPC based APIs ([standard APIs](https://ethereum.github.io/execution-apis/)
 and [`geth` specific APIs](https://geth.ethereum.org/docs/interacting-with-geth/rpc)).
 These can be exposed via HTTP, WebSockets and IPC (UNIX sockets on UNIX based
 platforms, and named pipes on Windows).


### PR DESCRIPTION
Replaced the outdated and non-working link to the Execution APIs documentation (https://ethereum.github.io/execution-apis/api-documentation/) with the correct and currently active URL (https://ethereum.github.io/execution-apis/). This ensures users can access the latest JSON-RPC API reference without encountering a 404 error.