### PR TITLE
chore: bump Go to 1.24.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG VERSION=""
 ARG BUILDNUM=""
 
 # Build Geth in a stock Go builder container
-FROM golang:1.24-alpine3.22 AS builder
+FROM golang:1.24.13-alpine3.22 AS builder
 
 RUN apk add --no-cache gcc musl-dev linux-headers git
 

--- a/Dockerfile.alltools
+++ b/Dockerfile.alltools
@@ -4,7 +4,7 @@ ARG VERSION=""
 ARG BUILDNUM=""
 
 # Build Geth in a stock Go builder container
-FROM golang:1.24-alpine3.22 AS builder
+FROM golang:1.24.13-alpine3.22 AS builder
 
 RUN apk add --no-cache gcc musl-dev linux-headers git
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/ethereum/go-ethereum
 
 go 1.24.0
 
+toolchain go1.24.13
+
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.2.0
 	github.com/BurntSushi/toml v1.4.0


### PR DESCRIPTION
## Summary

- Add `toolchain go1.24.13` to go.mod to pin the Go compiler version.
- Pin Docker builder images from `golang:1.24-alpine3.22` (floating) to `golang:1.24.13-alpine3.22`.
- Runtime base image (`alpine:3.22`) is unchanged.

### Go stdlib CVEs mitigated

**CVE-2025-68121** — Critical — crypto/tls — TLS session resumption auth bypass — https://github.com/advisories/GHSA-h355-32pf-p2xm
**CVE-2025-61732** — High — go command — Cgo comment parsing allows code smuggling — https://github.com/advisories/GHSA-8jvr-vh7g-f8gx
**CVE-2025-61731** — High — go command — pkg-config directive allows arbitrary file write — https://github.com/advisories/GHSA-xvqr-69v8-f3gv
**CVE-2025-61729** — High — crypto/x509 — Quadratic runtime via malicious certificate — https://github.com/advisories/GHSA-7c64-f9jr-v9h2
**CVE-2025-61726** — High — net/url — Unlimited query params causes memory exhaustion — https://github.com/advisories/GHSA-gm9r-q53w-2gh4
**CVE-2025-61728** — Medium — archive/zip — Malicious ZIP causes DoS via file name indexing — https://github.com/advisories/GHSA-g9q4-qjx4-2v7q
**CVE-2025-61727** — Medium — crypto/x509 — Wildcard SANs bypass subdomain constraints — https://github.com/advisories/GHSA-5mh9-3jwc-rp59
**CVE-2025-61730** — Medium — crypto/tls — TLS 1.3 handshake info disclosure — https://github.com/advisories/GHSA-gr56-3gp6-6gmj

Mirrors the same change in the monorepo (ethereum-optimism/optimism#19666).

## Test plan

- [ ] CI passes
- [ ] Docker image builds succeed