### PR TITLE
fix: guard CalcBaseFee against divide-by-zero from malformed extraData

### DIFF
--- a/consensus/misc/eip1559/eip1559.go
+++ b/consensus/misc/eip1559/eip1559.go
@@ -60,7 +60,6 @@ func VerifyEIP1559Header(config *params.ChainConfig, parent, header *types.Heade
 
 // CalcBaseFee calculates the basefee of the header.
 // The time belongs to the new block to check which upgrades are active.
-// It is assumed the parent Header has valid extraData.
 func CalcBaseFee(config *params.ChainConfig, parent *types.Header, time uint64) *big.Int {
 	// If the current block is the first EIP-1559 block, return the InitialBaseFee.
 	if !config.IsLondon(parent.Number) {
@@ -74,8 +73,13 @@ func CalcBaseFee(config *params.ChainConfig, parent *types.Header, time uint64) 
 	// OPStack addition: from Holocene onwards, decode
 	// denominator, elasticity and minBaseFee from
 	// the extra data using optimism-specific rules.
+	// Only override the chain-config defaults if the parent extraData is valid.
+	// The decoders use best-effort logic and return zeros on malformed input,
+	// which would cause a divide-by-zero panic in calcBaseFeeInner.
 	if config.IsOptimismHolocene(parent.Time) {
-		denominator, elasticity, minBaseFee = DecodeOptimismExtraData(config, parent.Time, parent.Extra)
+		if err := ValidateOptimismExtraData(config, parent.Time, parent.Extra); err == nil {
+			denominator, elasticity, minBaseFee = DecodeOptimismExtraData(config, parent.Time, parent.Extra)
+		}
 	}
 
 	// OPStack addition: calculate the base fee using the upstream code.

--- a/consensus/misc/eip1559/eip1559_test.go
+++ b/consensus/misc/eip1559/eip1559_test.go
@@ -194,7 +194,82 @@ func TestCalcBaseFeeOptimism(t *testing.T) {
 	}
 }
 
-// TestCalcBaseFeeOptimismHolocene assumes all blocks are Optimism blocks post-Holocene upgrade
+// TestCalcBaseFeeOptimismMalformedExtraData verifies that CalcBaseFee does not
+// panic when the parent header has malformed extraData and instead falls back to
+// chain-config defaults. This is a regression test for op-geth#757.
+func TestCalcBaseFeeOptimismMalformedExtraData(t *testing.T) {
+	cfg := opConfig()
+	parentGasLimit := uint64(30_000_000)
+	parentBaseFee := int64(10_000_000)
+
+	malformedExtras := []struct {
+		name  string
+		extra []byte
+		time  uint64
+	}{
+		{"holocene_empty", []byte{}, testHoloceneTime},
+		{"holocene_short", []byte{0x01}, testHoloceneTime},
+		{"holocene_wrong_len", []byte{0x00, 0x01, 0x02}, testHoloceneTime},
+		{"holocene_wrong_version", append([]byte{0xFF}, make([]byte, 8)...), testHoloceneTime},
+		{"holocene_zero_denom_elasticity", EncodeHoloceneExtraData(0, 0), testHoloceneTime},
+		{"holocene_zero_elasticity", EncodeHoloceneExtraData(10, 0), testHoloceneTime},
+		{"holocene_zero_denominator", EncodeHoloceneExtraData(0, 6), testHoloceneTime},
+		{"jovian_empty", []byte{}, testJovianTime},
+		{"jovian_short", []byte{0x01, 0x02}, testJovianTime},
+		{"jovian_wrong_len", make([]byte, 10), testJovianTime},
+	}
+
+	for _, tc := range malformedExtras {
+		t.Run(tc.name, func(t *testing.T) {
+			parent := &types.Header{
+				Number:   common.Big32,
+				GasLimit: parentGasLimit,
+				GasUsed:  parentGasLimit / 2,
+				BaseFee:  big.NewInt(parentBaseFee),
+				Time:     tc.time,
+				Extra:    tc.extra,
+			}
+			if cfg.IsJovian(tc.time) {
+				blobGas := uint64(0)
+				parent.BlobGasUsed = &blobGas
+			}
+
+			require.NotPanics(t, func() {
+				baseFee := CalcBaseFee(cfg, parent, tc.time+2)
+				require.NotNil(t, baseFee)
+			})
+		})
+	}
+}
+
+// TestCalcBaseFeeOptimismMalformedFallsBackToConfig verifies that malformed
+// parent extraData causes CalcBaseFee to use chain-config defaults rather than
+// the decoded zeros.
+func TestCalcBaseFeeOptimismMalformedFallsBackToConfig(t *testing.T) {
+	cfg := opConfig()
+	parentGasLimit := uint64(30_000_000)
+	parentBaseFee := int64(10_000_000)
+
+	parent := &types.Header{
+		Number:   common.Big32,
+		GasLimit: parentGasLimit,
+		GasUsed:  parentGasLimit / 2,
+		BaseFee:  big.NewInt(parentBaseFee),
+		Time:     testHoloceneTime,
+		Extra:    []byte{0x01}, // invalid: will fail ValidateOptimismExtraData
+	}
+
+	malformedResult := CalcBaseFee(cfg, parent, parent.Time+2)
+
+	// Compute the expected result using chain-config defaults (Canyon denominator=250, elasticity=6).
+	// gas target = 30M/6 = 5M, gasUsed = 15M (half of limit), so gasUsed > target.
+	// gasUsedDelta = 15M - 5M = 10M
+	// increase = parentBaseFee * gasUsedDelta / gasTarget / denominator
+	//          = 10M * 10M / 5M / 250 = 80000
+	// expectedBaseFee = 10M + 80000 = 10_080_000
+	expected := big.NewInt(10_080_000)
+	require.Equal(t, expected, malformedResult, "malformed extraData should fall back to chain-config defaults")
+}
 func TestCalcBaseFeeOptimismHolocene(t *testing.T) {
 	parentBaseFee := int64(10_000_000)
 	parentGasLimit := uint64(30_000_000)

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/tracing"
@@ -736,6 +737,11 @@ func (g *Genesis) Commit(db ethdb.Database, triedb *triedb.Database, tracer *tra
 	}
 	if config.Clique != nil && len(g.ExtraData) < 32+crypto.SignatureLength {
 		return nil, errors.New("can't start clique chain without signers")
+	}
+	if config.IsOptimism() && config.IsOptimismHolocene(g.Timestamp) {
+		if err := eip1559.ValidateOptimismExtraData(config, g.Timestamp, g.ExtraData); err != nil {
+			return nil, fmt.Errorf("invalid optimism genesis extraData: %w", err)
+		}
 	}
 	var stateRoot, storageRootMessagePasser common.Hash
 	var err error


### PR DESCRIPTION
## Summary

Fixes #757

`CalcBaseFee` unconditionally decoded Holocene/Jovian `extraData` from the parent header and passed the result to `calcBaseFeeInner`. The decoders use best-effort logic and return `0, 0` on malformed input, which causes a divide-by-zero panic:
- `elasticity == 0` panics on integer division (`parent.GasLimit / elasticity`)
- `denominator == 0` panics on `big.Int.Div`

### Root cause

The precondition documented in `CalcBaseFee` ("It is assumed the parent Header has valid extraData") is not upheld by all callers. Many non-consensus callers (RPC pending tx, fee history, GraphQL, txpool repricing, blobpool, miner, simulate, t8ntool) use `CalcBaseFee` on headers they assume are valid. A malformed parent header already present locally will trigger the panic.

Additionally, chains activating Holocene or Jovian at genesis can hit this because:
- Genesis `ExtraData` is written without Optimism-specific validation (`core/genesis.go`)
- Consensus header validation explicitly skips the genesis block (`consensus/beacon/consensus.go`)
- Block 1 calls `CalcBaseFee` on the genesis parent, triggering the panic

### Changes

1. **`consensus/misc/eip1559/eip1559.go`**: Gate the `DecodeOptimismExtraData` call behind `ValidateOptimismExtraData`. If the parent `extraData` is invalid, chain-config defaults are preserved instead of zero values. No API signature changes.

2. **`core/genesis.go`**: Reject invalid Optimism `extraData` at genesis commit time for chains that activate Holocene or later at genesis.

3. **`consensus/misc/eip1559/eip1559_test.go`**: Add regression tests:
   - `TestCalcBaseFeeOptimismMalformedExtraData`: 10 sub-tests covering empty, short, wrong-version, wrong-length, zero-denominator, zero-elasticity, and both-zero `extraData` for both Holocene and Jovian parent times. Asserts no panic.
   - `TestCalcBaseFeeOptimismMalformedFallsBackToConfig`: Verifies that malformed `extraData` produces the same base fee as chain-config defaults (Canyon denominator/elasticity), not zeros.

### What this does NOT change

- `ValidateHolocene1559Params` is not tightened. `(0, 0)` in payload attributes is an intentional sentinel per the [Holocene spec](https://specs.optimism.io/protocol/holocene/exec-engine.html).
- Consensus header validation already rejects zero denominator/elasticity in `extraData` via `ValidateOptimismExtraData` in `beacon.verifyHeader`.

## Test plan

- [x] All 30 existing + new tests pass (`go test ./consensus/misc/eip1559/ -v`)
- [x] `go build ./core/` compiles cleanly
- [ ] CI passes