### PR TITLE
consensus/misc/eip1559: Improve Holocene EIP1559 params checks

### DIFF
--- a/consensus/misc/eip1559/eip1559_optimism_test.go
+++ b/consensus/misc/eip1559/eip1559_optimism_test.go
@@ -1,0 +1,99 @@
+package eip1559
+
+import (
+	"testing"
+)
+
+func TestValidateHolocene1559Params(t *testing.T) {
+	tests := []struct {
+		name     string
+		params   []byte
+		expected string
+	}{
+		{
+			name:     "Wrong Length",
+			params:   []byte{0x00, 0x01},
+			expected: "holocene eip-1559 params should be 8 bytes, got 2",
+		},
+		{
+			name:     "Zero denominator, non-zero elasticity",
+			params:   []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01},
+			expected: "holocene params cannot have a 0 denominator unless elasticity is also 0",
+		},
+		{
+			name:     "Zero elasticity, non-zero denominator",
+			params:   []byte{0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00},
+			expected: "holocene params cannot have a 0 elasticity unless denominator is also 0",
+		},
+		{
+			name:   "Both zero (valid)",
+			params: []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+		},
+		{
+			name:   "Both non-zero (valid)",
+			params: []byte{0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateHolocene1559Params(tc.params)
+			if tc.expected == "" && err != nil {
+				t.Errorf("Expected no error, but got: %v", err)
+			}
+			if tc.expected != "" && (err == nil || err.Error() != tc.expected) {
+				t.Errorf("Expected error: %s, but got: %v", tc.expected, err)
+			}
+		})
+	}
+}
+
+func TestValidateHoloceneExtraData(t *testing.T) {
+	tests := []struct {
+		name     string
+		extra    []byte
+		expected string
+	}{
+		{
+			name:     "Wrong Length",
+			extra:    []byte{0x00, 0x01},
+			expected: "holocene extraData should be 9 bytes, got 2",
+		},
+		{
+			name:     "Wrong Version",
+			extra:    []byte{0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+			expected: "holocene extraData version byte should be 0, got 1",
+		},
+		{
+			name:     "Zero denominator, non-zero elasticity",
+			extra:    []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01},
+			expected: "holocene extraData must encode a non-zero denominator",
+		},
+		{
+			name:     "Zero elasticity, non-zero denominator",
+			extra:    []byte{0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00},
+			expected: "holocene extraData must encode a non-zero elasticity",
+		},
+		{
+			name:     "Both zero (invalid)",
+			extra:    []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+			expected: "holocene extraData must encode a non-zero denominator",
+		},
+		{
+			name:  "Both non-zero (valid)",
+			extra: []byte{0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateHoloceneExtraData(tc.extra)
+			if tc.expected == "" && err != nil {
+				t.Errorf("Expected no error, but got: %v", err)
+			}
+			if tc.expected != "" && (err == nil || err.Error() != tc.expected) {
+				t.Errorf("Expected error: %s, but got: %v", tc.expected, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Description**

Implementation of https://github.com/ethereum-optimism/specs/pull/872: also require non-zero elasticity in Holocene eip1559Params contained in payload attributes.

Plus, fix the Holocene extraData checks to not allow zero params, which _are_ allowed for the payload attributes EIP1559 params only.

**Tests**

Unit test added (were untested before).

**Additional context**

This is a safe retroactive change, see specs PR mentioned above for details.

The additional extraData non-zero check is safe retroactively because execution of any Holocene block with zero params would have caused zero panics for any of denominator or elasticity being zero.

**Metadata**

Towards https://github.com/ethereum-optimism/optimism/issues/18625
