### PR TITLE
feat: add distributed tracing support for JSON-RPC requests

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -207,6 +207,7 @@ var (
 		utils.RPCGlobalGasCapFlag,
 		utils.RPCGlobalEVMTimeoutFlag,
 		utils.RPCGlobalTxFeeCapFlag,
+		utils.EnableTracingFlag,
 		utils.AllowUnprotectedTxs,
 		utils.BatchRequestLimit,
 		utils.BatchResponseMaxSize,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -607,6 +607,11 @@ var (
 		Value:    ethconfig.Defaults.RPCTxFeeCap,
 		Category: flags.APICategory,
 	}
+	EnableTracingFlag = &cli.BoolFlag{
+		Name:     "enable-tracing",
+		Usage:    "Enable distributed tracing for JSON-RPC requests",
+		Category: flags.APICategory,
+	}
 	// Authenticated RPC HTTP settings
 	AuthListenFlag = &cli.StringFlag{
 		Name:     "authrpc.addr",
@@ -1875,6 +1880,12 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	}
 	if ctx.IsSet(RPCGlobalTxFeeCapFlag.Name) {
 		cfg.RPCTxFeeCap = ctx.Float64(RPCGlobalTxFeeCapFlag.Name)
+	}
+	if ctx.IsSet(EnableTracingFlag.Name) {
+		cfg.RPCTracing = ctx.Bool(EnableTracingFlag.Name)
+		// Also set the node HTTP tracing config
+		stackConfig := stack.Config()
+		stackConfig.HTTPTracing = cfg.RPCTracing
 	}
 	if ctx.IsSet(NoDiscoverFlag.Name) {
 		cfg.EthDiscoveryURLs, cfg.SnapDiscoveryURLs = []string{}, []string{}

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -40,6 +40,7 @@ import (
 	"github.com/ethereum/go-ethereum/eth/tracers"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
+	"github.com/ethereum/go-ethereum/internal/tracing"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -277,6 +278,9 @@ func (b *EthAPIBackend) SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscri
 }
 
 func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction) error {
+	// Add tracing context if available
+	traceParent, _ := tracing.GetTraceParent(ctx)
+
 	if b.ChainConfig().IsOptimism() && signedTx.Type() == types.BlobTxType {
 		return types.ErrTxTypeNotSupported
 	}
@@ -291,15 +295,34 @@ func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction)
 		if err != nil {
 			return err
 		}
+
+		// Log before sending to op-node/sequencer
+		if traceParent != "" {
+			log.Info("Forwarding transaction to sequencer", "hash", signedTx.Hash().Hex(), "trace", traceParent)
+		}
+
 		if err := b.eth.seqRPCService.CallContext(ctx, nil, "eth_sendRawTransaction", hexutil.Encode(data)); err != nil {
+			if traceParent != "" {
+				log.Warn("Failed to forward transaction to sequencer", "hash", signedTx.Hash().Hex(), "trace", traceParent, "err", err)
+			}
 			return err
+		}
+
+		if traceParent != "" {
+			log.Info("Successfully forwarded transaction to sequencer", "hash", signedTx.Hash().Hex(), "trace", traceParent)
 		}
 		if b.disableTxPool {
 			return nil
 		}
 		// Retain tx in local tx pool after forwarding, for local RPC usage.
 		if err := b.eth.txPool.Add([]*types.Transaction{signedTx}, false)[0]; err != nil {
-			log.Warn("successfully sent tx to sequencer, but failed to persist in local tx pool", "err", err, "tx", signedTx.Hash())
+			if traceParent != "" {
+				log.Warn("successfully sent tx to sequencer, but failed to persist in local tx pool", "err", err, "tx", signedTx.Hash(), "trace", traceParent)
+			} else {
+				log.Warn("successfully sent tx to sequencer, but failed to persist in local tx pool", "err", err, "tx", signedTx.Hash())
+			}
+		} else if traceParent != "" {
+			log.Info("Transaction added to local tx pool after sequencer", "hash", signedTx.Hash().Hex(), "trace", traceParent)
 		}
 		return nil
 	}
@@ -307,7 +330,20 @@ func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction)
 		return nil
 	}
 
