### PR TITLE
all: Store DA footprint in blob gas used header field

### DIFF
--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -410,6 +410,16 @@ func (beacon *Beacon) FinalizeAndAssemble(chain consensus.ChainHeaderReader, hea
 		}
 	}
 
+	// Store DA footprint in BlobGasUsed header field if it hasn't already been set yet.
+	// Builder code may already calculate it during block building to avoid recalculating it here.
+	if chain.Config().IsDAFootprintBlockLimit(header.Time) && (header.BlobGasUsed == nil || *header.BlobGasUsed == 0) {
+		daFootprint, err := types.CalcDAFootprint(body.Transactions)
+		if err != nil {
+			return nil, fmt.Errorf("error calculating DA footprint: %w", err)
+		}
+		header.BlobGasUsed = &daFootprint
+	}
+
 	// Assemble the final block.
 	block := types.NewBlock(header, body, receipts, trie.NewStackTrie(nil), chain.Config())
 

--- a/consensus/misc/eip1559/eip1559_test.go
+++ b/consensus/misc/eip1559/eip1559_test.go
@@ -57,17 +57,19 @@ func config() *params.ChainConfig {
 	return config
 }
 
-var TestCanyonTime = uint64(10)
-var TestHoloceneTime = uint64(12)
-var TestJovianTime = uint64(14)
+var (
+	testCanyonTime   = uint64(10)
+	testHoloceneTime = uint64(12)
+	testJovianTime   = uint64(14)
+)
 
 func opConfig() *params.ChainConfig {
 	config := copyConfig(params.TestChainConfig)
 	config.LondonBlock = big.NewInt(5)
 	eip1559DenominatorCanyon := uint64(250)
-	config.CanyonTime = &TestCanyonTime
-	config.HoloceneTime = &TestHoloceneTime
-	config.JovianTime = &TestJovianTime
+	config.CanyonTime = &testCanyonTime
+	config.HoloceneTime = &testHoloceneTime
+	config.JovianTime = &testJovianTime
 	config.Optimism = &params.OptimismConfig{
 		EIP1559Elasticity:        6,
 		EIP1559Denominator:       50,
@@ -227,59 +229,74 @@ func TestCalcBaseFeeOptimismHolocene(t *testing.T) {
 // TestCalcBaseFeeJovian tests that the minimum base fee is enforced
 // when the computed base fee is less than the minimum base fee,
 // if the feature is active and not enforced otherwise.
+// It also tests that the base fee udpate will take the DA footprint as stored
+// in the blob gas used field into account if it is larger than the gas used
+// field.
 func TestCalcBaseFeeJovian(t *testing.T) {
 	parentGasLimit := uint64(30_000_000)
 	denom := uint64(50)
 	elasticity := uint64(3)
+	parentGasTarget := parentGasLimit / elasticity
+	const zeroParentBlobGasUsed = 0
 
-	preJovian := TestJovianTime - 1
-	postJovian := TestJovianTime
+	preJovian := testJovianTime - 1
+	postJovian := testJovianTime
 
 	tests := []struct {
-		parentBaseFee   int64
-		parentGasUsed   uint64
-		parentTime      uint64
-		minBaseFee      uint64
-		expectedBaseFee uint64
+		parentBaseFee     int64
+		parentGasUsed     uint64
+		parentBlobGasUsed uint64
+		parentTime        uint64
+		minBaseFee        uint64
+		expectedBaseFee   uint64
 	}{
 		// Test 0: gas used is below target, and the new calculated base fee is very low.
 		// But since we are pre Jovian, we don't enforce the minBaseFee.
-		{1, parentGasLimit/elasticity - 1_000_000, preJovian, 1e9, 1},
+		{1, parentGasTarget - 1_000_000, zeroParentBlobGasUsed, preJovian, 1e9, 1},
 		// Test 1: gas used is exactly the target gas, but the base fee is set too low so
 		// the base fee is expected to be the minBaseFee
-		{1, parentGasLimit / elasticity, postJovian, 1e9, 1e9},
+		{1, parentGasTarget, zeroParentBlobGasUsed, postJovian, 1e9, 1e9},
 		// Test 2: gas used exceeds gas target, but the new calculated base fee is still
 		// too low so the base fee is expected to be the minBaseFee
-		{1, parentGasLimit/elasticity + 1_000_000, postJovian, 1e9, 1e9},
+		{1, parentGasTarget + 1_000_000, zeroParentBlobGasUsed, postJovian, 1e9, 1e9},
 		// Test 3: gas used exceeds gas target, but the new calculated base fee is higher
 		// than the minBaseFee, so don't enforce minBaseFee. See the calculation below:
 		// gasUsedDelta = gasUsed - parentGasTarget = 20_000_000 - 30_000_000 / 3 = 10_000_000
 		// 2e9 * 10_000_000 / 10_000_000 / 50 = 40_000_000
 		// 2e9 + 40_000_000 = 2_040_000_000, which is greater than minBaseFee
-		{2e9, parentGasLimit/elasticity + 10_000_000, postJovian, 1e9, 2_040_000_000},
+		{2e9, parentGasTarget + 10_000_000, zeroParentBlobGasUsed, postJovian, 1e9, 2_040_000_000},
 		// Test 4: gas used is below target, but the new calculated base fee is still
 		// too low so the base fee is expected to be the minBaseFee
-		{1, parentGasLimit/elasticity - 1_000_000, postJovian, 1e9, 1e9},
+		{1, parentGasTarget - 1_000_000, zeroParentBlobGasUsed, postJovian, 1e9, 1e9},
 		// Test 5: gas used is below target, and the new calculated base fee is higher
 		// than the minBaseFee, so don't enforce minBaseFee. See the calculation below:
 		// gasUsedDelta = gasUsed - parentGasTarget = 9_000_000 - 30_000_000 / 3 = -1_000_000
 		// 2_097_152 * -1_000_000 / 10_000_000 / 50 = -4194.304
 		// 2_097_152 - 4194.304 = 2_092_957.696, which is greater than minBaseFee
-		{2_097_152, parentGasLimit/elasticity - 1_000_000, postJovian, 2e6, 2_092_958},
+		{2_097_152, parentGasTarget - 1_000_000, zeroParentBlobGasUsed, postJovian, 2e6, 2_092_958},
 		// Test 6: parent base fee already at minimum, below target => no change
-		{1e4, parentGasLimit/elasticity - 1, postJovian, 1e4, 1e4},
+		{1e4, parentGasTarget - 1, zeroParentBlobGasUsed, postJovian, 1e4, 1e4},
 		// Test 7: parent base fee already at minimum, above target => small increase as usual
-		{1e4, parentGasLimit/elasticity + 1, postJovian, 1e4, 1e4 + 1},
+		{1e4, parentGasTarget + 1, zeroParentBlobGasUsed, postJovian, 1e4, 1e4 + 1},
+
+		// Test 8: Pre-Jovian: parent base fee already at minimum, gas used at target, blob gas used at limit
+		// => no increase, minBaseFee ignored, high blob gas used ignored
+		{1e4, parentGasTarget, parentGasLimit, preJovian, 1e6, 1e4},
+		// Test 9: parent base fee already at minimum, gas used at target, da footprint above target => small increase
+		{1e4, parentGasTarget, parentGasTarget + 1, postJovian, 1e4, 1e4 + 1},
+		// Test 10: Test 3, but with high blob gas used instead of gas used
+		{2e9, parentGasTarget, parentGasTarget + 10_000_000, postJovian, 1e9, 2_040_000_000},
 	}
 	for i, test := range tests {
 		testName := fmt.Sprintf("test %d", i)
 		t.Run(testName, func(t *testing.T) {
 			parent := &types.Header{
-				Number:   common.Big32,
-				GasLimit: parentGasLimit,
-				GasUsed:  test.parentGasUsed,
-				BaseFee:  big.NewInt(test.parentBaseFee),
-				Time:     test.parentTime,
+				Number:      common.Big32,
+				GasLimit:    parentGasLimit,
+				GasUsed:     test.parentGasUsed,
+				BlobGasUsed: &test.parentBlobGasUsed,
+				BaseFee:     big.NewInt(test.parentBaseFee),
+				Time:        test.parentTime,
 			}
 			parent.Extra = EncodeOptimismExtraData(opConfig(), test.parentTime, denom, elasticity, &test.minBaseFee)
 			have, want := CalcBaseFee(opConfig(), parent, parent.Time+2), big.NewInt(int64(test.expectedBaseFee))

--- a/consensus/misc/eip4844/eip4844.go
+++ b/consensus/misc/eip4844/eip4844.go
@@ -110,12 +110,16 @@ func VerifyEIP4844Header(config *params.ChainConfig, parent, header *types.Heade
 		return errors.New("header is missing blobGasUsed")
 	}
 
-	// Verify that the blob gas used remains within reasonable limits.
-	if !config.IsOptimism() && *header.BlobGasUsed > bcfg.maxBlobGas() {
-		return fmt.Errorf("blob gas used %d exceeds maximum allowance %d", *header.BlobGasUsed, bcfg.maxBlobGas())
-	}
-	if *header.BlobGasUsed%params.BlobTxBlobGasPerBlob != 0 {
-		return fmt.Errorf("blob gas used %d not a multiple of blob gas per blob %d", header.BlobGasUsed, params.BlobTxBlobGasPerBlob)
+	// OP Stack sets a zero blobGasUsed pre-Jovian. Post-Jovian, it stores the DA footprint, which is
+	// probably not a multiple of [params.BlobTxBlobGasPerBlob].
+	if !config.IsOptimism() {
+		// Verify that the blob gas used remains within reasonable limits.
+		if *header.BlobGasUsed > bcfg.maxBlobGas() {
+			return fmt.Errorf("blob gas used %d exceeds maximum allowance %d", *header.BlobGasUsed, bcfg.maxBlobGas())
+		}
+		if *header.BlobGasUsed%params.BlobTxBlobGasPerBlob != 0 {
+			return fmt.Errorf("blob gas used %d not a multiple of blob gas per blob %d", header.BlobGasUsed, params.BlobTxBlobGasPerBlob)
+		}
 	}
 
 	// Verify the excessBlobGas is correct based on the parent header

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -421,14 +421,6 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 			b.header.RequestsHash = &reqHash
 		}
 
-		if config.IsDAFootprintBlockLimit(b.header.Time) {
-			gasUsed, err := types.CalcGasUsedJovian(b.txs, b.header.GasUsed)
-			if err != nil {
-				panic(err)
-			}
-			b.header.GasUsed = gasUsed
-		}
-
 		body := types.Body{Transactions: b.txs, Uncles: b.uncles, Withdrawals: b.withdrawals}
 		block, err := b.engine.FinalizeAndAssemble(cm, b.header, statedb, &body, b.receipts)
 		if err != nil {

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -129,14 +129,6 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 		requests = [][]byte{}
 	}
 
-	if p.config.IsDAFootprintBlockLimit(block.Time()) {
-		gasUsed, err := types.CalcGasUsedJovian(block.Transactions(), *usedGas)
-		if err != nil {
-			return nil, fmt.Errorf("failed to calculate Jovian gas used: %w", err)
-		}
-		*usedGas = gasUsed
-	}
-
 	// Finalize the block, applying any consensus engine specific extras (e.g. block rewards)
 	p.chain.engine.Finalize(p.chain, header, tracingStateDB, block.Body())
 

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -96,6 +96,7 @@ type Header struct {
 	WithdrawalsHash *common.Hash `json:"withdrawalsRoot" rlp:"optional"`
 
 	// BlobGasUsed was added by EIP-4844 and is ignored in legacy headers.
+	// OP Stack stores the DA footprint in this field starting with the Jovian fork.
 	BlobGasUsed *uint64 `json:"blobGasUsed" rlp:"optional"`
 
 	// ExcessBlobGas was added by EIP-4844 and is ignored in legacy headers.

--- a/miner/miner_optimism_test.go
+++ b/miner/miner_optimism_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/consensus/beacon"
 	"github.com/ethereum/go-ethereum/consensus/ethash"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
+	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
@@ -21,15 +22,16 @@ const testDAFootprintGasScalar = 400
 // transactions and then imports the block into the chain, asserting that
 // execution succeeds.
 func TestDAFootprintMining(t *testing.T) {
-	requireTxGas := func(t *testing.T, block *types.Block, receipts []*types.Receipt) {
+	requirePreJovianBehavior := func(t *testing.T, block *types.Block, receipts []*types.Receipt) {
 		var txGas uint64
 		for _, receipt := range receipts {
 			txGas += receipt.GasUsed
 		}
 		require.Equal(t, txGas, block.GasUsed(), "total tx gas used should be equal to block gas used")
+		require.Zero(t, *block.Header().BlobGasUsed, "expected 0 blob gas used")
 	}
 
-	requireDAFootprint := func(t *testing.T, block *types.Block, receipts []*types.Receipt) {
+	requireLargeDAFootprintBehavior := func(t *testing.T, block *types.Block, receipts []*types.Receipt) {
 		var (
 			txGas       uint64
 			daFootprint uint64
@@ -45,30 +47,56 @@ func TestDAFootprintMining(t *testing.T) {
 			}
 			daFootprint += txs[i].RollupCostData().EstimatedDASize().Uint64() * testDAFootprintGasScalar
 		}
-		require.Less(t, txGas, block.GasUsed(), "total tx gas used must be smaller than block gas used")
-		require.Equal(t, daFootprint, block.GasUsed(), "total DA footprint used should be equal to block gas used")
+		require.Equal(t, txGas, block.GasUsed(), "total tx gas used should be equal to block gas used")
+		require.Greater(t, daFootprint, block.GasUsed(), "total DA footprint used should be greater than block gas used")
+		require.LessOrEqual(t, daFootprint, block.GasLimit(), "total DA footprint used should be less or equal block gas limit")
 	}
+	t.Run("jovian-one-min-tx", func(t *testing.T) {
+		testMineAndExecute(t, 0, jovianConfig(), func(t *testing.T, _ *core.BlockChain, block *types.Block, receipts []*types.Receipt) {
+			require.Len(t, receipts, 2) // 1 test pending tx and 1 deposit tx
+			requireLargeDAFootprintBehavior(t, block, receipts)
+
+			// Double-confirm DA footprint calculation manually in this simple transaction case.
+			daFootprint, err := types.CalcDAFootprint(block.Transactions())
+			require.NoError(t, err, "failed to calculate DA footprint")
+			require.Equal(t, daFootprint, *block.Header().BlobGasUsed,
+				"header blob gas used should match calculated DA footprint")
+			require.Equal(t, testDAFootprintGasScalar*types.MinTransactionSize.Uint64(), daFootprint,
+				"simple pending transaction should lead to min DA footprint")
+		})
+	})
 	t.Run("jovian-at-limit", func(t *testing.T) {
-		testMineAndExecute(t, 17, jovianConfig(), func(t *testing.T, block *types.Block, receipts []*types.Receipt) {
+		testMineAndExecute(t, 17, jovianConfig(), func(t *testing.T, _ *core.BlockChain, block *types.Block, receipts []*types.Receipt) {
 			require.Len(t, receipts, 19) // including 1 test pending tx and 1 deposit tx
-			requireDAFootprint(t, block, receipts)
+			requireLargeDAFootprintBehavior(t, block, receipts)
 		})
 	})
 	t.Run("jovian-above-limit", func(t *testing.T) {
-		testMineAndExecute(t, 18, jovianConfig(), func(t *testing.T, block *types.Block, receipts []*types.Receipt) {
+		testMineAndExecute(t, 18, jovianConfig(), func(t *testing.T, _ *core.BlockChain, block *types.Block, receipts []*types.Receipt) {
 			require.Len(t, receipts, 19) // same as for 17, because 18th tx from pool shouldn't have been included
-			requireDAFootprint(t, block, receipts)
+			requireLargeDAFootprintBehavior(t, block, receipts)
 		})
 	})
 	t.Run("isthmus", func(t *testing.T) {
-		testMineAndExecute(t, 39, isthmusConfig(), func(t *testing.T, block *types.Block, receipts []*types.Receipt) {
+		testMineAndExecute(t, 39, isthmusConfig(), func(t *testing.T, _ *core.BlockChain, block *types.Block, receipts []*types.Receipt) {
 			require.Len(t, receipts, 41) // including 1 test pending tx and 1 deposit tx
-			requireTxGas(t, block, receipts)
+			requirePreJovianBehavior(t, block, receipts)
+		})
+	})
+
+	t.Run("jovian-invalid-blobGasUsed", func(t *testing.T) {
+		testMineAndExecute(t, 0, jovianConfig(), func(t *testing.T, bc *core.BlockChain, block *types.Block, receipts []*types.Receipt) {
+			require.Len(t, receipts, 2) // 1 test pending tx and 1 deposit tx
+			header := block.Header()
+			*header.BlobGasUsed += 1 // invalidate blobGasUsed
+			invalidBlock := block.WithSeal(header)
+			_, err := bc.InsertChain(types.Blocks{invalidBlock})
+			require.ErrorContains(t, err, "invalid DA footprint in blobGasUsed field (remote: 40001 local: 40000)")
 		})
 	})
 }
 
-func testMineAndExecute(t *testing.T, numTxs uint64, cfg *params.ChainConfig, assertFn func(t *testing.T, block *types.Block, receipts []*types.Receipt)) {
+func testMineAndExecute(t *testing.T, numTxs uint64, cfg *params.ChainConfig, assertFn func(*testing.T, *core.BlockChain, *types.Block, []*types.Receipt)) {
 	db := rawdb.NewMemoryDatabase()
 	w, b := newTestWorker(t, cfg, beacon.New(ethash.NewFaker()), db, 0)
 
@@ -105,7 +133,7 @@ func testMineAndExecute(t *testing.T, numTxs uint64, cfg *params.ChainConfig, as
 	require.NoError(t, r.err, "block generation failed")
 	require.NotNil(t, r.block, "no block generated")
 
-	assertFn(t, r.block, r.receipts)
+	assertFn(t, b.chain, r.block, r.receipts)
 
 	// Import the block into the chain, which executes it via StateProcessor.
 	_, err := b.chain.InsertChain(types.Blocks{r.block})


### PR DESCRIPTION
**Description**

This PR changes the DA footprint implementation to store the DA footprint in the `blobGasUsed` header field instead of max'd in the `gasUsed` field.

A nice side effect is that the DA footprint can now be updated  in the beacon consensus `FinalizeAndAssemble` function, which is used by chain makers and monorepo block building code.

**Tests**

Existing DA footprint miner test got updated.

**Additional context**

Monorepo PR: https://github.com/ethereum-optimism/optimism/pull/17861

**Metadata**

Fixes https://github.com/ethereum-optimism/op-geth/issues/691
