### PR TITLE
core,miner,parms: DA footprint block limit (constant gas scalar)

### DIFF
--- a/miner/miner_optimism_test.go
+++ b/miner/miner_optimism_test.go
@@ -1,0 +1,107 @@
+package miner
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/beacon"
+	"github.com/ethereum/go-ethereum/consensus/ethash"
+	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDAFootprintMining tests that the miner correctly limits the DA footprint of the block.
+// It builds a block via the miner from txpool
+// transactions and then imports the block into the chain, asserting that
+// execution succeeds.
+func TestDAFootprintMining(t *testing.T) {
+	requireTxGas := func(t *testing.T, block *types.Block, receipts []*types.Receipt) {
+		var txGas uint64
+		for _, receipt := range receipts {
+			txGas += receipt.GasUsed
+		}
+		require.Equal(t, txGas, block.GasUsed(), "total tx gas used should be equal to block gas used")
+	}
+
+	requireDAFootprint := func(t *testing.T, block *types.Block, receipts []*types.Receipt) {
+		var (
+			txGas       uint64
+			daFootprint uint64
+			txs         = block.Transactions()
+		)
+
+		require.Equal(t, len(receipts), len(txs))
+
+		for i, receipt := range receipts {
+			txGas += receipt.GasUsed
+			if txs[i].IsDepositTx() {
+				continue
+			}
+			daFootprint += txs[i].RollupCostData().EstimatedDASize().Uint64() * params.DAFootprintGasScalar
+		}
+		require.Less(t, txGas, block.GasUsed(), "total tx gas used must be smaller than block gas used")
+		require.Equal(t, daFootprint, block.GasUsed(), "total DA footprint used should be equal to block gas used")
+	}
+	t.Run("jovian-at-limit", func(t *testing.T) {
+		testMineAndExecute(t, 17, jovianConfig(), func(t *testing.T, block *types.Block, receipts []*types.Receipt) {
+			require.Len(t, receipts, 19) // including 1 test pending tx and 1 deposit tx
+			requireDAFootprint(t, block, receipts)
+		})
+	})
+	t.Run("jovian-above-limit", func(t *testing.T) {
+		testMineAndExecute(t, 18, jovianConfig(), func(t *testing.T, block *types.Block, receipts []*types.Receipt) {
+			require.Len(t, receipts, 19) // same as for 17, because 18th tx from pool shouldn't have been included
+			requireDAFootprint(t, block, receipts)
+		})
+	})
+	t.Run("isthmus", func(t *testing.T) {
+		testMineAndExecute(t, 39, isthmusConfig(), func(t *testing.T, block *types.Block, receipts []*types.Receipt) {
+			require.Len(t, receipts, 41) // including 1 test pending tx and 1 deposit tx
+			requireTxGas(t, block, receipts)
+		})
+	})
+}
+
+func testMineAndExecute(t *testing.T, numTxs uint64, cfg *params.ChainConfig, assertFn func(t *testing.T, block *types.Block, receipts []*types.Receipt)) {
+	db := rawdb.NewMemoryDatabase()
+	w, b := newTestWorker(t, cfg, beacon.New(ethash.NewFaker()), db, 0)
+
+	// Start from nonce 1 to avoid colliding with the preloaded pending tx.
+	txs := genTxs(1, numTxs)
+
+	// Add to txpool for the miner to pick up.
+	if errs := b.txPool.Add(txs, false); len(errs) > 0 {
+		for _, err := range errs {
+			require.NoError(t, err, "failed adding tx to pool")
+		}
+	}
+
+	genParams := &generateParams{
+		parentHash:    b.chain.CurrentBlock().Hash(),
+		timestamp:     b.chain.CurrentBlock().Time + 12,
+		withdrawals:   types.Withdrawals{},
+		beaconRoot:    new(common.Hash),
+		gasLimit:      ptr(uint64(1e6)), // Small gas limit to easily fill block
+		txs:           types.Transactions{types.NewTx(&types.DepositTx{})},
+		eip1559Params: eip1559.EncodeHolocene1559Params(250, 6),
+	}
+	if cfg.IsJovian(b.chain.CurrentBlock().Time) {
+		genParams.minBaseFee = new(uint64)
+	}
+	r := w.generateWork(genParams, false)
+	require.NoError(t, r.err, "block generation failed")
+	require.NotNil(t, r.block, "no block generated")
+
+	assertFn(t, r.block, r.receipts)
+
+	// Import the block into the chain, which executes it via StateProcessor.
+	_, err := b.chain.InsertChain(types.Blocks{r.block})
+	require.NoError(t, err, "block import/execution failed")
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}

--- a/params/config.go
+++ b/params/config.go
@@ -377,6 +377,7 @@ var (
 	OptimismTestConfig = func() *ChainConfig {
 		conf := *MergedTestChainConfig // copy the config
 		conf.BlobScheduleConfig = nil
+		conf.OsakaTime = nil // needs to be removed when production fork introduces Osaka
 		conf.BedrockBlock = big.NewInt(0)
 		zero := uint64(0)
 		conf.RegolithTime = &zero
@@ -386,9 +387,9 @@ var (
 		conf.GraniteTime = &zero
 		conf.HoloceneTime = &zero
 		conf.IsthmusTime = &zero
-		conf.InteropTime = nil
 		conf.JovianTime = nil
-		conf.Optimism = &OptimismConfig{EIP1559Elasticity: 50, EIP1559Denominator: 10, EIP1559DenominatorCanyon: uint64ptr(250)}
+		conf.InteropTime = nil
+		conf.Optimism = &OptimismConfig{EIP1559Elasticity: 6, EIP1559Denominator: 50, EIP1559DenominatorCanyon: uint64ptr(250)}
 		return &conf
 	}()
 )

--- a/params/opstack_params.go
+++ b/params/opstack_params.go
@@ -1,0 +1,5 @@
+package params
+
+// Jovian
+
+const DAFootprintGasScalar = 400


### PR DESCRIPTION
**Description**

Spike of calldata footprint block limit implementation.

Following the idea of [multidimenstional gas metering](https://ethresear.ch/t/a-practical-proposal-for-multidimensional-gas-metering/22668) (but without changing regular gas accounting), a new _calldata footprint_ resource is introduced. The calldata footprint is of the same scale as transaction gas. The total calldata footprint of a block is limited by the same gas limit as for regular gas. This has the effect that total calldata usage of a block is constrained, with the right parameters, more than by calldata (floor) gas usage. The _calldata footprint cost_ is comparable to the regular _calldata floor cost_, but higher values would be chosen.

Using the FastLZ-based estimated size of a transaction from Fjord, a transaction's calldata footprint is now simply `calldataFootprint = estimatedSize * calldataFootprintCost`. So it estimates the transaction's calldata impact on the DA batch it will be a part of, scaled to be comparable to gas, so it can be limited by the same block limit.

A block's _gas used_ field is now set to the maximum of the two resources, the total gas used of all transaction (as before), and the total calldata footprint of all transactions. This has the benefit that the EIP-1559 fee market now also takes total calldata footprint into account and the base fee reacts to calldata-heavy blocks.

An open question is whether we want to make the _calldata footprint cost_ a protocol constant, or configurable per chain via the `SystemConfig` L1 contract.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
