### PR TITLE
dockerfile: pin to alpine 3.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN cd /go-ethereum && go run build/ci.go install -static ./cmd/geth
 # Pull Geth into a second stage deploy alpine container
 FROM alpine:3.22
 
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates=20250911-r0
 COPY --from=builder /go-ethereum/build/bin/geth /usr/local/bin/
 
 EXPOSE 8545 8546 30303 30303/udp

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG VERSION=""
 ARG BUILDNUM=""
 
 # Build Geth in a stock Go builder container
-FROM golang:1.24-alpine@sha256:12c199a889439928e36df7b4c5031c18bfdad0d33cdeae5dd35b2de369b5fbf5 AS builder
+FROM golang:1.24-alpine3.22 AS builder
 
 RUN apk add --no-cache gcc musl-dev linux-headers git
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ADD . /go-ethereum
 RUN cd /go-ethereum && go run build/ci.go install -static ./cmd/geth
 
 # Pull Geth into a second stage deploy alpine container
-FROM alpine:latest
+FROM alpine:3.22
 
 RUN apk add --no-cache ca-certificates
 COPY --from=builder /go-ethereum/build/bin/geth /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG VERSION=""
 ARG BUILDNUM=""
 
 # Build Geth in a stock Go builder container
-FROM golang:1.24-alpine AS builder
+FROM golang:1.24-alpine@sha256:12c199a889439928e36df7b4c5031c18bfdad0d33cdeae5dd35b2de369b5fbf5 AS builder
 
 RUN apk add --no-cache gcc musl-dev linux-headers git
 
@@ -19,7 +19,7 @@ RUN cd /go-ethereum && go run build/ci.go install -static ./cmd/geth
 # Pull Geth into a second stage deploy alpine container
 FROM alpine:3.22
 
-RUN apk add --no-cache ca-certificates=20250911-r0
+RUN apk add --no-cache ca-certificates
 COPY --from=builder /go-ethereum/build/bin/geth /usr/local/bin/
 
 EXPOSE 8545 8546 30303 30303/udp

--- a/Dockerfile.alltools
+++ b/Dockerfile.alltools
@@ -24,7 +24,7 @@ RUN cd /go-ethereum && go run build/ci.go install -static ./cmd/geth
 RUN cd /go-ethereum && go run build/ci.go install -static
 
 # Pull all binaries into a second stage deploy alpine container
-FROM alpine:latest
+FROM alpine:3.22
 
 RUN apk add --no-cache ca-certificates
 COPY --from=builder /go-ethereum/build/bin/* /usr/local/bin/

--- a/Dockerfile.alltools
+++ b/Dockerfile.alltools
@@ -4,7 +4,7 @@ ARG VERSION=""
 ARG BUILDNUM=""
 
 # Build Geth in a stock Go builder container
-FROM golang:1.24-alpine@sha256:12c199a889439928e36df7b4c5031c18bfdad0d33cdeae5dd35b2de369b5fbf5 AS builder
+FROM golang:1.24-alpine3.22 AS builder
 
 RUN apk add --no-cache gcc musl-dev linux-headers git
 

--- a/Dockerfile.alltools
+++ b/Dockerfile.alltools
@@ -4,7 +4,7 @@ ARG VERSION=""
 ARG BUILDNUM=""
 
 # Build Geth in a stock Go builder container
-FROM golang:1.24-alpine AS builder
+FROM golang:1.24-alpine@sha256:12c199a889439928e36df7b4c5031c18bfdad0d33cdeae5dd35b2de369b5fbf5 AS builder
 
 RUN apk add --no-cache gcc musl-dev linux-headers git
 
@@ -26,7 +26,7 @@ RUN cd /go-ethereum && go run build/ci.go install -static
 # Pull all binaries into a second stage deploy alpine container
 FROM alpine:3.22
 
-RUN apk add --no-cache ca-certificates=20250911-r0
+RUN apk add --no-cache ca-certificates
 COPY --from=builder /go-ethereum/build/bin/* /usr/local/bin/
 
 EXPOSE 8545 8546 30303 30303/udp

--- a/Dockerfile.alltools
+++ b/Dockerfile.alltools
@@ -26,7 +26,7 @@ RUN cd /go-ethereum && go run build/ci.go install -static
 # Pull all binaries into a second stage deploy alpine container
 FROM alpine:3.22
 
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates=20250911-r0
 COPY --from=builder /go-ethereum/build/bin/* /usr/local/bin/
 
 EXPOSE 8545 8546 30303 30303/udp


### PR DESCRIPTION
# Motivation
Fix for the following ci docker build failure:
```
Dockerfile:22
--------------------
  20 |     FROM alpine:latest
  21 |     
  22 | >>> RUN apk add --no-cache ca-certificates
  23 |     COPY --from=builder /go-ethereum/build/bin/geth /usr/local/bin/
  24 |     
--------------------
ERROR: failed to solve: process "/dev/.buildkit_qemu_emulator /bin/sh -c apk add --no-cache ca-certificates" did not complete successfully: exit code: 2
```

# Root cause
The latest alpine image `3.23`, which automatically got pulled in since the dockerfile used `alpine:latest` and `golang:1.24-alpine`, seems to have a bug related to trigger scripts: `busybox-1.37.0-r29` fails (used by alpine:3.23) vs `busybox-1.37.0-r19` (used by alpine:3.22) works. The newer scripts may have a bug or incompatibility with QEMU emulation.