### PR TITLE
sync-superchain: Handle case where skipped genesis file doesn't exist

### DIFF
--- a/sync-superchain.sh
+++ b/sync-superchain.sh
@@ -60,7 +60,7 @@ process_network_dir() {
         then
             echo "Skipping $network_name/$chain_name ($chain_id)"
             rm "$toml_file"
-            rm "genesis/$network_name/$chain_name.json.zst"
+            rm -f "genesis/$network_name/$chain_name.json.zst"
             continue
         fi
 


### PR DESCRIPTION
**Description**

Modify the sync-superchain.sh script to not error if a non-standard genesis file isn't actually available when trying to delete it.

Makes it possible to check kona prestates by converting the superchain-registry at a particular commit to the geth format. The celo genesis hasn't always been present so was causing conversion to fail.  While not ideal to use the latest conversion script from op-geth to convert an arbitrary superchain-registry commit, it seems far less brittle than attempting to parse the custom JSON kona converts the superchain-registry content to and be able to compare that with the go version accurately.

If the registry or this script changes in an incompatible way in the future, we may have to manually check compatibility of older kona-prestates or adjust the check-prestates tool to handle it, which isn't a big deal. We generally only need to check relatively recent prestates as well and worst case we could just tag a new kona release with an updated superchain-registry.