### PR TITLE
Run go run build/ci.go check_generate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,6 +194,8 @@ jobs:
       - checkout
       - run:
           command: go run build/ci.go lint
+      - run:
+          command: go run build/ci.go check_generate
   tidy-geth:
     resource_class: small
     docker:

--- a/build/ci.go
+++ b/build/ci.go
@@ -378,7 +378,7 @@ func doCheckGenerate() {
 
 	for _, mod := range goModules {
 		// Compute the origin hashes of all the files
-		hashes, err := build.HashFolder(mod, []string{"tests/testdata", "build/cache", ".git"})
+		hashes, err := build.HashFolder(mod, []string{"tests/testdata", "build/cache", ".git", ".jj"})
 		if err != nil {
 			log.Fatal("Error computing hashes", "err", err)
 		}
@@ -388,7 +388,7 @@ func doCheckGenerate() {
 		c.Dir = mod
 		build.MustRun(c)
 		// Check if generate file hashes have changed
-		generated, err := build.HashFolder(mod, []string{"tests/testdata", "build/cache", ".git"})
+		generated, err := build.HashFolder(mod, []string{"tests/testdata", "build/cache", ".git", ".jj"})
 		if err != nil {
 			log.Fatalf("Error re-computing hashes: %v", err)
 		}

--- a/core/types/gen_receipt_json.go
+++ b/core/types/gen_receipt_json.go
@@ -72,8 +72,6 @@ func (r Receipt) MarshalJSON() ([]byte, error) {
 	enc.OperatorFeeScalar = (*hexutil.Uint64)(r.OperatorFeeScalar)
 	enc.OperatorFeeConstant = (*hexutil.Uint64)(r.OperatorFeeConstant)
 	enc.DAFootprintGasScalar = (*hexutil.Uint64)(r.DAFootprintGasScalar)
-	enc.OperatorFeeScalar = (*hexutil.Uint64)(r.OperatorFeeScalar)
-	enc.OperatorFeeConstant = (*hexutil.Uint64)(r.OperatorFeeConstant)
 	return json.Marshal(&enc)
 }
 

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -77,7 +77,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		RollupHistoricalRPC                       string
 		RollupHistoricalRPCTimeout                time.Duration
 		RollupDisableTxPoolGossip                 bool
-		RollupNetrestrictTxPoolGossip             string
+		RollupTxPoolNetrestrict                   string `toml:",omitempty"`
 		RollupTxPoolTrustedPeersOnly              bool
 		RollupDisableTxPoolAdmission              bool
 		RollupHaltOnIncompatibleProtocolVersion   string
@@ -145,7 +145,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.RollupHistoricalRPC = c.RollupHistoricalRPC
 	enc.RollupHistoricalRPCTimeout = c.RollupHistoricalRPCTimeout
 	enc.RollupDisableTxPoolGossip = c.RollupDisableTxPoolGossip
-	enc.RollupNetrestrictTxPoolGossip = c.RollupTxPoolNetrestrict
+	enc.RollupTxPoolNetrestrict = c.RollupTxPoolNetrestrict
 	enc.RollupTxPoolTrustedPeersOnly = c.RollupTxPoolTrustedPeersOnly
 	enc.RollupDisableTxPoolAdmission = c.RollupDisableTxPoolAdmission
 	enc.RollupHaltOnIncompatibleProtocolVersion = c.RollupHaltOnIncompatibleProtocolVersion
@@ -217,7 +217,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		RollupHistoricalRPC                       *string
 		RollupHistoricalRPCTimeout                *time.Duration
 		RollupDisableTxPoolGossip                 *bool
-		RollupNetrestrictTxPoolGossip             *string
+		RollupTxPoolNetrestrict                   *string `toml:",omitempty"`
 		RollupTxPoolTrustedPeersOnly              *bool
 		RollupDisableTxPoolAdmission              *bool
 		RollupHaltOnIncompatibleProtocolVersion   *string
@@ -408,8 +408,8 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	if dec.RollupDisableTxPoolGossip != nil {
 		c.RollupDisableTxPoolGossip = *dec.RollupDisableTxPoolGossip
 	}
-	if dec.RollupNetrestrictTxPoolGossip != nil {
-		c.RollupTxPoolNetrestrict = *dec.RollupNetrestrictTxPoolGossip
+	if dec.RollupTxPoolNetrestrict != nil {
+		c.RollupTxPoolNetrestrict = *dec.RollupTxPoolNetrestrict
 	}
 	if dec.RollupTxPoolTrustedPeersOnly != nil {
 		c.RollupTxPoolTrustedPeersOnly = *dec.RollupTxPoolTrustedPeersOnly

--- a/internal/build/file.go
+++ b/internal/build/file.go
@@ -40,9 +40,11 @@ func HashFolder(folder string, exlude []string) (map[string][32]byte, error) {
 	res := make(map[string][32]byte)
 	err := filepath.WalkDir(folder, func(path string, d os.DirEntry, _ error) error {
 		// Skip anything that's exluded or not a regular file
-		for _, skip := range exlude {
-			if strings.HasPrefix(path, filepath.FromSlash(skip)) {
-				return filepath.SkipDir
+		if d.IsDir() {
+			for _, skip := range exlude {
+				if strings.HasPrefix(path, filepath.FromSlash(skip)) {
+					return filepath.SkipDir
+				}
 			}
 		}
 		if !d.Type().IsRegular() {


### PR DESCRIPTION
Unfortunately, the check_generate script doesn't consider eth/ethconfig, so ci can't catch this.