### PR TITLE
metrics: Block Basefee

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -64,6 +64,7 @@ var (
 	headFastBlockGauge      = metrics.NewRegisteredGauge("chain/head/receipt", nil)
 	headFinalizedBlockGauge = metrics.NewRegisteredGauge("chain/head/finalized", nil)
 	headSafeBlockGauge      = metrics.NewRegisteredGauge("chain/head/safe", nil)
+	headBaseFeeGauge        = metrics.NewRegisteredGauge("chain/head/basefee", nil)
 
 	chainInfoGauge = metrics.NewRegisteredGaugeInfo("chain/info", nil)
 
@@ -1175,6 +1176,7 @@ func (bc *BlockChain) writeHeadBlock(block *types.Block) {
 
 	bc.currentBlock.Store(block.Header())
 	headBlockGauge.Update(int64(block.NumberU64()))
+	headBaseFeeGauge.Update(block.Header().BaseFee.Int64())
 }
 
 // stopWithoutSaving stops the blockchain service. If any imports are currently in progress
@@ -1340,6 +1342,7 @@ func (bc *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain [
 		bc.currentSnapBlock.Store(header)
 		headHeaderGauge.Update(header.Number.Int64())
 		headFastBlockGauge.Update(header.Number.Int64())
+		headBaseFeeGauge.Update(header.BaseFee.Int64())
 		return nil
 	}
 	// writeAncient writes blockchain and corresponding receipt chain into ancient store.
@@ -2659,6 +2662,7 @@ func (bc *BlockChain) InsertHeadersBeforeCutoff(headers []*types.Header) (int, e
 	bc.currentSnapBlock.Store(last)
 	headHeaderGauge.Update(last.Number.Int64())
 	headFastBlockGauge.Update(last.Number.Int64())
+	headBaseFeeGauge.Update(last.BaseFee.Int64())
 	return 0, nil
 }
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1176,7 +1176,7 @@ func (bc *BlockChain) writeHeadBlock(block *types.Block) {
 
 	bc.currentBlock.Store(block.Header())
 	headBlockGauge.Update(int64(block.NumberU64()))
-	headBaseFeeGauge.Update(block.Header().BaseFee.Int64())
+	headBaseFeeGauge.TryUpdate(block.Header().BaseFee)
 }
 
 // stopWithoutSaving stops the blockchain service. If any imports are currently in progress
@@ -1342,7 +1342,7 @@ func (bc *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain [
 		bc.currentSnapBlock.Store(header)
 		headHeaderGauge.Update(header.Number.Int64())
 		headFastBlockGauge.Update(header.Number.Int64())
-		headBaseFeeGauge.Update(header.BaseFee.Int64())
+		headBaseFeeGauge.TryUpdate(header.BaseFee)
 		return nil
 	}
 	// writeAncient writes blockchain and corresponding receipt chain into ancient store.
@@ -2662,7 +2662,7 @@ func (bc *BlockChain) InsertHeadersBeforeCutoff(headers []*types.Header) (int, e
 	bc.currentSnapBlock.Store(last)
 	headHeaderGauge.Update(last.Number.Int64())
 	headFastBlockGauge.Update(last.Number.Int64())
-	headBaseFeeGauge.Update(last.BaseFee.Int64())
+	headBaseFeeGauge.TryUpdate(last.BaseFee)
 	return 0, nil
 }
 

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -92,6 +92,7 @@ func NewHeaderChain(chainDb ethdb.Database, config *params.ChainConfig, engine c
 	}
 	hc.currentHeaderHash = hc.CurrentHeader().Hash()
 	headHeaderGauge.Update(hc.CurrentHeader().Number.Int64())
+	headBaseFeeGauge.Update(hc.CurrentHeader().BaseFee.Int64())
 	return hc, nil
 }
 
@@ -182,6 +183,7 @@ func (hc *HeaderChain) Reorg(headers []*types.Header) error {
 	hc.currentHeaderHash = last.Hash()
 	hc.currentHeader.Store(types.CopyHeader(last))
 	headHeaderGauge.Update(last.Number.Int64())
+	headBaseFeeGauge.Update(last.BaseFee.Int64())
 	return nil
 }
 
@@ -484,6 +486,7 @@ func (hc *HeaderChain) SetCurrentHeader(head *types.Header) {
 	hc.currentHeader.Store(head)
 	hc.currentHeaderHash = head.Hash()
 	headHeaderGauge.Update(head.Number.Int64())
+	headBaseFeeGauge.Update(head.BaseFee.Int64())
 }
 
 type (
@@ -570,6 +573,7 @@ func (hc *HeaderChain) setHead(headBlock uint64, headTime uint64, updateFn Updat
 		hc.currentHeader.Store(parent)
 		hc.currentHeaderHash = parentHash
 		headHeaderGauge.Update(parent.Number.Int64())
+		headBaseFeeGauge.Update(parent.BaseFee.Int64())
 
 		// If this is the first iteration, wipe any leftover data upwards too so
 		// we don't end up with dangling daps in the database

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -92,7 +92,7 @@ func NewHeaderChain(chainDb ethdb.Database, config *params.ChainConfig, engine c
 	}
 	hc.currentHeaderHash = hc.CurrentHeader().Hash()
 	headHeaderGauge.Update(hc.CurrentHeader().Number.Int64())
-	headBaseFeeGauge.Update(hc.CurrentHeader().BaseFee.Int64())
+	headBaseFeeGauge.TryUpdate(hc.CurrentHeader().BaseFee)
 	return hc, nil
 }
 
@@ -183,7 +183,7 @@ func (hc *HeaderChain) Reorg(headers []*types.Header) error {
 	hc.currentHeaderHash = last.Hash()
 	hc.currentHeader.Store(types.CopyHeader(last))
 	headHeaderGauge.Update(last.Number.Int64())
-	headBaseFeeGauge.Update(last.BaseFee.Int64())
+	headBaseFeeGauge.TryUpdate(last.BaseFee)
 	return nil
 }
 
@@ -486,7 +486,7 @@ func (hc *HeaderChain) SetCurrentHeader(head *types.Header) {
 	hc.currentHeader.Store(head)
 	hc.currentHeaderHash = head.Hash()
 	headHeaderGauge.Update(head.Number.Int64())
-	headBaseFeeGauge.Update(head.BaseFee.Int64())
+	headBaseFeeGauge.TryUpdate(head.BaseFee)
 }
 
 type (
@@ -573,7 +573,7 @@ func (hc *HeaderChain) setHead(headBlock uint64, headTime uint64, updateFn Updat
 		hc.currentHeader.Store(parent)
 		hc.currentHeaderHash = parentHash
 		headHeaderGauge.Update(parent.Number.Int64())
-		headBaseFeeGauge.Update(parent.BaseFee.Int64())
+		headBaseFeeGauge.TryUpdate(parent.BaseFee)
 
 		// If this is the first iteration, wipe any leftover data upwards too so
 		// we don't end up with dangling daps in the database

--- a/fork.yaml
+++ b/fork.yaml
@@ -196,9 +196,12 @@ def:
           globs:
             - "eth/handler.go"
             - "eth/handler_eth.go"
-        - title: Warn on missing hardfork data
+        - title: Warn on missing hardfork data and emit additional metrics
           globs:
             - "core/blockchain.go"
+        - title: Additional metrics
+          globs:
+            - "core/headerchain.go"
         - title: Optional Engine API extensions
           globs:
             - "eth/catalyst/superchain.go"
@@ -368,6 +371,11 @@ def:
             not updated to handle the newly added `withdrawalsRoot` field in the block header.
           globs:
             - "cmd/evm/internal/t8ntool/block.go"
+        - title: Metrics
+          description: |
+            Adds support for safely updating gauges from optional big.Int values.
+          globs:
+            - "metrics/gauge.go"
     - title: "Testing"
       description: Additional or modified tests, not already captured by the above diff
       ignore:

--- a/metrics/gauge.go
+++ b/metrics/gauge.go
@@ -1,6 +1,9 @@
 package metrics
 
-import "sync/atomic"
+import (
+	"math/big"
+	"sync/atomic"
+)
 
 // GaugeSnapshot is a read-only copy of a Gauge.
 type GaugeSnapshot int64
@@ -43,6 +46,14 @@ func (g *Gauge) Snapshot() GaugeSnapshot {
 // Update updates the gauge's value.
 func (g *Gauge) Update(v int64) {
 	(*atomic.Int64)(g).Store(v)
+}
+
+// TryUpdate updates the gauge if the value is non-nil, converting it to int64.
+func (g *Gauge) TryUpdate(v *big.Int) {
+	if v == nil {
+		return
+	}
+	(*atomic.Int64)(g).Store(v.Int64())
 }
 
 // UpdateIfGt updates the gauge's value if v is larger then the current value.


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Adds block base fee metrics.

Base fee was introduced at london hardfork and block header is not populated before it. Considered this when we try to emit the base fee metric.

You may question that why I added the specific `headBaseFeeGauge` bumps across the codebase in this PR. The rationale is simple. Find the `headHeaderGauge` bump, and add the `headBaseFeeGauge` below it since header includes base fee.

Example metric when you read the raw prometheus endpoint:
```log
# TYPE chain_head_basefee gauge
chain_head_basefee 712475636
```

**Tests**

All existing tests are passing.

**Additional context**

Building block for calldata footprint limit. Also modified the forkdiff for the relevant changes.
