### PR TITLE
miner: fix flaky TestInteropTxRejectedWithFailsafe test

### DIFF
--- a/miner/op_interop_miner_test.go
+++ b/miner/op_interop_miner_test.go
@@ -114,8 +114,8 @@ func testInteropTransaction(t *testing.T, failsafeEnabled bool, expectIncluded b
 	miner, testBankKey, testUserAddress := createInteropMiner(t, failsafeEnabled, nil)
 	tx := createInteropTransaction(t, miner, testBankKey, testUserAddress)
 
-	// Add the transaction to the pool
-	err := miner.txpool.Add(types.Transactions{tx}, false)
+	// Add the transaction to the pool (sync=true to ensure promotion to pending completes)
+	err := miner.txpool.Add(types.Transactions{tx}, true)
 	if len(err) > 0 && err[0] != nil {
 		t.Fatalf("Failed to add interop transaction to pool: %v", err[0])
 	}


### PR DESCRIPTION
**Disclaimer**: after seeing [this](https://app.circleci.com/pipelines/github/ethereum-optimism/op-geth/3976/workflows/f2e16065-b881-44f7-ac4e-053cc047a7b2/jobs/14932) failed CI run, I gave the problem to Opus 4.5. I reviewed the code changes and commit message, and everything seems to check out. 

The test was flaky due to a race condition in transaction pool handling. When calling txpool.Add() with sync=false, the transaction is added to the pool's queue but promotion to the "pending" pool happens asynchronously in a background goroutine.

The test's Has() check passed because it checks all transactions (both queued and pending), but generateWork() only retrieves transactions from the "pending" pool via Pending(). If the background promotion hadn't completed yet, the transaction wouldn't be processed.

Fix by changing sync=false to sync=true, ensuring the Add() call waits for the transaction to be promoted to the pending pool before returning.