### PR TITLE
miner, txpool: detect supervisor failsafe and reject interop transactions if enabled

### DIFF
--- a/core/txpool/ingress_filters.go
+++ b/core/txpool/ingress_filters.go
@@ -60,6 +60,7 @@ func (f *interopAccessFilter) FilterTx(ctx context.Context, tx *types.Transactio
 		return false
 	}
 	exDesc := interoptypes.ExecutingDescriptor{Timestamp: t, Timeout: f.timeout, ChainID: f.chainID}
-	// perform the interop check
+
+	// perform the interop check and update internal failsafe bool if needed
 	return f.api.CheckAccessList(ctx, hashes, interoptypes.CrossUnsafe, exDesc) == nil
 }

--- a/core/types/interoptypes/interop.go
+++ b/core/types/interoptypes/interop.go
@@ -101,3 +101,5 @@ func TxToInteropAccessList(tx *types.Transaction) []common.Hash {
 	}
 	return hashes
 }
+
+var ErrFailsafeEnabled = errors.New("failsafe is enabled, rejecting all CheckAccessList requests")

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -696,6 +696,6 @@ func (s *Ethereum) setSupervisorFailsafe(enabled bool) {
 	s.supervisorFailsafe.Store(enabled)
 }
 
-func (s *Ethereum) SupervisorInFailsafe() bool {
+func (s *Ethereum) GetSupervisorFailsafe() bool {
 	return s.supervisorFailsafe.Load()
 }

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -691,11 +691,3 @@ func (s *Ethereum) HandleRequiredProtocolVersion(required params.ProtocolVersion
 	}
 	return nil
 }
-
-func (s *Ethereum) setSupervisorFailsafe(enabled bool) {
-	s.supervisorFailsafe.Store(enabled)
-}
-
-func (s *Ethereum) GetSupervisorFailsafe() bool {
-	return s.supervisorFailsafe.Load()
-}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -24,6 +24,7 @@ import (
 	"math/big"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/holiman/uint256"
@@ -111,8 +112,8 @@ type Ethereum struct {
 	// OP-Stack additions
 	seqRPCService        *rpc.Client
 	historicalRPCService *rpc.Client
-
-	interopRPC *interop.InteropClient
+	interopRPC           *interop.InteropClient
+	supervisorFailsafe   atomic.Bool
 
 	nodeCloser func() error
 }
@@ -689,4 +690,12 @@ func (s *Ethereum) HandleRequiredProtocolVersion(required params.ProtocolVersion
 		return s.nodeCloser()
 	}
 	return nil
+}
+
+func (s *Ethereum) setSupervisorFailsafe(enabled bool) {
+	s.supervisorFailsafe.Store(enabled)
+}
+
+func (s *Ethereum) SupervisorInFailsafe() bool {
+	return s.supervisorFailsafe.Load()
 }

--- a/eth/interop.go
+++ b/eth/interop.go
@@ -28,6 +28,22 @@ func (s *Ethereum) CheckAccessList(ctx context.Context, inboxEntries []common.Ha
 	return err
 }
 
