### PR TITLE
core: add gauge metrics + histograms for block gas used and blob gas used

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -64,7 +64,12 @@ var (
 	headFastBlockGauge      = metrics.NewRegisteredGauge("chain/head/receipt", nil)
 	headFinalizedBlockGauge = metrics.NewRegisteredGauge("chain/head/finalized", nil)
 	headSafeBlockGauge      = metrics.NewRegisteredGauge("chain/head/safe", nil)
-	headBaseFeeGauge        = metrics.NewRegisteredGauge("chain/head/basefee", nil)
+
+	// (BEGIN) OPStack additions
+	headBaseFeeGauge     = metrics.NewRegisteredGauge("chain/head/basefee", nil)
+	headGasUsedGauge     = metrics.NewRegisteredGauge("chain/head/gas_used", nil)
+	headBlobGasUsedGauge = metrics.NewRegisteredGauge("chain/head/blob_gas_used", nil)
+	// (END) OPStack additions
 
 	chainInfoGauge   = metrics.NewRegisteredGaugeInfo("chain/info", nil)
 	chainMgaspsMeter = metrics.NewRegisteredResettingTimer("chain/mgasps", nil)
@@ -1230,7 +1235,11 @@ func (bc *BlockChain) writeHeadBlock(block *types.Block) {
 
 	bc.currentBlock.Store(block.Header())
 	headBlockGauge.Update(int64(block.NumberU64()))
+
+	// OPStack additions
 	headBaseFeeGauge.TryUpdate(block.Header().BaseFee)
+	headGasUsedGauge.Update(int64(block.Header().GasUsed))
+	headBlobGasUsedGauge.TryUpdateUint64(block.Header().BlobGasUsed)
 }
 
 // stopWithoutSaving stops the blockchain service. If any imports are currently in progress
@@ -1398,7 +1407,11 @@ func (bc *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain [
 		bc.currentSnapBlock.Store(header)
 		headHeaderGauge.Update(header.Number.Int64())
 		headFastBlockGauge.Update(header.Number.Int64())
+
+		// OPStack additions
 		headBaseFeeGauge.TryUpdate(header.BaseFee)
+		headGasUsedGauge.Update(int64(header.GasUsed))
+		headBlobGasUsedGauge.TryUpdateUint64(header.BlobGasUsed)
 		return nil
 	}
 	// writeAncient writes blockchain and corresponding receipt chain into ancient store.
@@ -2771,7 +2784,11 @@ func (bc *BlockChain) InsertHeadersBeforeCutoff(headers []*types.Header) (int, e
 	bc.currentSnapBlock.Store(last)
 	headHeaderGauge.Update(last.Number.Int64())
 	headFastBlockGauge.Update(last.Number.Int64())
+
+	// OPStack additions
 	headBaseFeeGauge.TryUpdate(last.BaseFee)
+	headGasUsedGauge.Update(int64(last.GasUsed))
+	headBlobGasUsedGauge.TryUpdateUint64(last.BlobGasUsed)
 	return 0, nil
 }
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -65,12 +65,6 @@ var (
 	headFinalizedBlockGauge = metrics.NewRegisteredGauge("chain/head/finalized", nil)
 	headSafeBlockGauge      = metrics.NewRegisteredGauge("chain/head/safe", nil)
 
-	// (BEGIN) OPStack additions
-	headBaseFeeGauge     = metrics.NewRegisteredGauge("chain/head/basefee", nil)
-	headGasUsedGauge     = metrics.NewRegisteredGauge("chain/head/gas_used", nil)
-	headBlobGasUsedGauge = metrics.NewRegisteredGauge("chain/head/blob_gas_used", nil)
-	// (END) OPStack additions
-
 	chainInfoGauge   = metrics.NewRegisteredGaugeInfo("chain/info", nil)
 	chainMgaspsMeter = metrics.NewRegisteredResettingTimer("chain/mgasps", nil)
 
@@ -1236,10 +1230,8 @@ func (bc *BlockChain) writeHeadBlock(block *types.Block) {
 	bc.currentBlock.Store(block.Header())
 	headBlockGauge.Update(int64(block.NumberU64()))
 
-	// OPStack additions
-	headBaseFeeGauge.TryUpdate(block.Header().BaseFee)
-	headGasUsedGauge.Update(int64(block.Header().GasUsed))
-	headBlobGasUsedGauge.TryUpdateUint64(block.Header().BlobGasUsed)
+	// OPStack addition
+	updateOptimismBlockMetrics(block.Header())
 }
 
 // stopWithoutSaving stops the blockchain service. If any imports are currently in progress
@@ -1408,10 +1400,8 @@ func (bc *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain [
 		headHeaderGauge.Update(header.Number.Int64())
 		headFastBlockGauge.Update(header.Number.Int64())
 
-		// OPStack additions
-		headBaseFeeGauge.TryUpdate(header.BaseFee)
-		headGasUsedGauge.Update(int64(header.GasUsed))
-		headBlobGasUsedGauge.TryUpdateUint64(header.BlobGasUsed)
+		// OPStack addition
+		updateOptimismBlockMetrics(header)
 		return nil
 	}
 	// writeAncient writes blockchain and corresponding receipt chain into ancient store.
@@ -2785,10 +2775,8 @@ func (bc *BlockChain) InsertHeadersBeforeCutoff(headers []*types.Header) (int, e
 	headHeaderGauge.Update(last.Number.Int64())
 	headFastBlockGauge.Update(last.Number.Int64())
 
-	// OPStack additions
-	headBaseFeeGauge.TryUpdate(last.BaseFee)
-	headGasUsedGauge.Update(int64(last.GasUsed))
-	headBlobGasUsedGauge.TryUpdateUint64(last.BlobGasUsed)
+	// OPStack addition
+	updateOptimismBlockMetrics(last)
 	return 0, nil
 }
 

--- a/core/blockchain_optimism.go
+++ b/core/blockchain_optimism.go
@@ -10,11 +10,18 @@ var (
 	headBaseFeeGauge     = metrics.NewRegisteredGauge("chain/head/basefee", nil)
 	headGasUsedGauge     = metrics.NewRegisteredGauge("chain/head/gas_used", nil)
 	headBlobGasUsedGauge = metrics.NewRegisteredGauge("chain/head/blob_gas_used", nil)
+
+	headGasUsedHist     = metrics.NewRegisteredHistogram("chain/head/gas_used_hist", nil, metrics.NewExpDecaySample(1028, 0.015))
+	headBlobGasUsedHist = metrics.NewRegisteredHistogram("chain/head/blob_gas_used_hist", nil, metrics.NewExpDecaySample(1028, 0.015))
 )
 
 func updateOptimismBlockMetrics(header *types.Header) error {
 	headBaseFeeGauge.TryUpdate(header.BaseFee)
 	headGasUsedGauge.Update(int64(header.GasUsed))
 	headBlobGasUsedGauge.TryUpdateUint64(header.BlobGasUsed)
+	headGasUsedHist.Update(int64(header.GasUsed))
+	if header.BlobGasUsed != nil {
+		headBlobGasUsedHist.Update(int64(*header.BlobGasUsed))
+	}
 	return nil
 }

--- a/core/blockchain_optimism.go
+++ b/core/blockchain_optimism.go
@@ -1,0 +1,20 @@
+package core
+
+import (
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/metrics"
+)
+
+// OPStack additions
+var (
+	headBaseFeeGauge     = metrics.NewRegisteredGauge("chain/head/basefee", nil)
+	headGasUsedGauge     = metrics.NewRegisteredGauge("chain/head/gas_used", nil)
+	headBlobGasUsedGauge = metrics.NewRegisteredGauge("chain/head/blob_gas_used", nil)
+)
+
+func updateOptimismBlockMetrics(header *types.Header) error {
+	headBaseFeeGauge.TryUpdate(header.BaseFee)
+	headGasUsedGauge.Update(int64(header.GasUsed))
+	headBlobGasUsedGauge.TryUpdateUint64(header.BlobGasUsed)
+	return nil
+}

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -93,7 +93,7 @@ func NewHeaderChain(chainDb ethdb.Database, config *params.ChainConfig, engine c
 	hc.currentHeaderHash = hc.CurrentHeader().Hash()
 	headHeaderGauge.Update(hc.CurrentHeader().Number.Int64())
 
-	// OPStack additions
+	// OPStack addition
 	updateOptimismBlockMetrics(hc.CurrentHeader())
 	return hc, nil
 }

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -94,9 +94,7 @@ func NewHeaderChain(chainDb ethdb.Database, config *params.ChainConfig, engine c
 	headHeaderGauge.Update(hc.CurrentHeader().Number.Int64())
 
 	// OPStack additions
-	headBaseFeeGauge.TryUpdate(hc.CurrentHeader().BaseFee)
-	headGasUsedGauge.Update(int64(hc.CurrentHeader().GasUsed))
-	headBlobGasUsedGauge.TryUpdateUint64(hc.CurrentHeader().BlobGasUsed)
+	updateOptimismBlockMetrics(hc.CurrentHeader())
 	return hc, nil
 }
 
@@ -188,10 +186,8 @@ func (hc *HeaderChain) Reorg(headers []*types.Header) error {
 	hc.currentHeader.Store(types.CopyHeader(last))
 	headHeaderGauge.Update(last.Number.Int64())
 
-	// OPStack additions
-	headBaseFeeGauge.TryUpdate(last.BaseFee)
-	headGasUsedGauge.Update(int64(last.GasUsed))
-	headBlobGasUsedGauge.TryUpdateUint64(last.BlobGasUsed)
+	// OPStack addition
+	updateOptimismBlockMetrics(last)
 	return nil
 }
 
@@ -495,10 +491,8 @@ func (hc *HeaderChain) SetCurrentHeader(head *types.Header) {
 	hc.currentHeaderHash = head.Hash()
 	headHeaderGauge.Update(head.Number.Int64())
 
-	// OPStack additions
-	headBaseFeeGauge.TryUpdate(head.BaseFee)
-	headGasUsedGauge.Update(int64(head.GasUsed))
-	headBlobGasUsedGauge.TryUpdateUint64(head.BlobGasUsed)
+	// OPStack addition
+	updateOptimismBlockMetrics(head)
 }
 
 type (
@@ -586,10 +580,8 @@ func (hc *HeaderChain) setHead(headBlock uint64, headTime uint64, updateFn Updat
 		hc.currentHeaderHash = parentHash
 		headHeaderGauge.Update(parent.Number.Int64())
 
-		// OPStack additions
-		headBaseFeeGauge.TryUpdate(parent.BaseFee)
-		headGasUsedGauge.Update(int64(parent.GasUsed))
-		headBlobGasUsedGauge.TryUpdateUint64(parent.BlobGasUsed)
+		// OPStack addition
+		updateOptimismBlockMetrics(parent)
 
 		// If this is the first iteration, wipe any leftover data upwards too so
 		// we don't end up with dangling daps in the database

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -92,7 +92,11 @@ func NewHeaderChain(chainDb ethdb.Database, config *params.ChainConfig, engine c
 	}
 	hc.currentHeaderHash = hc.CurrentHeader().Hash()
 	headHeaderGauge.Update(hc.CurrentHeader().Number.Int64())
+
+	// OPStack additions
 	headBaseFeeGauge.TryUpdate(hc.CurrentHeader().BaseFee)
+	headGasUsedGauge.Update(int64(hc.CurrentHeader().GasUsed))
+	headBlobGasUsedGauge.TryUpdateUint64(hc.CurrentHeader().BlobGasUsed)
 	return hc, nil
 }
 
@@ -183,7 +187,11 @@ func (hc *HeaderChain) Reorg(headers []*types.Header) error {
 	hc.currentHeaderHash = last.Hash()
 	hc.currentHeader.Store(types.CopyHeader(last))
 	headHeaderGauge.Update(last.Number.Int64())
+
+	// OPStack additions
 	headBaseFeeGauge.TryUpdate(last.BaseFee)
+	headGasUsedGauge.Update(int64(last.GasUsed))
+	headBlobGasUsedGauge.TryUpdateUint64(last.BlobGasUsed)
 	return nil
 }
 
@@ -486,7 +494,11 @@ func (hc *HeaderChain) SetCurrentHeader(head *types.Header) {
 	hc.currentHeader.Store(head)
 	hc.currentHeaderHash = head.Hash()
 	headHeaderGauge.Update(head.Number.Int64())
+
+	// OPStack additions
 	headBaseFeeGauge.TryUpdate(head.BaseFee)
+	headGasUsedGauge.Update(int64(head.GasUsed))
+	headBlobGasUsedGauge.TryUpdateUint64(head.BlobGasUsed)
 }
 
 type (
@@ -573,7 +585,11 @@ func (hc *HeaderChain) setHead(headBlock uint64, headTime uint64, updateFn Updat
 		hc.currentHeader.Store(parent)
 		hc.currentHeaderHash = parentHash
 		headHeaderGauge.Update(parent.Number.Int64())
+
+		// OPStack additions
 		headBaseFeeGauge.TryUpdate(parent.BaseFee)
+		headGasUsedGauge.Update(int64(parent.GasUsed))
+		headBlobGasUsedGauge.TryUpdateUint64(parent.BlobGasUsed)
 
 		// If this is the first iteration, wipe any leftover data upwards too so
 		// we don't end up with dangling daps in the database

--- a/fork.yaml
+++ b/fork.yaml
@@ -199,7 +199,10 @@ def:
         - title: Warn on missing hardfork data and emit additional metrics
           globs:
             - "core/blockchain.go"
-        - title: Additional metrics
+        - title: Define additional header-based metrics
+          globs:
+            - "core/blockchain_optimism.go"
+        - title: Add hooks for additional header-chain metrics
           globs:
             - "core/headerchain.go"
         - title: Optional Engine API extensions

--- a/metrics/gauge.go
+++ b/metrics/gauge.go
@@ -45,7 +45,7 @@ func (g *Gauge) Update(v int64) {
 	(*atomic.Int64)(g).Store(v)
 }
 
-// OPStack additon
+// OPStack addition
 // TryUpdate updates the gauge if the value is non-nil, converting it to int64.
 func (g *Gauge) TryUpdate(v *big.Int) {
 	if v == nil {

--- a/metrics/gauge.go
+++ b/metrics/gauge.go
@@ -45,12 +45,22 @@ func (g *Gauge) Update(v int64) {
 	(*atomic.Int64)(g).Store(v)
 }
 
+// OPStack additon
 // TryUpdate updates the gauge if the value is non-nil, converting it to int64.
 func (g *Gauge) TryUpdate(v *big.Int) {
 	if v == nil {
 		return
 	}
 	(*atomic.Int64)(g).Store(v.Int64())
+}
+
+// OPStack additon
+// TryUpdate updates the gauge if the value is non-nil, converting it to int64.
+func (g *Gauge) TryUpdateUint64(v *uint64) {
+	if v == nil {
+		return
+	}
+	(*atomic.Int64)(g).Store(int64(*v))
 }
 
 // UpdateIfGt updates the gauge's value if v is larger then the current value.


### PR DESCRIPTION
This can be used to track the DA footprint per block.

I decided against using the "da footprint" terminology, felt cleaner to just mirror the names from the header fields. It also means it makes sense for running as an L1 node. Went ahead and added both gas used fields so we can compare them in a dashboard. 

Closes https://github.com/ethereum-optimism/optimism/issues/17501