### PR TITLE
ci: complete migration of docker builds from CircleCI to GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
 version: 2.1
 
 orbs:
-  gcp-cli: circleci/gcp-cli@3.0.1
   slack: circleci/slack@4.10.1
   utils: ethereum-optimism/circleci-utils@1.0.13
 
@@ -10,47 +9,6 @@ parameters:
     type: string
     default: 1.25.1 # update CI Go version here
 
-commands:
-  gcp-oidc-authenticate:
-    description: "Authenticate with GCP using a CircleCI OIDC token."
-    parameters:
-      project_id:
-        type: env_var_name
-        default: GCP_PROJECT_ID
-      workload_identity_pool_id:
-        type: env_var_name
-        default: GCP_WIP_ID
-      workload_identity_pool_provider_id:
-        type: env_var_name
-        default: GCP_WIP_PROVIDER_ID
-      service_account_email:
-        type: env_var_name
-        default: GCP_SERVICE_ACCOUNT_EMAIL
-      gcp_cred_config_file_path:
-        type: string
-        default: /home/circleci/gcp_cred_config.json
-      oidc_token_file_path:
-        type: string
-        default: /home/circleci/oidc_token.json
-    steps:
-      - run:
-          name: "Create OIDC credential configuration"
-          command: |
-            # Store OIDC token in temp file
-            echo $CIRCLE_OIDC_TOKEN > << parameters.oidc_token_file_path >>
-            # Create a credential configuration for the generated OIDC ID Token
-            gcloud iam workload-identity-pools create-cred-config \
-                "projects/${<< parameters.project_id >>}/locations/global/workloadIdentityPools/${<< parameters.workload_identity_pool_id >>}/providers/${<< parameters.workload_identity_pool_provider_id >>}"\
-                --output-file="<< parameters.gcp_cred_config_file_path >>" \
-                --service-account="${<< parameters.service_account_email >>}" \
-                --credential-source-file=<< parameters.oidc_token_file_path >>
-      - run:
-          name: "Authenticate with GCP using OIDC"
-          command: |
-            # Configure gcloud to leverage the generated credential configuration
-            gcloud auth login --brief --cred-file "<< parameters.gcp_cred_config_file_path >>"
-            # Configure ADC
-            echo "export GOOGLE_APPLICATION_CREDENTIALS='<< parameters.gcp_cred_config_file_path >>'" | tee -a "$BASH_ENV"
 
 jobs:
   build-and-deploy:
@@ -86,89 +44,6 @@ jobs:
             fi
       - utils/github-pages-deploy:
           src-pages-dir: /tmp/pages
