### PR TITLE
all: Introduce feature toggles for Jovian

### DIFF
--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -60,7 +60,7 @@ type PayloadAttributes struct {
 	// and contains encoded EIP-1559 parameters. See:
 	// https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/holocene/exec-engine.md#eip1559params-encoding
 	EIP1559Params []byte `json:"eip1559Params,omitempty" gencodec:"optional"`
-	// MinBaseFee is a field for rollups implementing the Jovian upgrade's minimum base fee feature.
+	// MinBaseFee is a field for rollups implementing the minimum base fee feature.
 	// See https://github.com/ethereum-optimism/specs/blob/main/specs/protocol/jovian/exec-engine.md#minimum-base-fee-in-payloadattributesv3
 	MinBaseFee *uint64 `json:"minBaseFee,omitempty" gencodec:"optional"`
 }

--- a/eth/catalyst/api_optimism_test.go
+++ b/eth/catalyst/api_optimism_test.go
@@ -162,7 +162,7 @@ func TestCheckOptimismPayload(t *testing.T) {
 				ExtraData: validExtraData,
 			},
 			cfg:      postJovian(),
-			expected: errors.New("jovian extraData should be 17 bytes, got 9"),
+			expected: errors.New("MinBaseFee extraData should be 17 bytes, got 9"),
 		},
 	}
 

--- a/miner/payload_building_test.go
+++ b/miner/payload_building_test.go
@@ -243,7 +243,7 @@ func testBuildPayload(t *testing.T, noTxPool, interrupt bool, params1559 []byte,
 	db := rawdb.NewMemoryDatabase()
 
 	var minBaseFee *uint64
-	if config.IsOptimismJovian(testTimestamp) {
+	if config.IsMinBaseFee(testTimestamp) {
 		val := uint64(1e9)
 		minBaseFee = &val
 	}
@@ -301,8 +301,8 @@ func testBuildPayload(t *testing.T, noTxPool, interrupt bool, params1559 []byte,
 	var expected []byte
 	if len(params1559) != 0 {
 		versionByte := eip1559.HoloceneExtraDataVersionByte
-		if config.IsOptimismJovian(testTimestamp) {
-			versionByte = eip1559.JovianExtraDataVersionByte
+		if config.IsMinBaseFee(testTimestamp) {
+			versionByte = eip1559.MinBaseFeeExtraDataVersionByte
 		}
 		expected = []byte{versionByte}
 
@@ -312,7 +312,7 @@ func testBuildPayload(t *testing.T, noTxPool, interrupt bool, params1559 []byte,
 		} else {
 			expected = append(expected, params1559...)
 		}
-		if versionByte == eip1559.JovianExtraDataVersionByte {
+		if versionByte == eip1559.MinBaseFeeExtraDataVersionByte {
 			buf := make([]byte, 8)
 			binary.BigEndian.PutUint64(buf, *minBaseFee)
 			expected = append(expected, buf...)
@@ -426,14 +426,14 @@ func TestBuildPayloadInvalidHoloceneParams(t *testing.T) {
 	}
 }
 
-func TestBuildPayloadInvalidJovianExtraData(t *testing.T) {
+func TestBuildPayloadInvalidMinBaseFeeExtraData(t *testing.T) {
 	t.Parallel()
 	db := rawdb.NewMemoryDatabase()
 	config := jovianConfig()
 	w, b := newTestWorker(t, config, ethash.NewFaker(), db, 0)
 
 	// 0 denominators shouldn't be allowed
-	badParams := eip1559.EncodeJovianExtraData(0, 6, 0)
+	badParams := eip1559.EncodeMinBaseFeeExtraData(0, 6, 0)
 
 	args := newPayloadArgs(b.chain.CurrentBlock().Hash(), badParams, &zero)
 	payload, err := w.buildPayload(args, false)

--- a/params/optimism_feature_toggles.go
+++ b/params/optimism_feature_toggles.go
@@ -9,5 +9,5 @@ func (c *ChainConfig) IsMinBaseFee(time uint64) bool {
 }
 
 func (c *ChainConfig) IsDAFootprintBlockLimit(time uint64) bool {
-	return c.IsMinBaseFee(time) // Replace with return false to disable
+	return c.IsJovian(time) // Replace with return false to disable
 }

--- a/params/optimism_feature_toggles.go
+++ b/params/optimism_feature_toggles.go
@@ -11,3 +11,7 @@ func (c *ChainConfig) IsMinBaseFee(time uint64) bool {
 func (c *ChainConfig) IsDAFootprintBlockLimit(time uint64) bool {
 	return c.IsJovian(time) // Replace with return false to disable
 }
+
+func (c *ChainConfig) IsOperatorFeeFix(time uint64) bool {
+	return c.IsJovian(time) // Replace with return false to disable
+}

--- a/params/optimism_feature_toggles.go
+++ b/params/optimism_feature_toggles.go
@@ -1,0 +1,13 @@
+package params
+
+// OPStack diff
+// This file contains ephemeral feature toggles which should be removed
+// after the fork scope is locked.
+
+func (c *ChainConfig) IsMinBaseFee(time uint64) bool {
+	return c.IsJovian(time) // Replace with return false to disable
+}
+
+func (c *ChainConfig) IsDAFootprintBlockLimit(time uint64) bool {
+	return c.IsMinBaseFee(time) // Replace with return false to disable
+}


### PR DESCRIPTION
Allows feature to be easily removed from Jovian hardfork. When the hardfork scope is locked, this commit can be reverted.

Pairs with https://github.com/ethereum-optimism/optimism/pull/17424