### PR TITLE
feat(ethapi): implement eth_baseFee RPC method

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/filtermaps"
@@ -465,6 +466,14 @@ func (b *EthAPIBackend) FeeHistory(ctx context.Context, blockCount uint64, lastB
 func (b *EthAPIBackend) BlobBaseFee(ctx context.Context) *big.Int {
 	if excess := b.CurrentHeader().ExcessBlobGas; excess != nil {
 		return eip4844.CalcBlobFee(b.ChainConfig(), b.CurrentHeader())
+	}
+	return nil
+}
+
+func (b *EthAPIBackend) BaseFee(ctx context.Context) *big.Int {
+	head := b.CurrentHeader()
+	if b.ChainConfig().IsLondon(head.Number) {
+		return eip1559.CalcBaseFee(b.ChainConfig(), head, head.Time+1)
 	}
 	return nil
 }

--- a/eth/api_backend_test.go
+++ b/eth/api_backend_test.go
@@ -28,6 +28,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/beacon"
 	"github.com/ethereum/go-ethereum/consensus/ethash"
+	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
+	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/txpool"
@@ -179,4 +181,70 @@ func testSendTx(t *testing.T, withLocal bool) {
 			t.Fatalf("Unexpected error, want: %v, got: %v", txpool.ErrInflightTxLimitReached, err)
 		}
 	}
+}
+
+func TestEthAPIBackendBaseFee(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("london_active", func(t *testing.T) {
+		b := initBackend(false)
+		head := b.CurrentHeader()
+		want := eip1559.CalcBaseFee(b.ChainConfig(), head, head.Time+1)
+		got := b.BaseFee(ctx)
+		if got == nil {
+			t.Fatal("BaseFee() returned nil for London-active chain")
+		}
+		if got.Cmp(want) != 0 {
+			t.Errorf("BaseFee() = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("pre_london", func(t *testing.T) {
+		cfg := &params.ChainConfig{
+			ChainID:        big.NewInt(1337),
+			HomesteadBlock: big.NewInt(0),
+			Ethash:         new(params.EthashConfig),
+		}
+		gs := &core.Genesis{Config: cfg, Difficulty: big.NewInt(1)}
+		db := rawdb.NewMemoryDatabase()
+		chain, err := core.NewBlockChain(db, gs, ethash.NewFaker(), nil)
+		if err != nil {
+			t.Fatalf("NewBlockChain: %v", err)
+		}
+		b := &EthAPIBackend{eth: &Ethereum{blockchain: chain}}
+		if got := b.BaseFee(ctx); got != nil {
+			t.Errorf("BaseFee() = %v, want nil", got)
+		}
+	})
+}
+
+func TestEthAPIBackendBlobBaseFee(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("cancun_active", func(t *testing.T) {
+		b := initBackend(false)
+		head := b.CurrentHeader()
+		want := eip4844.CalcBlobFee(b.ChainConfig(), head)
+		got := b.BlobBaseFee(ctx)
+		if got == nil {
+			t.Fatal("BlobBaseFee() returned nil for Cancun-active chain")
+		}
+		if got.Cmp(want) != 0 {
+			t.Errorf("BlobBaseFee() = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("pre_cancun", func(t *testing.T) {
+		// TestChainConfig has London active but no CancunTime, so ExcessBlobGas is never set.
+		gs := &core.Genesis{Config: params.TestChainConfig, Difficulty: big.NewInt(1)}
+		db := rawdb.NewMemoryDatabase()
+		chain, err := core.NewBlockChain(db, gs, ethash.NewFaker(), nil)
+		if err != nil {
+			t.Fatalf("NewBlockChain: %v", err)
+		}
+		b := &EthAPIBackend{eth: &Ethereum{blockchain: chain}}
+		if got := b.BlobBaseFee(ctx); got != nil {
+			t.Errorf("BlobBaseFee() = %v, want nil", got)
+		}
+	})
 }

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -146,6 +146,11 @@ func (api *EthereumAPI) BlobBaseFee(ctx context.Context) *hexutil.Big {
 	return (*hexutil.Big)(api.b.BlobBaseFee(ctx))
 }
 
+// BaseFee returns the base fee for the next block.
+func (api *EthereumAPI) BaseFee(ctx context.Context) *hexutil.Big {
+	return (*hexutil.Big)(api.b.BaseFee(ctx))
+}
+
 // Syncing returns false in case the node is currently not syncing with the network. It can be up-to-date or has not
 // yet received the latest block headers from its peers. In case it is synchronizing:
 // - startingBlock: block number this node started to synchronize from

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -658,6 +658,7 @@ func (b testBackend) FeeHistory(ctx context.Context, blockCount uint64, lastBloc
 	return nil, nil, nil, nil, nil, nil, nil
 }
 func (b testBackend) BlobBaseFee(ctx context.Context) *big.Int { return new(big.Int) }
+func (b testBackend) BaseFee(ctx context.Context) *big.Int     { return new(big.Int) }
 func (b testBackend) ChainDb() ethdb.Database                  { return b.db }
 func (b testBackend) AccountManager() *accounts.Manager        { return b.accman }
 func (b testBackend) ExtRPCEnabled() bool                      { return false }

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -46,6 +46,7 @@ type Backend interface {
 	SuggestGasTipCap(ctx context.Context) (*big.Int, error)
 	FeeHistory(ctx context.Context, blockCount uint64, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (*big.Int, [][]*big.Int, []*big.Int, []float64, []*big.Int, []float64, error)
 	BlobBaseFee(ctx context.Context) *big.Int
+	BaseFee(ctx context.Context) *big.Int
 	ChainDb() ethdb.Database
 	AccountManager() *accounts.Manager
 	ExtRPCEnabled() bool

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -318,6 +318,7 @@ func (b *backendMock) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
 	return big.NewInt(42), nil
 }
 func (b *backendMock) BlobBaseFee(ctx context.Context) *big.Int { return big.NewInt(42) }
+func (b *backendMock) BaseFee(ctx context.Context) *big.Int     { return big.NewInt(42) }
 
 func (b *backendMock) CurrentHeader() *types.Header     { return b.current }
 func (b *backendMock) ChainConfig() *params.ChainConfig { return b.config }


### PR DESCRIPTION
**Description**

Adds the nonstandard RPC method `eth_baseFee`, which returns the base fee of the next block, analogous to `eth_blobBaseFee`.
It is useful for certain advanced gas pricing strategies.

**Tests**

The method delegates to a function that already has tests, and there is no existing test for `eth_blobBaseFee`, but because I found similar tests for some other api methods, I added tests for `eth_baseFee` and `eth_blobBaseFee`, covering both pre-London and post-London.

**Additional context**

I am making [an effort](https://github.com/ethereum/execution-apis/pull/795) to standardize this method, but even if it is not accepted, it is still a useful method and fairly easy to maintain.
I have been adding it to every Ethereum client I can find.