### PR TITLE
feat: call interop_checkAccessList instead of supervisor_checkAccessList

### DIFF
--- a/eth/interop/interop.go
+++ b/eth/interop/interop.go
@@ -52,7 +52,7 @@ func (cl *InteropClient) CheckAccessList(ctx context.Context, inboxEntries []com
 	if err := cl.maybeDial(ctx); err != nil {
 		return err
 	}
-	err := cl.client.CallContext(ctx, nil, "supervisor_checkAccessList", inboxEntries, minSafety, executingDescriptor)
+	err := cl.client.CallContext(ctx, nil, "interop_checkAccessList", inboxEntries, minSafety, executingDescriptor)
 	return err
 }
 


### PR DESCRIPTION
The interop filter now exposes the access-list check under a new `interop` RPC namespace; the deprecated `supervisor` namespace will be removed.

Requires ethereum-optimism/optimism#20778 (adds the `interop` namespace alongside `supervisor`) to be deployed everywhere this op-geth talks to before merging.

Refs ethereum-optimism/optimism#20005.