### PR TITLE
eth/downloader: Fix deposit receipt correction

### DIFF
--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -75,7 +75,7 @@ func newTesterWithNotification(t *testing.T, success func()) *downloadTester {
 		chain: chain,
 		peers: make(map[string]*downloadTesterPeer),
 	}
-	tester.downloader = New(db, new(event.TypeMux), tester.chain, tester.dropPeer, success, 0)
+	tester.downloader = New(db, new(event.TypeMux), tester.chain, tester.dropPeer, success)
 	return tester
 }
 

--- a/eth/downloader/receiptreference.go
+++ b/eth/downloader/receiptreference.go
@@ -28,16 +28,16 @@ var (
 	systemAddress        = common.HexToAddress("0xDeaDDEaDDeAdDeAdDEAdDEaddeAddEAdDEAd0001")
 	receiptReferencePath = "userDepositData"
 	//go:embed userDepositData/*.gob
-	receiptReference                 embed.FS
-	userDepositNoncesAlreadySearched = map[uint64]bool{}
-	userDepositNoncesReference       = map[uint64]userDepositNonces{}
+	receiptReference             embed.FS
+	userDepositNoncesInitialized = map[uint64]bool{}
+	userDepositNoncesReference   = map[uint64]userDepositNonces{}
 )
 
 // lazy load the reference data for the requested chain
 // if this chain data was already requested, returns early
 func initReceiptReferences(chainID uint64) {
 	// if already loaded, return
-	if userDepositNoncesAlreadySearched[chainID] {
+	if userDepositNoncesInitialized[chainID] {
 		return
 	}
 	// look for a file prefixed by the chainID
@@ -48,7 +48,7 @@ func initReceiptReferences(chainID uint64) {
 		return
 	}
 	// mark as loaded so we don't try again, even if no files match
-	userDepositNoncesAlreadySearched[chainID] = true
+	userDepositNoncesInitialized[chainID] = true
 	for _, file := range files {
 		// skip files which don't match the prefix
 		if !strings.HasPrefix(file.Name(), fPrefix) {
@@ -67,8 +67,11 @@ func initReceiptReferences(chainID uint64) {
 			continue
 		}
 		userDepositNoncesReference[udns.ChainID] = udns
+		log.Info("Receipt Correction: Reference data initialized", "file", fpath,
+			"chainID", chainID, "count", len(udns.Results), "first", udns.First, "last", udns.Last)
 		return
 	}
+	log.Info("Receipt Correction: No reference data for chain", "chainID", chainID)
 }
 
 // correctReceipts corrects the deposit nonce in the receipts using the reference data
@@ -77,13 +80,19 @@ func initReceiptReferences(chainID uint64) {
 // This function inspects transaction data for user deposits, and if it is found to be incorrect, it is corrected.
 // The data used to correct the deposit nonce is stored in the userDepositData directory,
 // and was generated with the receipt reference tool in the optimism monorepo.
-func correctReceipts(receipts types.Receipts, transactions types.Transactions, blockNumber uint64, chainID uint64) types.Receipts {
+func correctReceipts(receiptsRLP rlp.RawValue, transactions types.Transactions, blockNumber uint64, chainIDBig *big.Int) rlp.RawValue {
+	if chainIDBig == nil || !chainIDBig.IsUint64() {
+		// Known chains that need receipt correction have uint64 chain IDs
+		return receiptsRLP
+	}
+	chainID := chainIDBig.Uint64()
 	initReceiptReferences(chainID)
+
 	// if there is no data even after initialization, return the receipts as is
 	depositNoncesForChain, ok := userDepositNoncesReference[chainID]
 	if !ok {
 		log.Trace("Receipt Correction: No data source for chain", "chainID", chainID)
-		return receipts
+		return receiptsRLP
 	}
 
 	// check that the block number being examined is within the range of the reference data
@@ -92,35 +101,35 @@ func correctReceipts(receipts types.Receipts, transactions types.Transactions, b
 			"blockNumber", blockNumber,
 			"start", depositNoncesForChain.First,
 			"end", depositNoncesForChain.Last)
-		return receipts
+		return receiptsRLP
 	}
 
 	// get the block nonces
 	blockNonces, ok := depositNoncesForChain.Results[blockNumber]
 	if !ok {
 		log.Trace("Receipt Correction: Block does not contain user deposits", "blockNumber", blockNumber)
-		return receipts
+		return receiptsRLP
 	}
 
-	signer := types.LatestSignerForChainID(big.NewInt(int64(chainID)))
+	// Decode RLP receipts to Receipt structs
+	var receipts []*types.ReceiptForStorage
+	if err := rlp.DecodeBytes(receiptsRLP, &receipts); err != nil {
+		log.Warn("Receipt Correction: Failed to decode RLP receipts", "err", err)
+		return receiptsRLP
+	}
+
 	// iterate through the receipts and transactions to correct the deposit nonce
 	// user deposits should always be at the front of the block, but we will check all transactions to be sure
 	udCount := 0
-	for i := 0; i < len(receipts); i++ {
-		r := receipts[i]
+	for i, r := range receipts {
+		tx := transactions[i]
 		// break as soon as a non deposit is found
-		if r.Type != types.DepositTxType {
+		if tx.Type() != types.DepositTxType {
 			break
 		}
 
-		tx := transactions[i]
-		from, err := types.Sender(signer, tx)
-		if err != nil {
-			log.Warn("Receipt Correction: Failed to determine sender", "err", err)
-			continue
-		}
 		// ignore any transactions from the system address
-		if from != systemAddress {
+		if from := tx.From(); from != systemAddress {
 			// prevent index out of range (indicates a problem with the reference data or the block data)
 			if udCount >= len(blockNonces) {
 				log.Warn("Receipt Correction: More user deposits in block than included in reference data", "in_reference", len(blockNonces))
@@ -128,12 +137,12 @@ func correctReceipts(receipts types.Receipts, transactions types.Transactions, b
 			}
 			nonce := blockNonces[udCount]
 			udCount++
-			log.Trace("Receipt Correction: User Deposit detected", "address", from, "nonce", nonce)
+			log.Trace("Receipt Correction: User Deposit detected", "from", from, "nonce", nonce)
 			if nonce != *r.DepositNonce {
 				// correct the deposit nonce
 				// warn because this should not happen unless the data was modified by corruption or a malicious peer
 				// by correcting the nonce, the entire block is still valid for use
-				log.Warn("Receipt Correction: Corrected deposit nonce", "nonce", *r.DepositNonce, "corrected", nonce)
+				log.Warn("Receipt Correction: Corrected deposit nonce", "from", from, "nonce", *r.DepositNonce, "corrected", nonce)
 				r.DepositNonce = &nonce
 			}
 		}
@@ -144,29 +153,12 @@ func correctReceipts(receipts types.Receipts, transactions types.Transactions, b
 	}
 
 	log.Trace("Receipt Correction: Completed", "blockNumber", blockNumber, "userDeposits", udCount, "receipts", len(receipts), "transactions", len(transactions))
-	return receipts
-}
-
-// correctReceiptsRLP corrects the deposit nonce in the receipts using the reference data
-// This function works with RLP encoded receipts, decoding them to Receipt structs,
-// applying corrections, and re-encoding them back to RLP.
-func correctReceiptsRLP(receiptsRLP rlp.RawValue, transactions types.Transactions, blockNumber uint64, chainID uint64) rlp.RawValue {
-	// Decode RLP receipts to Receipt structs
-	var receipts types.Receipts
-	if err := rlp.DecodeBytes(receiptsRLP, &receipts); err != nil {
-		log.Warn("Receipt Correction: Failed to decode RLP receipts", "err", err)
-		return receiptsRLP
-	}
-
-	// Apply corrections using existing correctReceipts function
-	correctedReceipts := correctReceipts(receipts, transactions, blockNumber, chainID)
 
 	// Re-encode to RLP
-	encoded, err := rlp.EncodeToBytes(correctedReceipts)
+	encoded, err := rlp.EncodeToBytes(receipts)
 	if err != nil {
 		log.Warn("Receipt Correction: Failed to encode corrected receipts to RLP", "err", err)
 		return receiptsRLP
 	}
-
 	return encoded
 }

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -195,14 +195,8 @@ func newHandler(config *handlerConfig) (*handler, error) {
 	if h.snapSync.Load() && (config.Chain.Snapshots() == nil && config.Chain.TrieDB().Scheme() == rawdb.HashScheme) {
 		return nil, errors.New("snap sync not supported with snapshots disabled")
 	}
-	// if the chainID is set, pass it to the downloader for use in sync
-	// this might not be set in tests
-	var chainID uint64
-	if cid := h.chain.Config().ChainID; cid != nil {
-		chainID = cid.Uint64()
-	}
 	// Construct the downloader (long sync)
-	h.downloader = downloader.New(config.Database, h.eventMux, h.chain, h.removePeer, h.enableSyncedFeatures, chainID)
+	h.downloader = downloader.New(config.Database, h.eventMux, h.chain, h.removePeer, h.enableSyncedFeatures)
 
 	fetchTx := func(peer string, hashes []common.Hash) error {
 		p := h.peers.peer(peer)


### PR DESCRIPTION
**Description**

Deposit receipt correction got broken in a previous upstream merge (#638 #652) because upstream changed the way receipts are transferred during snap sync. They are now sent directly in their storage RLP. The upstream merge attempted to decode receipts into the `types.Receipts` slice, but because these are storage receipts, the bloom field is missing, so the `[]*types.ReceiptForStorage` type has to be used.

The receipt correction also got vastly optimized by only rlp-decoding if correction is actually necessary, which is almost never.

This PR also reduces the diff to upstream by removing unnecessary passing around and storage of the chain ID (it can be retrieved from the chain config).

**Tests**

Existing test got adapted. There was previously a copy-pasted test for the rlp and non-rlp version.

Also ran an internal snap-sync test, confirming that the warning logs are gone.

**Metadata**

Should fix https://github.com/ethereum-optimism/op-geth/issues/679
