### PR TITLE
fix(p2p): use raw string literals for regular expressions

### DIFF
--- a/p2p/enode/urlv4.go
+++ b/p2p/enode/urlv4.go
@@ -32,7 +32,7 @@ import (
 )
 
 var (
-	incompleteNodeURL = regexp.MustCompile("(?i)^(?:enode://)?([0-9a-f]+)$")
+	incompleteNodeURL = regexp.MustCompile(`(?i)^(?:enode://)?([0-9a-f]+)$`)
 )
 
 // MustParseV4 parses a node URL. It panics if the URL is not valid.


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Replace double-quoted string with backtick-quoted raw string for regular expression in p2p/enode/urlv4.go. This improves readability and follows Go's idiomatic style for regular expressions, reducing the risk of escaping errors in future modifications.