### PR TITLE
txpool: drop interop transactions on reorg 

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -1507,7 +1507,7 @@ func filterInteropTxs(txs []*types.Transaction) []*types.Transaction {
 	filtered := make([]*types.Transaction, 0, len(txs))
 	for _, tx := range txs {
 		if len(interoptypes.TxToInteropAccessList(tx)) > 0 {
-			log.Debug("Dropping interop transaction during reorg", "hash", tx.Hash())
+			log.Warn("Dropping interop transaction during reorg", "hash", tx.Hash())
 			continue
 		}
 		filtered = append(filtered, tx)

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -35,6 +35,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/types/interoptypes"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
@@ -1471,6 +1472,9 @@ func (pool *LegacyPool) reset(oldHead, newHead *types.Header) {
 						lost = append(lost, tx)
 					}
 				}
+				if len(pool.ingressFilters) > 0 {
+					lost = filterInteropTxs(lost)
+				}
 				reinject = lost
 			}
 		}
@@ -1495,6 +1499,20 @@ func (pool *LegacyPool) reset(oldHead, newHead *types.Header) {
 	log.Debug("Reinjecting stale transactions", "count", len(reinject))
 	core.SenderCacher().Recover(pool.signer, reinject)
 	pool.addTxsLocked(reinject)
+}
+
+// filterInteropTxs returns a copy of txs with interop executing messages removed.
+// Interop txs are identified by having access list entries targeting CrossL2InboxAddress.
+func filterInteropTxs(txs []*types.Transaction) []*types.Transaction {
+	filtered := make([]*types.Transaction, 0, len(txs))
+	for _, tx := range txs {
+		if len(interoptypes.TxToInteropAccessList(tx)) > 0 {
+			log.Debug("Dropping interop transaction during reorg", "hash", tx.Hash())
+			continue
+		}
+		filtered = append(filtered, tx)
+	}
+	return filtered
 }
 
 func (pool *LegacyPool) resetRollupCostFn(ts uint64, statedb *state.StateDB) {

--- a/core/txpool/legacypool/legacypool_test.go
+++ b/core/txpool/legacypool/legacypool_test.go
@@ -2847,3 +2847,38 @@ func TestTxPoolMaxTxGasLimitDisabled(t *testing.T) {
 		t.Errorf("Expected transaction to be accepted when MaxTxGasLimit is disabled, got %v", err)
 	}
 }
+
+func TestInteropTxDroppedOnReorg(t *testing.T) {
+	t.Parallel()
+
+	pool, key := setupPool()
+	defer pool.Close()
+
+	// Create a normal transaction (no access list)
+	normalTx := pricedTransaction(0, 100000, big.NewInt(1), key)
+
+	// Create an interop transaction (access list targeting CrossL2InboxAddress)
+	interopTx, _ := types.SignNewTx(key, types.LatestSignerForChainID(params.TestChainConfig.ChainID), &types.AccessListTx{
+		ChainID:  params.TestChainConfig.ChainID,
+		Nonce:    1,
+		GasPrice: big.NewInt(1),
+		Gas:      100000,
+		To:       &common.Address{},
+		Value:    big.NewInt(100),
+		AccessList: types.AccessList{
+			{Address: params.InteropCrossL2InboxAddress, StorageKeys: []common.Hash{{0x01}}},
+		},
+	})
+
+	txs := []*types.Transaction{normalTx, interopTx}
+
+	// filterInteropTxs removes interop txs — the caller gates on
+	// len(pool.ingressFilters) > 0 to decide whether to call it.
+	lost := filterInteropTxs(txs)
+	if len(lost) != 1 {
+		t.Fatalf("expected 1 reinjected tx after filtering, got %d", len(lost))
+	}
+	if lost[0].Hash() != normalTx.Hash() {
+		t.Fatal("expected only the normal tx to survive interop filtering")
+	}
+}


### PR DESCRIPTION
## Summary
- Interop executing messages (targeting CrossL2InboxAddress) depend on cross-chain state that may be invalidated by reorgs.
- When discarded blocks are walked during a reorg, `filterInteropTxs` removes interop txs from the reinject set so they aren't re-added to the pool.
- Gated on `len(pool.ingressFilters) > 0`.

## Design Decision
We intentionally **drop** interop transactions when there is a reorg instead of attempting to keep them around. I think this is safe because interop transactions are **not initiated by end users** and therefore can be trivially inserted by the relayer or sequencer. Making this simplification is preferable to adding additional complexity to the already complex mempool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)