### PR TITLE
Remove approval hold job from release workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,13 +236,6 @@ workflows:
           name: Check superchain registry bundle diff
   release:
     jobs:
-      - hold:
-          type: approval
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
       - docker-release:
           name: Push to Docker (release)
           filters:
@@ -254,8 +247,6 @@ workflows:
           push_tags: true
           context:
             - oplabs-gcr-release
-          requires:
-            - hold
 
   merge:
     jobs:


### PR DESCRIPTION
Removed approval hold job from release process in CircleCI config.

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

This pull request makes a small update to the CircleCI workflow configuration by removing the manual approval step before the Docker release job in the `release` workflow.

* Removed the `hold` approval job from the `release` workflow, allowing the `docker-release` job to run automatically without requiring manual intervention. [[1]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L239-L245) [[2]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L257-L258)

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
