### PR TITLE
miner: fix flaky TestDAFilters test

### DIFF
--- a/miner/miner_optimism_test.go
+++ b/miner/miner_optimism_test.go
@@ -104,7 +104,7 @@ func testMineAndExecute(t *testing.T, numTxs uint64, cfg *params.ChainConfig, as
 	txs := genTxs(1, numTxs)
 
 	// Add to txpool for the miner to pick up.
-	if errs := b.txPool.Add(txs, false); len(errs) > 0 {
+	if errs := b.txPool.Add(txs, true); len(errs) > 0 {
 		for _, err := range errs {
 			require.NoError(t, err, "failed adding tx to pool")
 		}

--- a/miner/payload_building_test.go
+++ b/miner/payload_building_test.go
@@ -418,7 +418,7 @@ func testDAFilters(t *testing.T, maxDATxSize, maxDABlockSize *big.Int, expectedT
 	w, b := newTestWorker(t, config, ethash.NewFaker(), db, 0)
 	w.SetMaxDASize(maxDATxSize, maxDABlockSize)
 	txs := genTxs(1, numDAFilterTxs)
-	b.txPool.Add(txs, false)
+	b.txPool.Add(txs, true)
 
 	args := newPayloadArgs(b.chain.CurrentBlock().Hash(), config)
 	args.NoTxPool = false


### PR DESCRIPTION
[Here](https://app.circleci.com/pipelines/github/ethereum-optimism/op-geth/3998/workflows/85a121ff-c3ac-479b-800c-a5e64118caa9/jobs/15065) was the flaked CI run.

Same root cause as d78d84f51: txpool.Add() with sync=false returns before transactions are promoted to the pending pool, causing a race with buildPayload() which only retrieves pending transactions.

Fix by changing sync=false to sync=true.