### PR TITLE
sync-superchain: use yq instead of dasel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,7 +211,7 @@ jobs:
       - checkout
       - run:
           name: install yq
-          command: go install github.com/mikefarah/yq/v4@latest
+          command: go install github.com/mikefarah/yq/v4@v4.44.1
       - run:
           name: generate artifact and check diff
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,8 +210,8 @@ jobs:
     steps:
       - checkout
       - run:
-          name: install dasel
-          command: go install github.com/tomwright/dasel/v2/cmd/dasel@v2.8.1
+          name: install yq
+          command: go install github.com/mikefarah/yq/v4@latest
       - run:
           name: generate artifact and check diff
           command: |

--- a/sync-superchain.sh
+++ b/sync-superchain.sh
@@ -46,8 +46,8 @@ process_network_dir() {
         fi
 
         echo "Processing $toml_file..."
-        # Extract chain_id from TOML file using dasel
-        chain_id=$(dasel -f "$toml_file" -r toml "chain_id" | tr -d '"')
+        # Extract chain_id from TOML file using yq
+        chain_id=$(yq -r '.chain_id' "$toml_file")
         chain_name="$(basename "${toml_file%.*}")"
 
         if [[ -z "$chain_id"


### PR DESCRIPTION
## Summary
- Replaces dasel with yq for reading TOML files
- Simplifies the script by using a more stable, widely-adopted tool

## Context
This is an alternative to #761 that solves the dasel version compatibility issue by switching to yq instead. 

yq benefits:
- More stable syntax across versions
- More commonly used in the ecosystem
- Simpler, cleaner syntax for TOML parsing

The change is minimal - replacing:
```bash
chain_id=$(dasel -f "$toml_file" -r toml "chain_id" | tr -d '"')
```

With:
```bash
chain_id=$(yq -r '.chain_id' "$toml_file")
```

## Test plan
- [ ] Verify script works with yq installed
- [ ] Verify extracted chain IDs are correct