### PR TITLE
superchain: Return dependency set even if interop not scheduled

### DIFF
--- a/superchain/chain_test.go
+++ b/superchain/chain_test.go
@@ -20,7 +20,7 @@ func TestGetDepset(t *testing.T) {
 
 		depset, err := GetDepset(999999)
 		require.Nil(t, depset)
-		require.Error(t, err)
+		require.ErrorIs(t, err, ErrUnknownChain)
 		require.Contains(t, err.Error(), "unknown chain ID")
 	})
 
@@ -45,8 +45,13 @@ func TestGetDepset(t *testing.T) {
 		}
 
 		depset, err := GetDepset(42)
-		require.Nil(t, depset)
 		require.NoError(t, err)
+		require.NotNil(t, depset)
+
+		// Verify the default dependency was created
+		selfDep, exists := depset["42"]
+		require.True(t, exists)
+		require.Equal(t, selfDep, Dependency{})
 	})
 
 	t.Run("nil Interop creates default depset", func(t *testing.T) {


### PR DESCRIPTION
**Description**

Return a dependency set from the registry even if interop time is not set.
Use a typed error for unknown chains.

**Tests**

Updated unit tests.


**Metadata**

https://github.com/ethereum-optimism/optimism/issues/15889