### PR TITLE
ci: Update forkdiff version to v0.1.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
           name: Build forkdiff
           command: |
             docker run --volume $(pwd):/workspace \
-              protolambda/forkdiff:0.1.0 \
+              protolambda/forkdiff:0.1.1 \
               -repo=/workspace \
               -fork=/workspace/fork.yaml \
               -out=/workspace/index.html


### PR DESCRIPTION

**Description**

Update forkdiff version in CI so we get an updated version of https://op-geth.optimism.io/ with [file name and patch filter](https://github.com/protolambda/forkdiff/pull/7).
