### PR TITLE
beacon/engine,eth/catalyst: Fix engine API checks and exec payload creation

### DIFF
--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -359,8 +359,13 @@ func BlockToExecutableData(block *types.Block, fees *big.Int, sidecars []*types.
 		BlobGasUsed:      block.BlobGasUsed(),
 		ExcessBlobGas:    block.ExcessBlobGas(),
 		ExecutionWitness: block.ExecutionWitness(),
-		// OP-Stack addition: withdrawals list alone does not express the withdrawals storage-root.
-		WithdrawalsRoot: block.WithdrawalsRoot(),
+	}
+
+	// OP-Stack: only Isthmus execution payloads must set the withdrawals root.
+	// They are guaranteed to not be the empty withdrawals hash, which is set pre-Isthmus (post-Canyon).
+	if wr := block.WithdrawalsRoot(); wr != nil && *wr != types.EmptyWithdrawalsHash {
+		wr := *wr
+		data.WithdrawalsRoot = &wr
 	}
 
 	// Add blobs.


### PR DESCRIPTION
**Description**

https://github.com/ethereum-optimism/op-geth/pull/592 centralized OP Stack-specific engine API checks. While doing so, it introduced a few new checks, and a few errors. The checks where also wrong and incomplete before, just in a different way.

This PR fixes the wrong checks and also fixes a bug in payload creation, where the withdrawals root was set pre-Isthmus.

**Tests**

The corresponding monorepo PR (https://github.com/ethereum-optimism/optimism/pull/17154) also fixes the payload attributes conversion error and tests that were previously failing when just updating the op-geth dependency are succeeding.

**Additional context**

This was found during the ongoing upstream merge, where unrelated tests were failing in the monorepo because we hadn't updated the monorepo after merging #592.