-	return b.eth.txPool.Add([]*types.Transaction{signedTx}, false)[0]
+	// Add to transaction pool (non-sequencer mode)
+	if traceParent != "" {
+		log.Info("Adding transaction to local tx pool", "hash", signedTx.Hash().Hex(), "trace", traceParent)
+	}
+	if err := b.eth.txPool.Add([]*types.Transaction{signedTx}, false)[0]; err != nil {
+		if traceParent != "" {
+			log.Warn("Failed to add transaction to tx pool", "hash", signedTx.Hash().Hex(), "trace", traceParent, "err", err)
+		}
+		return err
+	}
+	if traceParent != "" {
+		log.Info("Successfully added transaction to tx pool", "hash", signedTx.Hash().Hex(), "trace", traceParent)
+	}
+	return nil
 }
 
 func (b *EthAPIBackend) GetPoolTransactions() (types.Transactions, error) {

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -149,6 +149,9 @@ type Config struct {
 	// send-transaction variants. The unit is ether.
 	RPCTxFeeCap float64
 
+	// RPCTracing enables distributed tracing for JSON-RPC requests.
+	RPCTracing bool
+
 	// OverrideCancun (TODO: remove after the fork)
 	OverrideCancun *uint64 `toml:",omitempty"`
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -42,6 +42,7 @@ import (
 	"github.com/ethereum/go-ethereum/eth/gasestimator"
 	"github.com/ethereum/go-ethereum/eth/tracers/logger"
 	"github.com/ethereum/go-ethereum/internal/ethapi/override"
+	"github.com/ethereum/go-ethereum/internal/tracing"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/params"
@@ -1652,6 +1653,9 @@ func (api *TransactionAPI) sign(addr common.Address, tx *types.Transaction) (*ty
 
 // SubmitTransaction is a helper function that submits tx to txPool and logs a message.
 func SubmitTransaction(ctx context.Context, b Backend, tx *types.Transaction) (common.Hash, error) {
+	// Add tracing context if available
+	traceParent, _ := tracing.GetTraceParent(ctx)
+
 	// If the transaction fee cap is already specified, ensure the
 	// fee of the given transaction is _reasonable_.
 	if err := checkTxFee(tx.GasPrice(), tx.Gas(), b.RPCTxFeeCap()); err != nil {
@@ -1674,9 +1678,17 @@ func SubmitTransaction(ctx context.Context, b Backend, tx *types.Transaction) (c
 
 	if tx.To() == nil {
 		addr := crypto.CreateAddress(from, tx.Nonce())
-		log.Info("Submitted contract creation", "hash", tx.Hash().Hex(), "from", from, "nonce", tx.Nonce(), "contract", addr.Hex(), "value", tx.Value())
+		if traceParent != "" {
+			log.Info("Submitted contract creation", "hash", tx.Hash().Hex(), "from", from, "nonce", tx.Nonce(), "contract", addr.Hex(), "value", tx.Value(), "trace", traceParent)
+		} else {
+			log.Info("Submitted contract creation", "hash", tx.Hash().Hex(), "from", from, "nonce", tx.Nonce(), "contract", addr.Hex(), "value", tx.Value())
+		}
 	} else {
-		log.Info("Submitted transaction", "hash", tx.Hash().Hex(), "from", from, "nonce", tx.Nonce(), "recipient", tx.To(), "value", tx.Value())
+		if traceParent != "" {
+			log.Info("Submitted transaction", "hash", tx.Hash().Hex(), "from", from, "nonce", tx.Nonce(), "recipient", tx.To(), "value", tx.Value(), "trace", traceParent)
+		} else {
+			log.Info("Submitted transaction", "hash", tx.Hash().Hex(), "from", from, "nonce", tx.Nonce(), "recipient", tx.To(), "value", tx.Value())
+		}
 	}
 	return tx.Hash(), nil
 }

--- a/internal/tracing/distributed.go
+++ b/internal/tracing/distributed.go
@@ -1,0 +1,142 @@
+// Package tracing provides distributed tracing utilities for op-geth.
+package tracing
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+
+	"github.com/ethereum/go-ethereum/log"
+)
+
+const (
+	// W3C TraceContext header
+	TraceParentHeader = "traceparent"
+)
+
+// Context keys for storing trace information
+type contextKey string
+
+const (
+	traceParentKey contextKey = "traceparent"
+	enabledKey     contextKey = "tracing_enabled"
+)
+
+// generateTraceID creates a new 32-character hex trace ID
+func generateTraceID() string {
+	b := make([]byte, 16)
+	rand.Read(b)
+	return hex.EncodeToString(b)
+}
+
+// generateSpanID creates a new 16-character hex span ID
+func generateSpanID() string {
+	b := make([]byte, 8)
+	rand.Read(b)
+	return hex.EncodeToString(b)
+}
+
+// ExtractTraceContext extracts W3C TraceContext headers from the incoming request
+// and stores them in the context for later propagation
+func ExtractTraceContext(req *http.Request, ctx context.Context) context.Context {
+	// Check if tracing is enabled in this context
+	if enabled, ok := ctx.Value(enabledKey).(bool); !ok || !enabled {
+		return ctx
+	}
+
+	// Extract traceparent header
+	if traceparent := req.Header.Get(TraceParentHeader); traceparent != "" {
+		if isValidTraceParent(traceparent) {
+			ctx = context.WithValue(ctx, traceParentKey, traceparent)
+			log.Debug("Extracted trace context", "traceparent", traceparent)
+		}
+	}
+
+	return ctx
+}
+
+// CreateTraceContext generates a new trace context from request data
+func CreateTraceContext(requestData []byte, ctx context.Context) context.Context {
+	// Check if tracing is enabled
+	if enabled, ok := ctx.Value(enabledKey).(bool); !ok || !enabled {
+		return ctx
+	}
+
+	// Generate new trace and span IDs
+	traceID := generateTraceID()
+	spanID := generateSpanID()
+
+	// Create W3C traceparent header: version-traceid-spanid-flags
+	// Version: 00, Flags: 01 (sampled)
+	traceparent := fmt.Sprintf("00-%s-%s-01", traceID, spanID)
+
+	// Store hash of request data for correlation (optional, for debugging)
+	if len(requestData) > 0 {
+		bodyHash := hashRequestData(requestData)
+		log.Debug("Created trace context", "traceparent", traceparent, "data_hash", bodyHash)
+	}
+
+	return context.WithValue(ctx, traceParentKey, traceparent)
+}
+
+// GetTraceParent returns the traceparent value from context, if any
+func GetTraceParent(ctx context.Context) (string, bool) {
+	if traceparent, ok := ctx.Value(traceParentKey).(string); ok {
+		return traceparent, true
+	}
+	return "", false
+}
+
+// EnableTracing adds tracing enabled flag to context
+func EnableTracing(ctx context.Context) context.Context {
+	return context.WithValue(ctx, enabledKey, true)
+}
+
+// IsTracingEnabled checks if tracing is enabled in the context
+func IsTracingEnabled(ctx context.Context) bool {
+	if enabled, ok := ctx.Value(enabledKey).(bool); ok {
+		return enabled
+	}
+	return false
+}
+
+// GetTraceID extracts the trace ID from the traceparent header in the context
+func GetTraceID(ctx context.Context) string {
+	if traceparent, ok := ctx.Value(traceParentKey).(string); ok && len(traceparent) >= 36 {
+		// Extract trace ID from traceparent format: 00-TRACEID-SPANID-01
+		// TraceID is at positions 3-34 (32 chars)
+		return traceparent[3:35]
+	}
+	return ""
+}
+
+// hashRequestData creates a SHA256 hash of the request data for trace correlation
+func hashRequestData(data []byte) string {
+	h := sha256.Sum256(data)
+	return hex.EncodeToString(h[:8]) // Use first 8 bytes for brevity
+}
+
+// isValidTraceParent validates the format of a traceparent header
+// Basic validation - should be 55 characters in format: 00-{32hex}-{16hex}-{2hex}
+func isValidTraceParent(traceparent string) bool {
+	if len(traceparent) != 55 {
+		return false
+	}
+	if traceparent[2] != '-' || traceparent[35] != '-' || traceparent[52] != '-' {
+		return false
+	}
+	return true
+}
+
+// LogWithTrace logs a message with trace correlation if tracing is enabled
+func LogWithTrace(ctx context.Context, msg string, keyvals ...interface{}) {
+	if IsTracingEnabled(ctx) {
+		if traceID := GetTraceID(ctx); traceID != "" {
+			keyvals = append(keyvals, "trace_id", traceID)
+		}
+	}
+	log.Info(msg, keyvals...)
+}

--- a/node/config.go
+++ b/node/config.go
@@ -137,6 +137,9 @@ type Config struct {
 	// HTTPPathPrefix specifies a path prefix on which http-rpc is to be served.
 	HTTPPathPrefix string `toml:",omitempty"`
 
+	// HTTPTracing enables distributed tracing for HTTP RPC requests.
+	HTTPTracing bool `toml:",omitempty"`
+
 	// AuthAddr is the listening address on which authenticated APIs are provided.
 	AuthAddr string `toml:",omitempty"`
 

--- a/node/node.go
+++ b/node/node.go
@@ -393,6 +393,7 @@ func (n *Node) startRPC() error {
 	rpcConfig := rpcEndpointConfig{
 		batchItemLimit:         n.config.BatchRequestLimit,
 		batchResponseSizeLimit: n.config.BatchResponseMaxSize,
+		enableTracing:          n.config.HTTPTracing,
 	}
 
 	initHttp := func(server *httpServer, port int) error {

--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -58,6 +58,7 @@ type rpcEndpointConfig struct {
 	batchItemLimit         int
 	batchResponseSizeLimit int
 	httpBodyLimit          int
+	enableTracing          bool
 }
 
 type rpcHandler struct {
@@ -309,6 +310,7 @@ func (h *httpServer) enableRPC(apis []rpc.API, config httpConfig) error {
 	if config.httpBodyLimit > 0 {
 		srv.SetHTTPBodyLimit(config.httpBodyLimit)
 	}
+	srv.SetTracingEnabled(config.enableTracing)
 	if err := RegisterApis(apis, config.Modules, srv); err != nil {
 		return err
 	}
@@ -344,6 +346,7 @@ func (h *httpServer) enableWS(apis []rpc.API, config wsConfig) error {
 	if config.httpBodyLimit > 0 {
 		srv.SetHTTPBodyLimit(config.httpBodyLimit)
 	}
+	srv.SetTracingEnabled(config.enableTracing)
 	if err := RegisterApis(apis, config.Modules, srv); err != nil {
 		return err
 	}

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -30,6 +30,8 @@ import (
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/ethereum/go-ethereum/internal/tracing"
 )
 
 const (
@@ -326,6 +328,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	connInfo.HTTP.UserAgent = r.Header.Get("User-Agent")
 	ctx := r.Context()
 	ctx = context.WithValue(ctx, peerInfoContextKey{}, connInfo)
+
+	// Enable tracing if configured
+	if s.enableTracing {
+		ctx = tracing.EnableTracing(ctx)
+		ctx = tracing.ExtractTraceContext(r, ctx)
+	}
 
 	// All checks passed, create a codec that reads directly from the request body
 	// until EOF, writes the response to w, and orders the server to process a

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -54,6 +54,7 @@ type Server struct {
 	batchItemLimit     int
 	batchResponseLimit int
 	httpBodyLimit      int
+	enableTracing      bool
 
 	recorder Recorder // optional, may be nil
 }
@@ -93,6 +94,13 @@ func (s *Server) SetBatchLimits(itemLimit, maxResponseSize int) {
 // This method should be called before processing any requests via ServeHTTP.
 func (s *Server) SetHTTPBodyLimit(limit int) {
 	s.httpBodyLimit = limit
+}
+
+// SetTracingEnabled enables or disables distributed tracing for RPC requests.
+//
+// This method should be called before processing any requests via ServeHTTP.
+func (s *Server) SetTracingEnabled(enabled bool) {
+	s.enableTracing = enabled
 }
 
 // RegisterName creates a service for the given receiver type under the given name. When no


### PR DESCRIPTION
Implements end-to-end distributed tracing for op-geth to enable observability of transaction ingress path from HTTP requests through to op-node interface.

Key features:
- --enable-tracing CLI flag for opt-in tracing activation
- W3C TraceContext header extraction from HTTP requests
- Trace propagation through JSON-RPC processing pipeline
- Transaction tracing in eth_sendRawTransaction flow
- Trace logging at op-geth → op-node boundary
- Integration with transaction pool operations

Modified components:
- CLI flag infrastructure and configuration propagation
- HTTP server trace extraction (rpc/http.go)
- RPC server tracing support (rpc/server.go)
- Transaction API tracing (internal/ethapi/api.go)
- Backend transaction submission tracing (eth/api_backend.go)
- Node configuration and startup (node/*.go)

Implementation provides complete audit trail for transaction processing from HTTP ingestion to sequencer handoff, enabling comprehensive observability of the OP Stack ingress path.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
