### PR TITLE
chore(docker): switch runtime base image for smaller runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,9 @@ RUN cd /go-ethereum && go mod download
 ADD . /go-ethereum
 RUN cd /go-ethereum && go run build/ci.go install -static ./cmd/geth
 
-# Pull Geth into a second stage deploy alpine container
-FROM alpine:latest
+# Pull Geth into a second stage deploy minimal container
+FROM chainguard/static:latest
 
-RUN apk add --no-cache ca-certificates
 COPY --from=builder /go-ethereum/build/bin/geth /usr/local/bin/
 
 EXPOSE 8545 8546 30303 30303/udp


### PR DESCRIPTION
## Summary

Swap the runtime stage base image to a smaller, leaner alternative. Builder stage unchanged.

## What changed

- `Dockerfile` runtime stage: `alpine:latest` → `chainguard/static:latest` (distroless, shell-less, ca-certs included)
- Dropped the `apk add --no-cache ca-certificates` line — `chainguard/static` ships `ca-certificates-bundle` by default.

The `geth` binary is already built with `-static` (see `go run build/ci.go install -static ./cmd/geth`), so a libc-less runtime works.

## Testing

`docker buildx build --platform linux/amd64` succeeds. `geth version` runs cleanly from the built image.
