### PR TITLE
eth, cmd: add RollupNetrestrictTxPoolGossipFlag PoC using `NilPool`

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -318,11 +318,9 @@ func (h *handler) runEthPeer(peer *eth.Peer, handler eth.Handler) error {
 		}
 	}
 
-	if peer.IsAllowedForTxGossip() {
-		// Propagate existing transactions. new transactions appearing
-		// after this will be sent via broadcasts.
-		h.syncTransactions(peer)
-	}
+	// Propagate existing transactions. new transactions appearing
+	// after this will be sent via broadcasts.
+	h.syncTransactions(peer)
 
 	// Create a notification channel for pending requests if the peer goes down
 	dead := make(chan struct{})
@@ -517,9 +515,6 @@ func (h *handler) BroadcastTransactions(txs types.Transactions) {
 
 		for _, peer := range peers {
 			if peer.KnownTransaction(tx.Hash()) {
-				continue
-			}
-			if !peer.IsAllowedForTxGossip() {
 				continue
 			}
 			if _, ok := directSet[peer]; ok {

--- a/eth/handler_eth.go
+++ b/eth/handler_eth.go
@@ -19,6 +19,7 @@ package eth
 import (
 	"errors"
 	"fmt"
+	"net/netip"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
@@ -43,11 +44,17 @@ func (n NilPool) Get(common.Hash) *types.Transaction              { return nil }
 func (n NilPool) GetRLP(common.Hash) []byte                       { return nil }
 func (n NilPool) GetMetadata(hash common.Hash) *txpool.TxMetadata { return nil }
 
-func (h *ethHandler) TxPool() eth.TxPool {
+func (h *ethHandler) TxPool(ip netip.Addr) eth.TxPool {
 	if h.noTxGossip {
 		return &NilPool{}
 	}
-	return h.txpool
+	if h.txGossipNetRestrict == nil {
+		return h.txpool
+	}
+	if h.txGossipNetRestrict.ContainsAddr(ip) {
+		return h.txpool
+	}
+	return &NilPool{}
 }
 
 func (h *ethHandler) TxGossipNetRestrict() *netutil.Netlist {

--- a/eth/handler_eth_test.go
+++ b/eth/handler_eth_test.go
@@ -19,6 +19,7 @@ package eth
 import (
 	"fmt"
 	"math/big"
+	"net/netip"
 	"testing"
 	"time"
 
@@ -45,7 +46,7 @@ type testEthHandler struct {
 }
 
 func (h *testEthHandler) Chain() *core.BlockChain               { panic("no backing chain") }
-func (h *testEthHandler) TxPool() eth.TxPool                    { panic("no backing tx pool") }
+func (h *testEthHandler) TxPool(netip.Addr) eth.TxPool          { panic("no backing tx pool") }
 func (h *testEthHandler) AcceptTxs() bool                       { return true }
 func (h *testEthHandler) RunPeer(*eth.Peer, eth.Handler) error  { panic("not used in tests") }
 func (h *testEthHandler) PeerInfo(enode.ID) interface{}         { panic("not used in tests") }

--- a/eth/protocols/eth/handler.go
+++ b/eth/protocols/eth/handler.go
@@ -18,6 +18,7 @@ package eth
 
 import (
 	"fmt"
+	"net/netip"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -28,7 +29,6 @@ import (
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/enr"
-	"github.com/ethereum/go-ethereum/p2p/netutil"
 	"github.com/ethereum/go-ethereum/params"
 )
 
@@ -63,14 +63,11 @@ type Backend interface {
 	Chain() *core.BlockChain
 
 	// TxPool retrieves the transaction pool object to serve data.
-	TxPool() TxPool
+	TxPool(ip netip.Addr) TxPool
 
 	// AcceptTxs retrieves whether transaction processing is enabled on the node
 	// or if inbound transactions should simply be dropped.
 	AcceptTxs() bool
-
-	// TxGossipNetRestrict retrieves the network restriction list for transaction gossip.
-	TxGossipNetRestrict() *netutil.Netlist
 
 	// RunPeer is invoked when a peer joins on the `eth` protocol. The handler
 	// should do any peer maintenance work, handshakes and validations. If all
@@ -110,7 +107,7 @@ func MakeProtocols(backend Backend, network uint64, disc enode.Iterator) []p2p.P
 			Version: version,
 			Length:  protocolLengths[version],
 			Run: func(p *p2p.Peer, rw p2p.MsgReadWriter) error {
-				peer := NewPeer(version, p, rw, backend.TxPool()).WithTxGossipNetRestrict(backend.TxGossipNetRestrict())
+				peer := NewPeer(version, p, rw, backend.TxPool(p.Node().IPAddr()))
 				defer peer.Close()
 
 				return backend.RunPeer(peer, func(peer *Peer) error {

--- a/eth/protocols/eth/handler_test.go
+++ b/eth/protocols/eth/handler_test.go
@@ -22,6 +22,7 @@ import (
 	"math"
 	"math/big"
 	"math/rand"
+	"net/netip"
 	"os"
 	"testing"
 	"time"
@@ -40,7 +41,6 @@ import (
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
-	"github.com/ethereum/go-ethereum/p2p/netutil"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/holiman/uint256"
@@ -152,10 +152,8 @@ func (b *testBackend) close() {
 	b.chain.Stop()
 }
 
-func (b *testBackend) Chain() *core.BlockChain               { return b.chain }
-func (b *testBackend) TxPool() TxPool                        { return b.txpool }
-func (b *testBackend) TxGossipNetRestrict() *netutil.Netlist { return nil }
-
+func (b *testBackend) Chain() *core.BlockChain     { return b.chain }
+func (b *testBackend) TxPool(ip netip.Addr) TxPool { return b.txpool }
 func (b *testBackend) RunPeer(peer *Peer, handler Handler) error {
 	// Normally the backend would do peer maintenance and handshakes. All that
 	// is omitted and we will just give control back to the handler.

--- a/eth/protocols/eth/handlers.go
+++ b/eth/protocols/eth/handlers.go
@@ -457,11 +457,11 @@ func handleGetPooledTransactions(backend Backend, msg Decoder, peer *Peer) error
 	if err := msg.Decode(&query); err != nil {
 		return err
 	}
-	hashes, txs := answerGetPooledTransactions(backend, query.GetPooledTransactionsRequest)
+	hashes, txs := answerGetPooledTransactions(backend, query.GetPooledTransactionsRequest, peer)
 	return peer.ReplyPooledTransactionsRLP(query.RequestId, hashes, txs)
 }
 
-func answerGetPooledTransactions(backend Backend, query GetPooledTransactionsRequest) ([]common.Hash, []rlp.RawValue) {
+func answerGetPooledTransactions(backend Backend, query GetPooledTransactionsRequest, peer *Peer) ([]common.Hash, []rlp.RawValue) {
 	// Gather transactions until the fetch or network limits is reached
 	var (
 		bytes  int
@@ -473,7 +473,7 @@ func answerGetPooledTransactions(backend Backend, query GetPooledTransactionsReq
 			break
 		}
 		// Retrieve the requested transaction, skipping if unknown to us
-		encoded := backend.TxPool().GetRLP(hash)
+		encoded := backend.TxPool(peer.Node().IPAddr()).GetRLP(hash)
 		if len(encoded) == 0 {
 			continue
 		}

--- a/eth/protocols/eth/handlers.go
+++ b/eth/protocols/eth/handlers.go
@@ -437,10 +437,6 @@ func handleNewPooledTransactionHashes(backend Backend, msg Decoder, peer *Peer) 
 	if !backend.AcceptTxs() {
 		return nil
 	}
-	// Check if peer is allowed for transaction gossip
-	if !peer.IsAllowedForTxGossip() {
-		return nil
-	}
 	ann := new(NewPooledTransactionHashesPacket)
 	if err := msg.Decode(ann); err != nil {
 		return err
@@ -456,10 +452,6 @@ func handleNewPooledTransactionHashes(backend Backend, msg Decoder, peer *Peer) 
 }
 
 func handleGetPooledTransactions(backend Backend, msg Decoder, peer *Peer) error {
-	// Check if peer is allowed for transaction gossip
-	if !peer.IsAllowedForTxGossip() {
-		return nil
-	}
 	// Decode the pooled transactions retrieval message
 	var query GetPooledTransactionsPacket
 	if err := msg.Decode(&query); err != nil {
@@ -497,10 +489,6 @@ func handleTransactions(backend Backend, msg Decoder, peer *Peer) error {
 	if !backend.AcceptTxs() {
 		return nil
 	}
-	// Check if peer is allowed for transaction gossip
-	if !peer.IsAllowedForTxGossip() {
-		return nil
-	}
 	// Transactions can be processed, parse all of them and deliver to the pool
 	var txs TransactionsPacket
 	if err := msg.Decode(&txs); err != nil {
@@ -519,10 +507,6 @@ func handleTransactions(backend Backend, msg Decoder, peer *Peer) error {
 func handlePooledTransactions(backend Backend, msg Decoder, peer *Peer) error {
 	// Transactions arrived, make sure we have a valid and fresh chain to handle them
 	if !backend.AcceptTxs() {
-		return nil
-	}
-	// Check if peer is allowed for transaction gossip
-	if !peer.IsAllowedForTxGossip() {
 		return nil
 	}
 	// Transactions can be processed, parse all of them and deliver to the pool

--- a/eth/protocols/eth/peer.go
+++ b/eth/protocols/eth/peer.go
@@ -24,7 +24,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/p2p"
-	"github.com/ethereum/go-ethereum/p2p/netutil"
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
@@ -61,9 +60,6 @@ type Peer struct {
 	resDispatch chan *response // Dispatch channel to fulfil pending requests and untrack them
 
 	term chan struct{} // Termination channel to stop the broadcasters
-
-	// txGossipNetRestrict restricts transaction gossip to specific IP networks
-	txGossipNetRestrict *netutil.Netlist
 }
 
 // NewPeer creates a wrapper for a network connection and negotiated  protocol
@@ -89,22 +85,6 @@ func NewPeer(version uint, p *p2p.Peer, rw p2p.MsgReadWriter, txpool TxPool) *Pe
 	go peer.dispatcher()
 
 	return peer
-}
-
-// WithTxGossipNetRestrict sets the txGossipNetRestrict field on the peer and returns the peer.
-// This is a modifier function that allows setting the field after peer creation.
-func (p *Peer) WithTxGossipNetRestrict(txGossipNetRestrict *netutil.Netlist) *Peer {
-	p.txGossipNetRestrict = txGossipNetRestrict
-	return p
-}
-
-// IsAllowedForTxGossip checks if the peer is allowed to participate in transaction gossip
-// based on the txGossipNetRestrict configuration.
-func (p *Peer) IsAllowedForTxGossip() bool {
-	if p.txGossipNetRestrict == nil {
-		return true // No restrictions, allow all peers
-	}
-	return p.txGossipNetRestrict.ContainsAddr(p.Node().IPAddr())
 }
 
 // Close signals the broadcast goroutine to terminate. Only ever call this if
@@ -152,10 +132,6 @@ func (p *Peer) markTransaction(hash common.Hash) {
 // The reasons this is public is to allow packages using this protocol to write
 // tests that directly send messages without having to do the async queueing.
 func (p *Peer) SendTransactions(txs types.Transactions) error {
-	// Check if peer is allowed for transaction gossip
-	if !p.IsAllowedForTxGossip() {
-		return nil
-	}
 	// Mark all the transactions as known, but ensure we don't overflow our limits
 	for _, tx := range txs {
 		p.knownTxs.Add(tx.Hash())
@@ -167,10 +143,6 @@ func (p *Peer) SendTransactions(txs types.Transactions) error {
 // propagate to a remote peer. The number of pending sends are capped (new ones
 // will force old sends to be dropped)
 func (p *Peer) AsyncSendTransactions(hashes []common.Hash) {
-	// Check if peer is allowed for transaction gossip
-	if !p.IsAllowedForTxGossip() {
-		return
-	}
 	select {
 	case p.txBroadcast <- hashes:
 		// Mark all the transactions as known, but ensure we don't overflow our limits
@@ -188,10 +160,6 @@ func (p *Peer) AsyncSendTransactions(hashes []common.Hash) {
 // directly as the queueing (memory) and transmission (bandwidth) costs should
 // not be managed directly.
 func (p *Peer) sendPooledTransactionHashes(hashes []common.Hash, types []byte, sizes []uint32) error {
-	// Check if peer is allowed for transaction gossip
-	if !p.IsAllowedForTxGossip() {
-		return nil
-	}
 	// Mark all the transactions as known, but ensure we don't overflow our limits
 	p.knownTxs.Add(hashes...)
 	return p2p.Send(p.rw, NewPooledTransactionHashesMsg, NewPooledTransactionHashesPacket{Types: types, Sizes: sizes, Hashes: hashes})
@@ -201,10 +169,6 @@ func (p *Peer) sendPooledTransactionHashes(hashes []common.Hash, types []byte, s
 // announce to a remote peer.  The number of pending sends are capped (new ones
 // will force old sends to be dropped)
 func (p *Peer) AsyncSendPooledTransactionHashes(hashes []common.Hash) {
-	// Check if peer is allowed for transaction gossip
-	if !p.IsAllowedForTxGossip() {
-		return
-	}
 	select {
 	case p.txAnnounce <- hashes:
 		// Mark all the transactions as known, but ensure we don't overflow our limits
@@ -216,10 +180,6 @@ func (p *Peer) AsyncSendPooledTransactionHashes(hashes []common.Hash) {
 
 // ReplyPooledTransactionsRLP is the response to RequestTxs.
 func (p *Peer) ReplyPooledTransactionsRLP(id uint64, hashes []common.Hash, txs []rlp.RawValue) error {
-	// Check if peer is allowed for transaction gossip
-	if !p.IsAllowedForTxGossip() {
-		return nil
-	}
 	// Mark all the transactions as known, but ensure we don't overflow our limits
 	p.knownTxs.Add(hashes...)
 
@@ -381,10 +341,6 @@ func (p *Peer) RequestReceipts(hashes []common.Hash, sink chan *Response) (*Requ
 
 // RequestTxs fetches a batch of transactions from a remote node.
 func (p *Peer) RequestTxs(hashes []common.Hash) error {
-	// Check if peer is allowed for transaction gossip
-	if !p.IsAllowedForTxGossip() {
-		return nil
-	}
 	p.Log().Debug("Fetching batch of transactions", "count", len(hashes))
 	id := rand.Uint64()
 

--- a/eth/protocols/eth/peer_test.go
+++ b/eth/protocols/eth/peer_test.go
@@ -45,7 +45,8 @@ func newTestPeer(name string, version uint, backend Backend) (*testPeer, <-chan 
 	var id enode.ID
 	rand.Read(id[:])
 
-	peer := NewPeer(version, p2p.NewPeer(id, name, nil), net, backend.TxPool()).WithTxGossipNetRestrict(backend.TxGossipNetRestrict())
+	p := p2p.NewPeer(id, name, nil)
+	peer := NewPeer(version, p, net, backend.TxPool(p.Node().IPAddr()))
 	errc := make(chan error, 1)
 	go func() {
 		defer app.Close()


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

PoC implementation of RollupNetrestrictTxPoolGossip built on top of https://github.com/ethereum-optimism/op-geth/pull/706.

Rationale:

Using `NilPool` worked fine for implementing notxgossip feature.
```go
	if h.noTxGossip {
		return &NilPool{}
	}
```

Instead of peer manage every inbound/outbound connection, we may make initialization of txpool ip aware, from `TxPool() TxPool` to `TxPool(ip netip.Addr) TxPool`.

```go
func (h *ethHandler) TxPool(ip netip.Addr) eth.TxPool {
	if h.noTxGossip {
		return &NilPool{}
	}
	if h.txGossipNetRestrict == nil {
		return h.txpool
	}
	if h.txGossipNetRestrict.ContainsAddr(ip) {
		return h.txpool
	}
	return &NilPool{}
}
```

Ethhandler must be initialized using the `txGossipNetRestrict`.

We have these benefits
- We do not check peer ip every time for the inbound / outbound connection
    - Less likelihood to leak the txpool, since we check the filtering when txpool initialization. More easy to reason about the flow.
- Possibly less diff with upstream


