### PR TITLE
fix: filter interop txs on reorg based on chain config

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -1478,7 +1478,7 @@ func (pool *LegacyPool) reset(oldHead, newHead *types.Header) {
 						lost = append(lost, tx)
 					}
 				}
-				if len(pool.ingressFilters) > 0 {
+				if pool.chainconfig.IsInterop(newHead.Time) {
 					lost = filterInteropTxs(lost)
 				}
 				reinject = lost


### PR DESCRIPTION
**Description**

Previously, the interop txs would only get dropped on reorg if pool.ingressFilters was set, which requires passing a supervisor RPC URL.

Not all tests were doing this when setting up the supernode interop environment, because supervisor is deprecated and the supernode devstack presets don't need to set a supervisor RPC endpoint anymore, leading to tests crash-looping because the filters were never enabled.

It makes more sense to always filter interop transactions if interop is active on the chain config at the current timestamp instead.

**Tests**

Checked with [`TestSupernodeInteropInvalidMessageReplacement`](https://github.com/ethereum-optimism/optimism/blob/79877d57277d8b207328f6e14f6df7d57cf37603/op-acceptance-tests/tests/supernode/interop/reorg/invalid_message_reorg_test.go#L26) which was previously not activating the filter, now it correctly activates the filter.

**Additional context**

Check added in #772
