### PR TITLE
fix: Use sync txpool.Add in TestInteropTxRejectedWithFailsafe

### DIFF
--- a/miner/op_interop_miner_test.go
+++ b/miner/op_interop_miner_test.go
@@ -115,7 +115,7 @@ func testInteropTransaction(t *testing.T, failsafeEnabled bool, expectIncluded b
 	tx := createInteropTransaction(t, miner, testBankKey, testUserAddress)
 
 	// Add the transaction to the pool
-	err := miner.txpool.Add(types.Transactions{tx}, false)
+	err := miner.txpool.Add(types.Transactions{tx}, true)
 	if len(err) > 0 && err[0] != nil {
 		t.Fatalf("Failed to add interop transaction to pool: %v", err[0])
 	}


### PR DESCRIPTION
Not using sync can lead to race conditions and cause the test to fail randomly.

Very small PR, with a very small fix.