+// QueryFailsafe queries the supervisor for the failsafe status,
+// caches it in the backend, and returns the status.
+func (s *Ethereum) QueryFailsafe(ctx context.Context) bool {
+	if s.interopRPC == nil {
+		return false
+	}
+
+	enabled, err := s.interopRPC.GetFailsafeEnabled(ctx)
+	if err != nil {
+		return false
+	}
+
+	s.setSupervisorFailsafe(enabled)
+	return enabled
+}
+
 func (s *Ethereum) inferBlockTime(current *types.Header) (uint64, error) {
 	if current.Number.Uint64() == 0 {
 		return 0, errors.New("current head is at genesis: penultimate header is nil")

--- a/eth/interop.go
+++ b/eth/interop.go
@@ -11,6 +11,14 @@ import (
 	"github.com/ethereum/go-ethereum/miner"
 )
 
+func (s *Ethereum) setSupervisorFailsafe(enabled bool) {
+	s.supervisorFailsafe.Store(enabled)
+}
+
+func (s *Ethereum) GetSupervisorFailsafe() bool {
+	return s.supervisorFailsafe.Load()
+}
+
 func (s *Ethereum) CheckAccessList(ctx context.Context, inboxEntries []common.Hash, minSafety interoptypes.SafetyLevel, execDesc interoptypes.ExecutingDescriptor) error {
 	if s.interopRPC == nil {
 		return errors.New("cannot check interop access list, no RPC available")
@@ -30,18 +38,18 @@ func (s *Ethereum) CheckAccessList(ctx context.Context, inboxEntries []common.Ha
 
 // QueryFailsafe queries the supervisor for the failsafe status,
 // caches it in the backend, and returns the status.
-func (s *Ethereum) QueryFailsafe(ctx context.Context) bool {
+func (s *Ethereum) QueryFailsafe(ctx context.Context) (bool, error) {
 	if s.interopRPC == nil {
-		return false
+		return false, errors.New("cannot query failsafe, no RPC available")
 	}
 
 	enabled, err := s.interopRPC.GetFailsafeEnabled(ctx)
 	if err != nil {
-		return false
+		return false, err
 	}
 
 	s.setSupervisorFailsafe(enabled)
-	return enabled
+	return enabled, nil
 }
 
 func (s *Ethereum) inferBlockTime(current *types.Header) (uint64, error) {

--- a/eth/interop.go
+++ b/eth/interop.go
@@ -15,7 +15,17 @@ func (s *Ethereum) CheckAccessList(ctx context.Context, inboxEntries []common.Ha
 	if s.interopRPC == nil {
 		return errors.New("cannot check interop access list, no RPC available")
 	}
-	return s.interopRPC.CheckAccessList(ctx, inboxEntries, minSafety, execDesc)
+
+	err := s.interopRPC.CheckAccessList(ctx, inboxEntries, minSafety, execDesc)
+
+	// Detect failsafe mode and cache it in the backend
+	switch err {
+	case nil:
+		s.setSupervisorFailsafe(false)
+	case interoptypes.ErrFailsafeEnabled:
+		s.setSupervisorFailsafe(true)
+	}
+	return err
 }
 
 func (s *Ethereum) inferBlockTime(current *types.Header) (uint64, error) {

--- a/eth/interop/interop.go
+++ b/eth/interop/interop.go
@@ -55,3 +55,13 @@ func (cl *InteropClient) CheckAccessList(ctx context.Context, inboxEntries []com
 	err := cl.client.CallContext(ctx, nil, "supervisor_checkAccessList", inboxEntries, minSafety, executingDescriptor)
 	return err
 }
+
+// GetFailsafeEnabled queries the supervisor for the failsafe status using the admin_failsafeEnabled RPC.
+func (cl *InteropClient) GetFailsafeEnabled(ctx context.Context) (bool, error) {
+	if err := cl.maybeDial(ctx); err != nil {
+		return false, err
+	}
+	var enabled bool
+	err := cl.client.CallContext(ctx, &enabled, "admin_getFailsafeEnabled")
+	return enabled, err
+}

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -57,7 +57,7 @@ type BackendWithInterop interface {
 	CheckAccessList(ctx context.Context, inboxEntries []common.Hash, minSafety interoptypes.SafetyLevel, executingDescriptor interoptypes.ExecutingDescriptor) error
 
 	// GetFailsafeEnabled reads the local failsafe status from the backend
-	GetFailsafeEnabled() bool
+	GetSupervisorFailsafe() bool
 
 	// QueryFailsafe queries the supervisor over RPC for the failsafe status,
 	// caches it in the backend, and returns the status.

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -48,9 +48,6 @@ var (
 type Backend interface {
 	BlockChain() *core.BlockChain
 	TxPool() *txpool.TxPool
-
-	// OP-Stack addition
-	SupervisorInFailsafe() bool
 }
 type BackendWithHistoricalState interface {
 	StateAtBlock(ctx context.Context, block *types.Block, reexec uint64, base *state.StateDB, readOnly bool, preferDisk bool) (*state.StateDB, tracers.StateReleaseFunc, error)
@@ -58,6 +55,7 @@ type BackendWithHistoricalState interface {
 
 type BackendWithInterop interface {
 	CheckAccessList(ctx context.Context, inboxEntries []common.Hash, minSafety interoptypes.SafetyLevel, executingDescriptor interoptypes.ExecutingDescriptor) error
+	SupervisorInFailsafe() bool
 }
 
 // Config is the configuration parameters of mining.

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -55,7 +55,13 @@ type BackendWithHistoricalState interface {
 
 type BackendWithInterop interface {
 	CheckAccessList(ctx context.Context, inboxEntries []common.Hash, minSafety interoptypes.SafetyLevel, executingDescriptor interoptypes.ExecutingDescriptor) error
-	QueryFailsafe(ctx context.Context) bool
+
+	// GetFailsafeEnabled reads the local failsafe status from the backend
+	GetFailsafeEnabled() bool
+
+	// QueryFailsafe queries the supervisor over RPC for the failsafe status,
+	// caches it in the backend, and returns the status.
+	QueryFailsafe(ctx context.Context) (bool, error)
 }
 
 // Config is the configuration parameters of mining.

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -55,7 +55,7 @@ type BackendWithHistoricalState interface {
 
 type BackendWithInterop interface {
 	CheckAccessList(ctx context.Context, inboxEntries []common.Hash, minSafety interoptypes.SafetyLevel, executingDescriptor interoptypes.ExecutingDescriptor) error
-	SupervisorInFailsafe() bool
+	GetSupervisorFailsafe() bool
 }
 
 // Config is the configuration parameters of mining.

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/types/interoptypes"
 	"github.com/ethereum/go-ethereum/eth/tracers"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/params"
 )
@@ -47,6 +48,9 @@ var (
 type Backend interface {
 	BlockChain() *core.BlockChain
 	TxPool() *txpool.TxPool
+
+	// OP-Stack addition
+	SupervisorInFailsafe() bool
 }
 type BackendWithHistoricalState interface {
 	StateAtBlock(ctx context.Context, block *types.Block, reexec uint64, base *state.StateDB, readOnly bool, preferDisk bool) (*state.StateDB, tracers.StateReleaseFunc, error)
@@ -107,7 +111,7 @@ type Miner struct {
 // New creates a new miner with provided config.
 func New(eth Backend, config Config, engine consensus.Engine) *Miner {
 	ctx, cancel := context.WithCancel(context.Background())
-	return &Miner{
+	miner := &Miner{
 		backend:     eth,
 		config:      &config,
 		chainConfig: eth.BlockChain().Config(),
@@ -119,6 +123,42 @@ func New(eth Backend, config Config, engine consensus.Engine) *Miner {
 		lifeCtxCancel: cancel,
 		lifeCtx:       ctx,
 	}
+
+	// OP-Stack: Start background RPC polling
+	miner.startBackgroundInteropFailsafeDetection()
+
+	return miner
+}
+
+// OP-Stack: startBackgroundInteropFailsafeDetection starts a background goroutine that periodically
+// calls the supervisor over RPC to check if the failsafe is enabled
+func (miner *Miner) startBackgroundInteropFailsafeDetection() {
+	backend, ok := miner.backend.(BackendWithInterop)
+	if !ok {
+		log.Warn("Miner backend does not implement BackendWithInterop, skipping interop failsafe detection")
+		return
+	}
+
+	go func() {
+		ticker := time.NewTicker(1 * time.Second)
+		defer ticker.Stop()
+
+		log.Info("Starting background interop failsafe detection", "interval", "1s")
+
+		for {
+			select {
+			case <-ticker.C:
+				ctx, cancel := context.WithTimeout(miner.lifeCtx, 1*time.Second)
+				defer cancel()
+				// Simply calling CheckAccessList will update the failsafe status in the backend
+				// We do not need to do anything with the result
+				_ = backend.CheckAccessList(ctx, []common.Hash{}, interoptypes.CrossUnsafe, interoptypes.ExecutingDescriptor{})
+			case <-miner.lifeCtx.Done():
+				log.Info("Stopping background RPC polling due to miner shutdown")
+				return
+			}
+		}
+	}()
 }
 
 // Pending returns the currently pending block and associated receipts, logs

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -55,7 +55,7 @@ type BackendWithHistoricalState interface {
 
 type BackendWithInterop interface {
 	CheckAccessList(ctx context.Context, inboxEntries []common.Hash, minSafety interoptypes.SafetyLevel, executingDescriptor interoptypes.ExecutingDescriptor) error
-	GetSupervisorFailsafe() bool
+	QueryFailsafe(ctx context.Context) bool
 }
 
 // Config is the configuration parameters of mining.
@@ -148,9 +148,7 @@ func (miner *Miner) startBackgroundInteropFailsafeDetection() {
 			case <-ticker.C:
 				ctx, cancel := context.WithTimeout(miner.lifeCtx, 1*time.Second)
 				defer cancel()
-				// Simply calling CheckAccessList will update the failsafe status in the backend
-				// We do not need to do anything with the result
-				_ = backend.CheckAccessList(ctx, []common.Hash{}, interoptypes.CrossUnsafe, interoptypes.ExecutingDescriptor{})
+				backend.QueryFailsafe(ctx)
 			case <-miner.lifeCtx.Done():
 				log.Info("Stopping background RPC polling due to miner shutdown")
 				return

--- a/miner/miner_test.go
+++ b/miner/miner_test.go
@@ -73,7 +73,7 @@ func (m *mockBackend) TxPool() *txpool.TxPool {
 }
 
 // OP-Stack additions
-func (m *mockBackend) GetFailsafeEnabled() bool {
+func (m *mockBackend) GetSupervisorFailsafe() bool {
 	return m.supervisorInFailsafe
 }
 func (m *mockBackend) CheckAccessList(ctx context.Context, inboxEntries []common.Hash, minSafety interoptypes.SafetyLevel, executingDescriptor interoptypes.ExecutingDescriptor) error {

--- a/miner/miner_test.go
+++ b/miner/miner_test.go
@@ -18,6 +18,7 @@
 package miner
 
 import (
+	"context"
 	"math/big"
 	"sync"
 	"testing"
@@ -31,6 +32,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/txpool/legacypool"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/types/interoptypes"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/event"
@@ -42,12 +44,23 @@ import (
 type mockBackend struct {
 	bc     *core.BlockChain
 	txPool *txpool.TxPool
+
+	// OP-Stack additions
+	supervisorInFailsafe bool
+	checkAccessListCb    func()
 }
 
-func NewMockBackend(bc *core.BlockChain, txPool *txpool.TxPool) *mockBackend {
+func NewMockBackend(bc *core.BlockChain, txPool *txpool.TxPool,
+	supervisorInFailsafe bool, // OP-Stack addition
+	checkAccessListCallback func(), // OP-Stack addition
+) *mockBackend {
 	return &mockBackend{
 		bc:     bc,
 		txPool: txPool,
+
+		// OP-Stack addition
+		supervisorInFailsafe: supervisorInFailsafe,
+		checkAccessListCb:    checkAccessListCallback,
 	}
 }
 
@@ -57,6 +70,17 @@ func (m *mockBackend) BlockChain() *core.BlockChain {
 
 func (m *mockBackend) TxPool() *txpool.TxPool {
 	return m.txPool
+}
+
+// OP-Stack addition
+func (m *mockBackend) SupervisorInFailsafe() bool {
+	return m.supervisorInFailsafe
+}
+func (m *mockBackend) CheckAccessList(ctx context.Context, inboxEntries []common.Hash, minSafety interoptypes.SafetyLevel, executingDescriptor interoptypes.ExecutingDescriptor) error {
+	if m.checkAccessListCb != nil {
+		m.checkAccessListCb()
+	}
+	return nil
 }
 
 type testBlockChain struct {
@@ -167,7 +191,7 @@ func createMiner(t *testing.T) *Miner {
 	txpool, _ := txpool.New(testTxPoolConfig.PriceLimit, blockchain, []txpool.SubPool{pool}, nil)
 
 	// Create Miner
-	backend := NewMockBackend(bc, txpool)
+	backend := NewMockBackend(bc, txpool, false, nil)
 	miner := New(backend, config, engine)
 	return miner
 }

--- a/miner/miner_test.go
+++ b/miner/miner_test.go
@@ -47,12 +47,12 @@ type mockBackend struct {
 
 	// OP-Stack additions
 	supervisorInFailsafe bool
-	checkAccessListCb    func()
+	queryFailsafeCb      func()
 }
 
 func NewMockBackend(bc *core.BlockChain, txPool *txpool.TxPool,
 	supervisorInFailsafe bool, // OP-Stack addition
-	checkAccessListCallback func(), // OP-Stack addition
+	queryFailsafeCb func(), // OP-Stack addition
 ) *mockBackend {
 	return &mockBackend{
 		bc:     bc,
@@ -60,7 +60,7 @@ func NewMockBackend(bc *core.BlockChain, txPool *txpool.TxPool,
 
 		// OP-Stack addition
 		supervisorInFailsafe: supervisorInFailsafe,
-		checkAccessListCb:    checkAccessListCallback,
+		queryFailsafeCb:      queryFailsafeCb,
 	}
 }
 
@@ -72,16 +72,21 @@ func (m *mockBackend) TxPool() *txpool.TxPool {
 	return m.txPool
 }
 
-// OP-Stack addition
-func (m *mockBackend) SupervisorInFailsafe() bool {
+// OP-Stack additions
+func (m *mockBackend) GetFailsafeEnabled() bool {
 	return m.supervisorInFailsafe
 }
 func (m *mockBackend) CheckAccessList(ctx context.Context, inboxEntries []common.Hash, minSafety interoptypes.SafetyLevel, executingDescriptor interoptypes.ExecutingDescriptor) error {
-	if m.checkAccessListCb != nil {
-		m.checkAccessListCb()
-	}
 	return nil
 }
+func (m *mockBackend) QueryFailsafe(ctx context.Context) (bool, error) {
+	if m.queryFailsafeCb != nil {
+		m.queryFailsafeCb()
+	}
+	return m.supervisorInFailsafe, nil
+}
+
+var _ BackendWithInterop = (*mockBackend)(nil)
 
 type testBlockChain struct {
 	root          common.Hash

--- a/miner/op_interop_miner_test.go
+++ b/miner/op_interop_miner_test.go
@@ -1,0 +1,190 @@
+package miner
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/clique"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/txpool"
+	"github.com/ethereum/go-ethereum/core/txpool/legacypool"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/types/interoptypes"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/triedb"
+	"github.com/stretchr/testify/require"
+)
+
+func createInteropMiner(t *testing.T, supervisorInFailsafe bool, checkAccessListCallback func()) (*Miner, *ecdsa.PrivateKey, common.Address) {
+	// Create Ethash config with interop enabled
+	config := Config{
+		PendingFeeRecipient:                   common.HexToAddress("123456789"),
+		RollupTransactionConditionalRateLimit: params.TransactionConditionalMaxCost,
+	}
+
+	// Create chainConfig with interop enabled
+	chainDB := rawdb.NewMemoryDatabase()
+	triedb := triedb.NewDatabase(chainDB, nil)
+
+	// Create test keys that will have funds in genesis
+	testBankKey, _ := crypto.GenerateKey()
+	testBankAddress := crypto.PubkeyToAddress(testBankKey.PublicKey)
+
+	genesis := minerTestGenesisBlock(15, 11_500_000, testBankAddress)
+
+	// Enable interop by setting InteropTime to 0
+	genesis.Config.InteropTime = new(uint64)
+	*genesis.Config.InteropTime = 0
+
+	chainConfig, _, _, err := core.SetupGenesisBlock(chainDB, triedb, genesis)
+	if err != nil {
+		t.Fatalf("can't create new chain config: %v", err)
+	}
+
+	// Create consensus engine
+	engine := clique.New(chainConfig.Clique, chainDB)
+
+	// Create Ethereum backend
+	bc, err := core.NewBlockChain(chainDB, nil, genesis, nil, engine, vm.Config{}, nil)
+	if err != nil {
+		t.Fatalf("can't create new chain %v", err)
+	}
+
+	statedb, _ := state.New(bc.Genesis().Root(), bc.StateCache())
+	blockchain := &testBlockChain{bc.Genesis().Root(), chainConfig, statedb, 10000000, new(event.Feed)}
+
+	pool := legacypool.New(legacypool.DefaultConfig, blockchain)
+	txpool, _ := txpool.New(legacypool.DefaultConfig.PriceLimit, blockchain, []txpool.SubPool{pool}, nil)
+
+	// Create mock backend with interop support
+	backend := NewMockBackend(bc, txpool, supervisorInFailsafe, checkAccessListCallback)
+
+	miner := New(backend, config, engine)
+	return miner, testBankKey, testBankAddress
+}
+
+func createInteropTransaction(t *testing.T, miner *Miner, testBankKey *ecdsa.PrivateKey, testUserAddress common.Address) *types.Transaction {
+	// Create an interop transaction with executing messages (access list)
+	signer := types.LatestSigner(miner.chainConfig)
+
+	// Create a transaction with access list pointing to CrossL2Inbox (interop address)
+	accessList := types.AccessList{
+		{
+			Address: params.InteropCrossL2InboxAddress,
+			StorageKeys: []common.Hash{
+				common.HexToHash("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"),
+			},
+		},
+	}
+
+	// Calculate gas needed: base gas + access list cost
+	// Access list cost: 2400 for address + 1900 per storage key
+	gasNeeded := params.TxGas + 2400 + 1900
+
+	tx := types.MustSignNewTx(testBankKey, signer, &types.DynamicFeeTx{
+		ChainID:    miner.chainConfig.ChainID,
+		Nonce:      0,
+		To:         &testUserAddress,
+		Value:      big.NewInt(1000),
+		Gas:        gasNeeded,
+		GasFeeCap:  big.NewInt(params.InitialBaseFee * 2),
+		GasTipCap:  big.NewInt(params.InitialBaseFee),
+		AccessList: accessList,
+	})
+
+	// Verify the transaction has executing messages
+	execMsgs := interoptypes.TxToInteropAccessList(tx)
+	if len(execMsgs) == 0 {
+		t.Fatalf("transaction should have executing messages")
+	}
+
+	return tx
+}
+
+// testInteropTransaction runs a complete interop transaction test
+func testInteropTransaction(t *testing.T, failsafeEnabled bool, expectIncluded bool, expectRejected bool) {
+	miner, testBankKey, testUserAddress := createInteropMiner(t, failsafeEnabled, nil)
+	tx := createInteropTransaction(t, miner, testBankKey, testUserAddress)
+
+	// Add the transaction to the pool
+	err := miner.txpool.Add(types.Transactions{tx}, false)
+	if len(err) > 0 && err[0] != nil {
+		t.Fatalf("Failed to add interop transaction to pool: %v", err[0])
+	}
+
+	if !miner.txpool.Has(tx.Hash()) {
+		t.Fatalf("interop transaction is not in the mempool")
+	}
+
+	// Request block generation with RPC context (required for interop check)
+	timestamp := uint64(time.Now().Unix())
+	r := miner.generateWork(&generateParams{
+		parentHash: miner.chain.CurrentBlock().Hash(),
+		timestamp:  timestamp,
+		random:     common.HexToHash("0xcafebabe"),
+		noTxs:      false,
+		forceTime:  true,
+		rpcCtx:     context.Background(), // Enable interop checks
+	}, false)
+
+	// Check transaction inclusion in block
+	if expectIncluded {
+		if len(r.block.Transactions()) != 1 {
+			t.Fatalf("block should contain 1 transaction, got %d transactions", len(r.block.Transactions()))
+		}
+	} else {
+		if len(r.block.Transactions()) != 0 {
+			t.Fatalf("block should be empty, got %d transactions", len(r.block.Transactions()))
+		}
+	}
+
+	// Check transaction rejection status
+	if expectRejected {
+		if !tx.Rejected() {
+			t.Fatalf("interop transaction should be marked as rejected")
+		}
+		// Rejected transaction should be evicted from the txpool
+		miner.txpool.Sync()
+		if miner.txpool.Has(tx.Hash()) {
+			t.Fatalf("rejected interop transaction should be evicted from the mempool")
+		}
+	} else {
+		if tx.Rejected() {
+			t.Fatalf("interop transaction should not be marked as rejected")
+		}
+		// Transaction should still be in the txpool
+		if !miner.txpool.Has(tx.Hash()) {
+			t.Fatalf("successful interop transaction should still be in the mempool")
+		}
+	}
+}
+
+func TestInteropTxRejectedWithFailsafe(t *testing.T) {
+	t.Run("failsafe enabled", func(t *testing.T) {
+		testInteropTransaction(t, true, false, true) // not included, rejected
+	})
+	t.Run("failsafe disabled", func(t *testing.T) {
+		testInteropTransaction(t, false, true, false) // included, not rejected
+	})
+}
+
+func TestFailsafeDetection(t *testing.T) {
+	supervisorRPCCalls := 0
+	cb := func() {
+		supervisorRPCCalls++
+	}
+	// Create a miner, but do no work
+	createInteropMiner(t, true, cb)
+	require.Eventually(t, func() bool {
+		return supervisorRPCCalls > 0
+	}, 10*time.Second, 100*time.Millisecond, "supervisor RPC calls should be made")
+}

--- a/miner/op_interop_miner_test.go
+++ b/miner/op_interop_miner_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func createInteropMiner(t *testing.T, supervisorInFailsafe bool, checkAccessListCallback func()) (*Miner, *ecdsa.PrivateKey, common.Address) {
+func createInteropMiner(t *testing.T, supervisorInFailsafe bool, queryFailsafeCb func()) (*Miner, *ecdsa.PrivateKey, common.Address) {
 	// Create Ethash config with interop enabled
 	config := Config{
 		PendingFeeRecipient:                   common.HexToAddress("123456789"),
@@ -66,7 +66,7 @@ func createInteropMiner(t *testing.T, supervisorInFailsafe bool, checkAccessList
 	txpool, _ := txpool.New(legacypool.DefaultConfig.PriceLimit, blockchain, []txpool.SubPool{pool}, nil)
 
 	// Create mock backend with interop support
-	backend := NewMockBackend(bc, txpool, supervisorInFailsafe, checkAccessListCallback)
+	backend := NewMockBackend(bc, txpool, supervisorInFailsafe, queryFailsafeCb)
 
 	miner := New(backend, config, engine)
 	return miner, testBankKey, testBankAddress

--- a/miner/payload_building_test.go
+++ b/miner/payload_building_test.go
@@ -150,6 +150,11 @@ func newTestWorkerBackend(t *testing.T, chainConfig *params.ChainConfig, engine 
 func (b *testWorkerBackend) BlockChain() *core.BlockChain { return b.chain }
 func (b *testWorkerBackend) TxPool() *txpool.TxPool       { return b.txPool }
 
+// OP-Stack addition
+func (b *testWorkerBackend) SupervisorInFailsafe() bool {
+	return false
+}
+
 func newTestWorker(t *testing.T, chainConfig *params.ChainConfig, engine consensus.Engine, db ethdb.Database, blocks int) (*Miner, *testWorkerBackend) {
 	backend := newTestWorkerBackend(t, chainConfig, engine, db, blocks)
 	backend.txPool.Add(pendingTxs, true)

--- a/miner/payload_building_test.go
+++ b/miner/payload_building_test.go
@@ -150,11 +150,6 @@ func newTestWorkerBackend(t *testing.T, chainConfig *params.ChainConfig, engine 
 func (b *testWorkerBackend) BlockChain() *core.BlockChain { return b.chain }
 func (b *testWorkerBackend) TxPool() *txpool.TxPool       { return b.txPool }
 
-// OP-Stack addition
-func (b *testWorkerBackend) SupervisorInFailsafe() bool {
-	return false
-}
-
 func newTestWorker(t *testing.T, chainConfig *params.ChainConfig, engine consensus.Engine, db ethdb.Database, blocks int) (*Miner, *testWorkerBackend) {
 	backend := newTestWorkerBackend(t, chainConfig, engine, db, blocks)
 	backend.txPool.Add(pendingTxs, true)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -377,7 +377,7 @@ func (miner *Miner) commitTransaction(env *environment, tx *types.Transaction) e
 	interopAccessList := interoptypes.TxToInteropAccessList(tx)
 	if len(interopAccessList) > 0 {
 		backend, ok := miner.backend.(BackendWithInterop)
-		if ok && backend.GetSupervisorFailsafe() {
+		if ok && backend.GetFailsafeEnabled() {
 			log.Trace("Supervisor failsafe is enabled, rejecting transaction", "hash", tx.Hash)
 			tx.SetRejected()
 			return errSupervisorInFailsafe

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -55,6 +55,9 @@ var (
 	errBlockInterruptedByTimeout  = errors.New("timeout while building block")
 	errBlockInterruptedByResolve  = errors.New("payload resolution while building block")
 
+	// OP-Stack addition
+	errSupervisorInFailsafe = errors.New("supervisor in failsafe")
+
 	txConditionalRejectedCounter = metrics.NewRegisteredCounter("miner/transactionConditional/rejected", nil)
 	txConditionalMinedTimer      = metrics.NewRegisteredTimer("miner/transactionConditional/elapsedtime", nil)
 )
@@ -369,6 +372,13 @@ func (miner *Miner) makeEnv(parent *types.Header, header *types.Header, coinbase
 }
 
 func (miner *Miner) commitTransaction(env *environment, tx *types.Transaction) error {
+	// OP-Stack addition
+	if len(tx.AccessList()) > 0 && miner.backend.SupervisorInFailsafe() {
+		log.Trace("Supervisor failsafe is enabled, rejecting transaction", "hash", tx.Hash)
+		tx.SetRejected()
+		return errSupervisorInFailsafe
+	}
+
 	if tx.Type() == types.BlobTxType {
 		return miner.commitBlobTransaction(env, tx)
 	}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -373,10 +373,13 @@ func (miner *Miner) makeEnv(parent *types.Header, header *types.Header, coinbase
 
 func (miner *Miner) commitTransaction(env *environment, tx *types.Transaction) error {
 	// OP-Stack addition
-	if len(tx.AccessList()) > 0 && miner.backend.SupervisorInFailsafe() {
-		log.Trace("Supervisor failsafe is enabled, rejecting transaction", "hash", tx.Hash)
-		tx.SetRejected()
-		return errSupervisorInFailsafe
+	if len(tx.AccessList()) > 0 {
+		backend, ok := miner.backend.(BackendWithInterop)
+		if ok && backend.SupervisorInFailsafe() {
+			log.Trace("Supervisor failsafe is enabled, rejecting transaction", "hash", tx.Hash)
+			tx.SetRejected()
+			return errSupervisorInFailsafe
+		}
 	}
 
 	if tx.Type() == types.BlobTxType {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -375,7 +375,7 @@ func (miner *Miner) commitTransaction(env *environment, tx *types.Transaction) e
 	// OP-Stack addition
 	if len(tx.AccessList()) > 0 {
 		backend, ok := miner.backend.(BackendWithInterop)
-		if ok && backend.SupervisorInFailsafe() {
+		if ok && backend.GetSupervisorFailsafe() {
 			log.Trace("Supervisor failsafe is enabled, rejecting transaction", "hash", tx.Hash)
 			tx.SetRejected()
 			return errSupervisorInFailsafe

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -377,7 +377,7 @@ func (miner *Miner) commitTransaction(env *environment, tx *types.Transaction) e
 	interopAccessList := interoptypes.TxToInteropAccessList(tx)
 	if len(interopAccessList) > 0 {
 		backend, ok := miner.backend.(BackendWithInterop)
-		if ok && backend.GetFailsafeEnabled() {
+		if ok && backend.GetSupervisorFailsafe() {
 			log.Trace("Supervisor failsafe is enabled, rejecting transaction", "hash", tx.Hash)
 			tx.SetRejected()
 			return errSupervisorInFailsafe

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/stateless"
 	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/types/interoptypes"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/eth/tracers"
 	"github.com/ethereum/go-ethereum/log"
@@ -373,7 +374,8 @@ func (miner *Miner) makeEnv(parent *types.Header, header *types.Header, coinbase
 
 func (miner *Miner) commitTransaction(env *environment, tx *types.Transaction) error {
 	// OP-Stack addition
-	if len(tx.AccessList()) > 0 {
+	interopAccessList := interoptypes.TxToInteropAccessList(tx)
+	if len(interopAccessList) > 0 {
 		backend, ok := miner.backend.(BackendWithInterop)
 		if ok && backend.GetSupervisorFailsafe() {
 			log.Trace("Supervisor failsafe is enabled, rejecting transaction", "hash", tx.Hash)


### PR DESCRIPTION
The supervisor is already consulted (via a CheckAccessList call) on tx ingress into the mempool.

This PR does the following:
* adds a local boolean to the backend to cache whether the supervisor response indicates failsafe is active or inactive
* adds a routine to the miner which refreshes that boolean (by making further RPC calls) on a ticker
* has txs evicted from the mempool if failsafe is detected to be active
* has txs rejected at block building time if failsafe was active last time we checked

Also adds a test for handling interop transactions under different supervisor responses. 