### PR TITLE
Add new precompile limits for Jovian

### DIFF
--- a/core/vm/contracts_test.go
+++ b/core/vm/contracts_test.go
@@ -74,6 +74,11 @@ var allPrecompiles = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{0x0b}): &p256Verify{},
 
 	common.BytesToAddress([]byte{0x01, 0x00}): &p256VerifyFjord{},
+
+	common.BytesToAddress([]byte{0x2f, 0x08}): &bn256PairingJovian{},
+	common.BytesToAddress([]byte{0x2f, 0x0e}): &bls12381PairingJovian{},
+	common.BytesToAddress([]byte{0x2f, 0x0b}): &bls12381G1MultiExpJovian{},
+	common.BytesToAddress([]byte{0x2f, 0x0d}): &bls12381G2MultiExpJovian{},
 }
 
 // EIP-152 test vectors

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -185,6 +185,11 @@ const (
 	Bls12381G2MulMaxInputSizeIsthmus   uint64 = 488448 // Maximum input size for BLS12-381 G2 multiple-scalar-multiply operation
 	Bls12381PairingMaxInputSizeIsthmus uint64 = 235008 // Maximum input size for BLS12-381 pairing check
 
+	Bn256PairingMaxInputSizeJovian    uint64 = 81984  // bn256Pairing limit (427 pairs)
+	Bls12381G1MulMaxInputSizeJovian   uint64 = 288960 // BLS12-381 G1 MSM limit (1,806 pairs)
+	Bls12381G2MulMaxInputSizeJovian   uint64 = 278784 // BLS12-381 G2 MSM limit (968 pairs)
+	Bls12381PairingMaxInputSizeJovian uint64 = 156672 // BLS12-381 pairing limit (408 pairs)
+
 	// The Refund Quotient is the cap on how much of the used gas can be refunded. Before EIP-3529,
 	// up to half the consumed gas could be refunded. Redefined as 1/5th in EIP-3529
 	RefundQuotient        uint64 = 2


### PR DESCRIPTION
This introduces more realistic limits on accelerated precompiles for the Jovian hard fork.
