### PR TITLE
core: Log DA usage estimates

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -115,9 +115,7 @@ var (
 	errInvalidNewChain      = errors.New("invalid new chain")
 )
 
-var (
-	forkReadyInterval = 3 * time.Minute
-)
+var forkReadyInterval = 3 * time.Minute
 
 const (
 	bodyCacheLimit     = 256
@@ -2053,6 +2051,14 @@ func (bc *BlockChain) processBlock(parentRoot common.Hash, block *types.Block, s
 	}
 	ptime := time.Since(pstart)
 
+	// OP-Stack: DA usage logging
+	if res.EstDAUsage > 0 {
+		log.Info("Block processed with OP-Stack DA usage estimate",
+			"number", block.Number(), "hash", block.Hash(),
+			"da_usage", res.EstDAUsage, "tx_count", len(block.Transactions()),
+		)
+	}
+
 	vstart := time.Now()
 	if err := bc.validator.ValidateState(block, statedb, res, false); err != nil {
 		bc.reportBlock(block, res, err)
@@ -2153,7 +2159,7 @@ func (bc *BlockChain) processBlock(parentRoot common.Hash, block *types.Block, s
 // switch over to the new chain if the TD exceeded the current chain.
 // insertSideChain is only used pre-merge.
 func (bc *BlockChain) insertSideChain(block *types.Block, it *insertIterator, makeWitness bool) (*stateless.Witness, int, error) {
-	var current = bc.CurrentBlock()
+	current := bc.CurrentBlock()
 
 	// The first sidechain block error is already verified to be ErrPrunedAncestor.
 	// Since we don't import them here, we expect ErrUnknownAncestor for the remaining

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -63,6 +63,9 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 		blockNumber = block.Number()
 		allLogs     []*types.Log
 		gp          = new(GasPool).AddGas(block.GasLimit())
+
+		// OP-Stack: DA usage logging
+		estDAUsage uint64
 	)
 
 	// Mutate the block and state according to any hard-fork specs
@@ -103,6 +106,10 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 		}
 		receipts = append(receipts, receipt)
 		allLogs = append(allLogs, receipt.Logs...)
+
+		if tx.Type() != types.DepositTxType {
+			estDAUsage += tx.RollupCostData().EstimatedDASize().Uint64()
+		}
 	}
 
 	isIsthmus := p.config.IsIsthmus(block.Time())
@@ -137,6 +144,8 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 		Requests: requests,
 		Logs:     allLogs,
 		GasUsed:  *usedGas,
+
+		EstDAUsage: estDAUsage,
 	}, nil
 }
 

--- a/core/types.go
+++ b/core/types.go
@@ -57,4 +57,7 @@ type ProcessResult struct {
 	Requests [][]byte
 	Logs     []*types.Log
 	GasUsed  uint64
+
+	// OP-Stack: DA usage logging
+	EstDAUsage uint64
 }


### PR DESCRIPTION

**Description**

Adds logging of DA usage for each processed block. Only used to debug the DA footprint analysis, not intended to be merged.