### PR TITLE
Use read lock for Content, Pending, ToJournal methods

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -514,7 +514,7 @@ func (pool *LegacyPool) SetIngressFilters(filters []txpool.IngressFilter) {
 // Content retrieves the data content of the transaction pool, returning all the
 // pending as well as queued transactions, grouped by account and sorted by nonce.
 func (pool *LegacyPool) Content() (map[common.Address][]*types.Transaction, map[common.Address][]*types.Transaction) {
-	pool.mu.Lock()
+	pool.mu.RLock()
 	defer pool.mu.Unlock()
 
 	pending := make(map[common.Address][]*types.Transaction, len(pool.pending))
@@ -549,7 +549,7 @@ func (pool *LegacyPool) ContentFrom(addr common.Address) ([]*types.Transaction, 
 //
 // OP-Stack addition.
 func (pool *LegacyPool) ToJournal() map[common.Address]types.Transactions {
-	pool.mu.Lock()
+	pool.mu.RLock()
 	defer pool.mu.Unlock()
 
 	txs := make(map[common.Address]types.Transactions, len(pool.pending)+len(pool.queue))
@@ -577,7 +577,7 @@ func (pool *LegacyPool) Pending(filter txpool.PendingFilter) map[common.Address]
 	if filter.OnlyBlobTxs {
 		return nil
 	}
-	pool.mu.Lock()
+	pool.mu.RLock()
 	defer pool.mu.Unlock()
 
 	pending := make(map[common.Address][]*txpool.LazyTransaction, len(pool.pending))

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -515,7 +515,7 @@ func (pool *LegacyPool) SetIngressFilters(filters []txpool.IngressFilter) {
 // pending as well as queued transactions, grouped by account and sorted by nonce.
 func (pool *LegacyPool) Content() (map[common.Address][]*types.Transaction, map[common.Address][]*types.Transaction) {
 	pool.mu.RLock()
-	defer pool.mu.Unlock()
+	defer pool.mu.RUnlock()
 
 	pending := make(map[common.Address][]*types.Transaction, len(pool.pending))
 	for addr, list := range pool.pending {
@@ -550,7 +550,7 @@ func (pool *LegacyPool) ContentFrom(addr common.Address) ([]*types.Transaction, 
 // OP-Stack addition.
 func (pool *LegacyPool) ToJournal() map[common.Address]types.Transactions {
 	pool.mu.RLock()
-	defer pool.mu.Unlock()
+	defer pool.mu.RUnlock()
 
 	txs := make(map[common.Address]types.Transactions, len(pool.pending)+len(pool.queue))
 	for addr, pending := range pool.pending {
@@ -578,7 +578,7 @@ func (pool *LegacyPool) Pending(filter txpool.PendingFilter) map[common.Address]
 		return nil
 	}
 	pool.mu.RLock()
-	defer pool.mu.Unlock()
+	defer pool.mu.RUnlock()
 
 	pending := make(map[common.Address][]*txpool.LazyTransaction, len(pool.pending))
 	for addr, list := range pool.pending {


### PR DESCRIPTION
**Description**

Changed mutex locking from exclusive to read-only for improved concurrency.

**Additional context**

This is the PR for upstream go-ethereum.
- Fix https://github.com/ethereum/go-ethereum/pull/32927