-  docker-release:
-    environment:
-      DOCKER_BUILDKIT: 1
-    parameters:
-      docker_name:
-        description: Docker image name
-        type: string
-        default: "op-geth"
-      docker_tags:
-        description: Docker image tags as csv
-        type: string
-      registry:
-        description: Docker registry
-        type: string
-        default: "us-docker.pkg.dev"
-      repo:
-        description: Docker repo
-        type: string
-        default: "oplabs-tools-artifacts/images"
-      push_tags:
-        description: Push release push tags
-        type: boolean
-        default: false
-    machine:
-      image: default
-      resource_class: xlarge
-    steps:
-      - gcp-cli/install
-      - gcp-oidc-authenticate
-      - checkout
-      - run:
-          name: Configure Docker
-          command: |
-            gcloud auth configure-docker <<parameters.registry>>
-      - run:
-          name: Build and push
-          command: |
-            RAW_TAGS="<<parameters.docker_tags>>"
-            if [ "$CIRCLE_BRANCH" = "optimism" ]; then
-              RAW_TAGS="$RAW_TAGS,optimism"
-            fi
-            IMAGE_BASE="<<parameters.registry>>/<<parameters.repo>>/<<parameters.docker_name>>"
-            DOCKER_TAGS=$(echo -ne "$RAW_TAGS" | sed "s/,/\n/g" | sed "s/[^a-zA-Z0-9\n.]/-/g" | sed -e "s|^|-t ${IMAGE_BASE}:|")
-            docker context create buildx-build
-            docker buildx create --use buildx-build
-            docker buildx build --push \
-              $(echo -ne $DOCKER_TAGS | tr '\n' ' ') \
-              --platform=linux/arm64,linux/amd64 \
-              --build-arg VERSION=$CIRCLE_TAG \
-              --build-arg COMMIT=$CIRCLE_SHA \
-              --build-arg BUILDNUM=$CIRCLE_BUILD_NUM \
-              --progress plain \
-              -f Dockerfile .
-      - when:
-          condition:
-            equal: [true, <<parameters.push_tags>>]
-          steps:
-            - run:
-                name: Tag
-                command: |
-                  ./.circleci/ci-docker-tag-op-geth-release.sh <<parameters.registry>>/<<parameters.repo>> $CIRCLE_TAG $CIRCLE_SHA1
-      - when:
-          condition:
-            equal: [optimism, << pipeline.git.branch >>]
-          steps:
-            - gcp-oidc-authenticate:
-                service_account_email: GCP_SERVICE_ATTESTOR_ACCOUNT_EMAIL
-            - run:
-                name: Sign
-                command: |
-                  git clone --branch v1.0.3 --depth 1 https://github.com/ethereum-optimism/binary_signer
-                  cd binary_signer/signer
-
-                  IMAGE_PATH="<<parameters.registry>>/<<parameters.repo>>/<<parameters.docker_name>>:<<pipeline.git.revision>>"
-                  echo $IMAGE_PATH
-                  pip3 install -r requirements.txt
-
-                  python3 ./sign_image.py --command="sign"\
-                      --attestor-project-name="$ATTESTOR_PROJECT_NAME"\
-                      --attestor-name="$ATTESTOR_NAME"\
-                      --image-path="$IMAGE_PATH"\
-                      --signer-logging-level="INFO"\
-                      --attestor-key-id="//cloudkms.googleapis.com/v1/projects/$ATTESTOR_PROJECT_NAME/locations/global/keyRings/$ATTESTOR_NAME-key-ring/cryptoKeys/$ATTESTOR_NAME-key/cryptoKeyVersions/1"
 
   build-geth:
     docker:
@@ -227,26 +102,8 @@ workflows:
           name: Run linter over geth
       - tidy-geth:
           name: Check geth go.mod file has been tidied
-      - docker-release:
-          name: Push to Docker
-          docker_tags: <<pipeline.git.revision>>
-          context:
-            - oplabs-gcr
       - check-sr-diff:
           name: Check superchain registry bundle diff
-  release:
-    jobs:
-      - docker-release:
-          name: Push to Docker (release)
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
-          docker_tags: <<pipeline.git.revision>>,<<pipeline.git.tag>>
-          push_tags: true
-          context:
-            - oplabs-gcr-release
 
   merge:
     jobs:

--- a/.github/workflows/op-geth.yml
+++ b/.github/workflows/op-geth.yml
@@ -5,14 +5,13 @@ on:
 
 jobs:
   build:
-    uses: ethereum-optimism/factory/.github/workflows/docker-build.yaml@c8bcfc1a537d01a005a09276b1b673dca9132540
+    uses: ethereum-optimism/factory/.github/workflows/docker.yaml@f8f3cb4800e538003134fb5f50cc734c2c98d762
     with:
       image_name: ${{ github.workflow }}
       context: .
       dockerfile: Dockerfile
-      platforms: linux/amd64,linux/arm64
       gcp_project_id: ${{ vars.GCP_PROJECT_ID_OPLABS_TOOLS_ARTIFACTS }}
-      gcp_registry: us-docker.pkg.dev/oplabs-tools-artifacts/oss
+      registry: us-docker.pkg.dev/oplabs-tools-artifacts/images
       build_args: |
         VERSION=${{ github.ref_type == 'tag' && github.ref_name || '' }}
         COMMIT=${{ github.sha }}


### PR DESCRIPTION
Migrating docker builds from CircleCI to GitHub Actions.

- GHA now pushes to `images` registry instead of `oss`
- Upgraded to latest factory workflow
- Removed CCI docker-release job and release workflow
- Kept all test jobs and github pages deployment