### PR TITLE
consensus/beacon: Fix OP Legacy header verification dispatch

### DIFF
--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -125,7 +125,7 @@ func (beacon *Beacon) VerifyHeader(chain consensus.ChainHeaderReader, header *ty
 	// Check >0 TDs with pre-merge, --0 TDs with post-merge rules
 	if header.Difficulty.Sign() > 0 ||
 		// OP-Stack: transitioned networks must use legacy consensus pre-Bedrock
-		cfg.IsOptimismBedrock(header.Number) {
+		cfg.IsOptimismPreBedrock(header.Number) {
 		return beacon.ethone.VerifyHeader(chain, header)
 	}
 	return beacon.verifyHeader(chain, header, parent)


### PR DESCRIPTION
**Description**

Fixes header verification to correctly dispatch to OP legacy pseudo consensus only for OP legacy headers.

**Test**

Did a successful snap-sync test of op-mainnet and op-sepolia, which performs full header chain verification.
