### PR TITLE
consensus/beacon: skip extraData validation for OP genesis blocks

### DIFF
--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -235,8 +235,8 @@ func (beacon *Beacon) verifyHeader(chain consensus.ChainHeaderReader, header, pa
 	if len(header.Extra) > int(params.MaximumExtraDataSize) {
 		return fmt.Errorf("extra-data longer than 32 bytes (%d)", len(header.Extra))
 	}
-	// Validate Optimism extraData format
-	if chain.Config().IsOptimism() {
+	// Validate Optimism extraData format (skip genesis block which may have non-empty extraData)
+	if chain.Config().IsOptimism() && !chain.Config().IsOptimismGenesisBlock(header.Number) {
 		if err := eip1559.ValidateOptimismExtraData(chain.Config(), header.Time, header.Extra); err != nil {
 			return fmt.Errorf("invalid optimism extraData: %w", err)
 		}

--- a/consensus/misc/eip1559/eip1559_optimism.go
+++ b/consensus/misc/eip1559/eip1559_optimism.go
@@ -24,7 +24,7 @@ func ValidateOptimismExtraData(fc ForkChecker, time uint64, extraData []byte) er
 		return ValidateJovianExtraData(extraData)
 	} else if fc.IsHolocene(time) {
 		return ValidateHoloceneExtraData(extraData)
-	} else if len(extraData) > 0 { // pre-Holocene
+	} else if len(extraData) > 0 { // pre-Holocene, apart from the genesis block
 		return errors.New("extraData must be empty before Holocene")
 	}
 	return nil

--- a/params/config.go
+++ b/params/config.go
@@ -36,9 +36,10 @@ var (
 )
 
 const (
-	OPMainnetChainID   = 10
-	BaseMainnetChainID = 8453
-	baseSepoliaChainID = 84532
+	OPMainnetChainID          = 10
+	OPMainnetGenesisBlockNum  = 105235063
+	BaseMainnetChainID        = 8453
+	baseSepoliaChainID        = 84532
 )
 
 func newUint64(val uint64) *uint64 { return &val }
@@ -1031,6 +1032,19 @@ func (c *ChainConfig) IsInterop(time uint64) bool {
 // IsOptimism returns whether the node is an optimism node or not.
 func (c *ChainConfig) IsOptimism() bool {
 	return c.Optimism != nil
+}
+
+// IsOptimismGenesisBlock returns true if the given block number is the genesis block for this
+// Optimism chain. For OP Mainnet (chain ID 10), the genesis block is 105235063. For all other
+// OP chains, the genesis block is 0.
+func (c *ChainConfig) IsOptimismGenesisBlock(num *big.Int) bool {
+	if !c.IsOptimism() || num == nil {
+		return false
+	}
+	if c.ChainID.Uint64() == OPMainnetChainID {
+		return num.Uint64() == OPMainnetGenesisBlockNum
+	}
+	return num.Uint64() == 0
 }
 
 // IsOptimismBedrock returns true iff this is an optimism node & bedrock is active

--- a/params/config.go
+++ b/params/config.go
@@ -36,10 +36,10 @@ var (
 )
 
 const (
-	OPMainnetChainID          = 10
-	OPMainnetGenesisBlockNum  = 105235063
-	BaseMainnetChainID        = 8453
-	baseSepoliaChainID        = 84532
+	OPMainnetChainID         = 10
+	OPMainnetGenesisBlockNum = 105235063
+	BaseMainnetChainID       = 8453
+	baseSepoliaChainID       = 84532
 )
 
 func newUint64(val uint64) *uint64 { return &val }
@@ -1041,10 +1041,10 @@ func (c *ChainConfig) IsOptimismGenesisBlock(num *big.Int) bool {
 	if !c.IsOptimism() || num == nil {
 		return false
 	}
-	if c.ChainID.Uint64() == OPMainnetChainID {
+	if c.ChainID.Cmp(big.NewInt(OPMainnetChainID)) == 0 {
 		return num.Uint64() == OPMainnetGenesisBlockNum
 	}
-	return num.Uint64() == 0
+	return num.Sign() == 0
 }
 
 // IsOptimismBedrock returns true iff this is an optimism node & bedrock is active

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -364,3 +364,41 @@ func TestCheckOptimismValidity(t *testing.T) {
 func ptr[T any](t T) *T {
 	return &t
 }
+
+func TestIsOptimismGenesisBlock(t *testing.T) {
+	highChainID := new(big.Int)
+	highChainID.SetString("99918446744073709551615", 10)
+	highBlockNum := new(big.Int)
+	highBlockNum.SetString("18446744073709551616", 10) // Uint64 max + 1, resulting in Uint64 overflow, and Uint64 equal to 0
+	tests := []struct {
+		name    string
+		chainID *big.Int
+		blockNo *big.Int
+		want    bool
+	}{
+		{"OP Mainnet genesis", big.NewInt(OPMainnetChainID), big.NewInt(OPMainnetGenesisBlockNum), true},
+		{"OP Mainnet non-genesis", big.NewInt(OPMainnetChainID), big.NewInt(0), false},
+		{"OP Mainnet non-genesis high", big.NewInt(OPMainnetChainID), big.NewInt(OPMainnetGenesisBlockNum + 1), false},
+		{"other chain genesis", big.NewInt(42069), big.NewInt(0), true},
+		{"other chain non-genesis", big.NewInt(42069), big.NewInt(1), false},
+		{"Base genesis", big.NewInt(BaseMainnetChainID), big.NewInt(0), true},
+		{"chain with a high chain id", highChainID, big.NewInt(0), true},
+		{"chain with a high block num", highChainID, highBlockNum, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &ChainConfig{
+				ChainID:  tt.chainID,
+				Optimism: &OptimismConfig{},
+			}
+			got := c.IsOptimismGenesisBlock(tt.blockNo)
+			require.Equal(t, tt.want, got)
+		})
+	}
+	// non-optimism chain always returns false
+	c := &ChainConfig{ChainID: big.NewInt(1)}
+	require.False(t, c.IsOptimismGenesisBlock(big.NewInt(0)))
+	// nil block number returns false
+	c.Optimism = &OptimismConfig{}
+	require.False(t, c.IsOptimismGenesisBlock(nil))
+}


### PR DESCRIPTION
The validation added in `0ab188d73` rejects non-empty extraData for pre-Holocene blocks, but genesis blocks of OP chains have non-empty extraData.

Add `ChainConfig.IsOptimismGenesisBlock` to identify genesis blocks (block 105235063 for OP Mainnet, block 0 for all other OP chains) and skip the validation for them.