### PR TITLE
Cherry-pick BAL-related changes from upstream

### DIFF
--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -302,12 +302,22 @@ func (beacon *Beacon) verifyHeader(chain consensus.ChainHeaderReader, header, pa
 		}
 	}
 
+	// Verify the existence / non-existence of Amsterdam-specific header fields
 	amsterdam := chain.Config().IsAmsterdam(header.Number, header.Time)
-	if amsterdam && header.SlotNumber == nil {
-		return errors.New("header is missing slotNumber")
-	}
-	if !amsterdam && header.SlotNumber != nil {
-		return fmt.Errorf("invalid slotNumber: have %d, expected nil", *header.SlotNumber)
+	if amsterdam {
+		if header.BlockAccessListHash == nil {
+			return errors.New("header is missing block access list hash")
+		}
+		if header.SlotNumber == nil {
+			return errors.New("header is missing slotNumber")
+		}
+	} else {
+		if header.BlockAccessListHash != nil {
+			return fmt.Errorf("invalid block access list hash: have %x, expected nil", *header.BlockAccessListHash)
+		}
+		if header.SlotNumber != nil {
+			return fmt.Errorf("invalid slotNumber: have %d, expected nil", *header.SlotNumber)
+		}
 	}
 	return nil
 }

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/types/bal"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
@@ -604,6 +605,55 @@ func DeleteReceipts(db ethdb.KeyValueWriter, hash common.Hash, number uint64) {
 	}
 }
 
+// HasAccessList verifies the existence of a block access list for a block.
+func HasAccessList(db ethdb.Reader, hash common.Hash, number uint64) bool {
+	has, _ := db.Has(accessListKey(number, hash))
+	return has
+}
+
+// ReadAccessListRLP retrieves the RLP-encoded block access list for a block from KV.
+func ReadAccessListRLP(db ethdb.Reader, hash common.Hash, number uint64) rlp.RawValue {
+	data, _ := db.Get(accessListKey(number, hash))
+	return data
+}
+
+// ReadAccessList retrieves and decodes the block access list for a block.
+func ReadAccessList(db ethdb.Reader, hash common.Hash, number uint64) *bal.BlockAccessList {
+	data := ReadAccessListRLP(db, hash, number)
+	if len(data) == 0 {
+		return nil
+	}
+	b := new(bal.BlockAccessList)
+	if err := rlp.DecodeBytes(data, b); err != nil {
+		log.Error("Invalid BAL RLP", "hash", hash, "err", err)
+		return nil
+	}
+	return b
+}
+
+// WriteAccessList RLP-encodes and stores a block access list in the active KV store.
+func WriteAccessList(db ethdb.KeyValueWriter, hash common.Hash, number uint64, b *bal.BlockAccessList) {
+	bytes, err := rlp.EncodeToBytes(b)
+	if err != nil {
+		log.Crit("Failed to encode BAL", "err", err)
+	}
+	WriteAccessListRLP(db, hash, number, bytes)
+}
+
+// WriteAccessListRLP stores a pre-encoded block access list in the active KV store.
+func WriteAccessListRLP(db ethdb.KeyValueWriter, hash common.Hash, number uint64, encoded rlp.RawValue) {
+	if err := db.Put(accessListKey(number, hash), encoded); err != nil {
+		log.Crit("Failed to store BAL", "err", err)
+	}
+}
+
+// DeleteAccessList removes a block access list from the active KV store.
+func DeleteAccessList(db ethdb.KeyValueWriter, hash common.Hash, number uint64) {
+	if err := db.Delete(accessListKey(number, hash)); err != nil {
+		log.Crit("Failed to delete BAL", "err", err)
+	}
+}
+
 // ReceiptLogs is a barebone version of ReceiptForStorage which only keeps
 // the list of logs. When decoding a stored receipt into this object we
 // avoid creating the bloom filter.
@@ -658,13 +708,25 @@ func ReadBlock(db ethdb.Reader, hash common.Hash, number uint64) *types.Block {
 	if body == nil {
 		return nil
 	}
-	return types.NewBlockWithHeader(header).WithBody(*body)
+	block := types.NewBlockWithHeader(header).WithBody(*body)
+
+	// Best-effort assembly of the block access list from the database.
+	if header.BlockAccessListHash != nil {
+		al := ReadAccessList(db, hash, number)
+		block = block.WithAccessListUnsafe(al)
+	}
+	return block
 }
 
 // WriteBlock serializes a block into the database, header and body separately.
 func WriteBlock(db ethdb.KeyValueWriter, block *types.Block) {
-	WriteBody(db, block.Hash(), block.NumberU64(), block.Body())
+	hash, number := block.Hash(), block.NumberU64()
+	WriteBody(db, hash, number, block.Body())
 	WriteHeader(db, block.Header())
+
+	if accessList := block.AccessList(); accessList != nil {
+		WriteAccessList(db, hash, number, accessList)
+	}
 }
 
 // WriteAncientBlocks writes entire block data into ancient store and returns the total written size.

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -28,10 +28,12 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/types/bal"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/keccak"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/holiman/uint256"
 )
 
 // Tests block header storage and retrieval operations.
@@ -924,4 +926,79 @@ func TestHeadersRLPStorage(t *testing.T) {
 	checkSequence(0, 1)    // Only genesis
 	checkSequence(1, 1)    // Only block 1
 	checkSequence(1, 2)    // Genesis + block 1
+}
+
+func makeTestBAL(t *testing.T) (rlp.RawValue, *bal.BlockAccessList) {
+	t.Helper()
+
+	cb := bal.NewConstructionBlockAccessList()
+	addr := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	cb.AccountRead(addr)
+	cb.StorageRead(addr, common.BytesToHash([]byte{0x01}))
+	cb.StorageWrite(0, addr, common.BytesToHash([]byte{0x02}), common.BytesToHash([]byte{0xaa}))
+	cb.BalanceChange(0, addr, uint256.NewInt(100))
+	cb.NonceChange(addr, 0, 1)
+
+	var buf bytes.Buffer
+	if err := cb.EncodeRLP(&buf); err != nil {
+		t.Fatalf("failed to encode BAL: %v", err)
+	}
+	encoded := buf.Bytes()
+
+	var decoded bal.BlockAccessList
+	if err := rlp.DecodeBytes(encoded, &decoded); err != nil {
+		t.Fatalf("failed to decode BAL: %v", err)
+	}
+	return encoded, &decoded
+}
+
+// TestBALStorage tests write/read/delete of BALs in the KV store.
+func TestBALStorage(t *testing.T) {
+	db := NewMemoryDatabase()
+
+	hash := common.BytesToHash([]byte{0x03, 0x14})
+	number := uint64(42)
+
+	// Check that no BAL exists in a new database.
+	if HasAccessList(db, hash, number) {
+		t.Fatal("BAL found in new database")
+	}
+	if b := ReadAccessList(db, hash, number); b != nil {
+		t.Fatalf("non existent BAL returned: %v", b)
+	}
+
+	// Write a BAL and verify it can be read back.
+	encoded, testBAL := makeTestBAL(t)
+	WriteAccessList(db, hash, number, testBAL)
+
+	if !HasAccessList(db, hash, number) {
+		t.Fatal("HasAccessList returned false after write")
+	}
+	if blob := ReadAccessListRLP(db, hash, number); len(blob) == 0 {
+		t.Fatal("ReadAccessListRLP returned empty after write")
+	}
+	if b := ReadAccessList(db, hash, number); b == nil {
+		t.Fatal("ReadAccessList returned nil after write")
+	} else if b.Hash() != testBAL.Hash() {
+		t.Fatalf("BAL hash mismatch: got %x, want %x", b.Hash(), testBAL.Hash())
+	}
+
+	// Also test WriteAccessListRLP with pre-encoded data.
+	hash2 := common.BytesToHash([]byte{0x03, 0x15})
+	WriteAccessListRLP(db, hash2, number, encoded)
+	if b := ReadAccessList(db, hash2, number); b == nil {
+		t.Fatal("ReadAccessList returned nil after WriteAccessListRLP")
+	} else if b.Hash() != testBAL.Hash() {
+		t.Fatalf("BAL hash mismatch after WriteAccessListRLP: got %x, want %x", b.Hash(), testBAL.Hash())
+	}
+
+	// Delete the BAL and verify it's gone.
+	DeleteAccessList(db, hash, number)
+
+	if HasAccessList(db, hash, number) {
+		t.Fatal("HasAccessList returned true after delete")
+	}
+	if b := ReadAccessList(db, hash, number); b != nil {
+		t.Fatalf("deleted BAL returned: %v", b)
+	}
 }

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -413,6 +413,7 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 		tds                stat
 		numHashPairings    stat
 		hashNumPairings    stat
+		blockAccessList    stat
 		legacyTries        stat
 		stateLookups       stat
 		accountTries       stat
@@ -484,6 +485,9 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 				numHashPairings.add(size)
 			case bytes.HasPrefix(key, headerNumberPrefix) && len(key) == (len(headerNumberPrefix)+common.HashLength):
 				hashNumPairings.add(size)
+			case bytes.HasPrefix(key, accessListPrefix) && len(key) == len(accessListPrefix)+8+common.HashLength:
+				blockAccessList.add(size)
+
 			case IsLegacyTrieNode(key, it.Value()):
 				legacyTries.add(size)
 			case bytes.HasPrefix(key, stateIDPrefix) && len(key) == len(stateIDPrefix)+common.HashLength:
@@ -625,6 +629,7 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 		{"Key-Value store", "Difficulties (deprecated)", tds.sizeString(), tds.countString()},
 		{"Key-Value store", "Block number->hash", numHashPairings.sizeString(), numHashPairings.countString()},
 		{"Key-Value store", "Block hash->number", hashNumPairings.sizeString(), hashNumPairings.countString()},
+		{"Key-Value store", "Block accessList", blockAccessList.sizeString(), blockAccessList.countString()},
 		{"Key-Value store", "Transaction index", txLookups.sizeString(), txLookups.countString()},
 		{"Key-Value store", "Log index filter-map rows", filterMapRows.sizeString(), filterMapRows.countString()},
 		{"Key-Value store", "Log index last-block-of-map", filterMapLastBlock.sizeString(), filterMapLastBlock.countString()},

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -112,6 +112,7 @@ var (
 
 	blockBodyPrefix     = []byte("b") // blockBodyPrefix + num (uint64 big endian) + hash -> block body
 	blockReceiptsPrefix = []byte("r") // blockReceiptsPrefix + num (uint64 big endian) + hash -> block receipts
+	accessListPrefix    = []byte("j") // accessListPrefix + num (uint64 big endian) + hash -> block access list
 
 	txLookupPrefix        = []byte("l") // txLookupPrefix + hash -> transaction/receipt lookup metadata
 	bloomBitsPrefix       = []byte("B") // bloomBitsPrefix + bit (uint16 big endian) + section (uint64 big endian) + hash -> bloom bits
@@ -212,6 +213,11 @@ func blockBodyKey(number uint64, hash common.Hash) []byte {
 // blockReceiptsKey = blockReceiptsPrefix + num (uint64 big endian) + hash
 func blockReceiptsKey(number uint64, hash common.Hash) []byte {
 	return append(append(blockReceiptsPrefix, encodeBlockNumber(number)...), hash.Bytes()...)
+}
+
+// accessListKey = accessListPrefix + num (uint64 big endian) + hash
+func accessListKey(number uint64, hash common.Hash) []byte {
+	return append(append(accessListPrefix, encodeBlockNumber(number)...), hash.Bytes()...)
 }
 
 // txLookupKey = txLookupPrefix + hash

--- a/core/types/bal/bal_encoding.go
+++ b/core/types/bal/bal_encoding.go
@@ -350,9 +350,12 @@ func (e *BlockAccessList) PrettyPrint() string {
 }
 
 // Copy returns a deep copy of the access list
-func (e *BlockAccessList) Copy() (res BlockAccessList) {
-	for _, accountAccess := range e.Accesses {
-		res.Accesses = append(res.Accesses, accountAccess.Copy())
+func (e *BlockAccessList) Copy() *BlockAccessList {
+	cpy := &BlockAccessList{
+		Accesses: make([]AccountAccess, 0, len(e.Accesses)),
 	}
-	return
+	for _, accountAccess := range e.Accesses {
+		cpy.Accesses = append(cpy.Accesses, accountAccess.Copy())
+	}
+	return cpy
 }

--- a/core/types/bal/bal_test.go
+++ b/core/types/bal/bal_test.go
@@ -190,8 +190,8 @@ func makeTestAccountAccess(sort bool) AccountAccess {
 	}
 }
 
-func makeTestBAL(sort bool) BlockAccessList {
-	list := BlockAccessList{}
+func makeTestBAL(sort bool) *BlockAccessList {
+	list := &BlockAccessList{}
 	for i := 0; i < 5; i++ {
 		list.Accesses = append(list.Accesses, makeTestAccountAccess(sort))
 	}

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -102,7 +102,7 @@ type Header struct {
 	RequestsHash *common.Hash `json:"requestsHash" rlp:"optional"`
 
 	// BlockAccessListHash was added by EIP-7928 and is ignored in legacy headers.
-	BlockAccessListHash *common.Hash `json:"balHash" rlp:"optional"`
+	BlockAccessListHash *common.Hash `json:"blockAccessListHash" rlp:"optional"`
 
 	// SlotNumber was added by EIP-7843 and is ignored in legacy headers.
 	SlotNumber *uint64 `json:"slotNumber" rlp:"optional"`

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types/bal"
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
@@ -99,6 +100,9 @@ type Header struct {
 
 	// RequestsHash was added by EIP-7685 and is ignored in legacy headers.
 	RequestsHash *common.Hash `json:"requestsHash" rlp:"optional"`
+
+	// BlockAccessListHash was added by EIP-7928 and is ignored in legacy headers.
+	BlockAccessListHash *common.Hash `json:"balHash" rlp:"optional"`
 
 	// SlotNumber was added by EIP-7843 and is ignored in legacy headers.
 	SlotNumber *uint64 `json:"slotNumber" rlp:"optional"`
@@ -222,6 +226,7 @@ type Block struct {
 	uncles       []*Header
 	transactions Transactions
 	withdrawals  Withdrawals
+	accessList   *bal.BlockAccessList
 
 	// caches
 	hash atomic.Pointer[common.Hash]
@@ -388,9 +393,10 @@ func (b *Block) Body() *Body {
 // Accessors for body data. These do not return a copy because the content
 // of the body slices does not affect the cached hash/size in block.
 
-func (b *Block) Uncles() []*Header          { return b.uncles }
-func (b *Block) Transactions() Transactions { return b.transactions }
-func (b *Block) Withdrawals() Withdrawals   { return b.withdrawals }
+func (b *Block) Uncles() []*Header                { return b.uncles }
+func (b *Block) Transactions() Transactions       { return b.transactions }
+func (b *Block) Withdrawals() Withdrawals         { return b.withdrawals }
+func (b *Block) AccessList() *bal.BlockAccessList { return b.accessList }
 
 func (b *Block) Transaction(hash common.Hash) *Transaction {
 	for _, transaction := range b.transactions {
@@ -549,6 +555,24 @@ func (b *Block) WithBody(body Body) *Block {
 		block.uncles[i] = CopyHeader(body.Uncles[i])
 	}
 	return block
+}
+
+// WithAccessList returns a copy of the block with the given access list embedded.
+func (b *Block) WithAccessList(accessList *bal.BlockAccessList) *Block {
+	return b.WithAccessListUnsafe(accessList.Copy())
+}
+
+// WithAccessListUnsafe returns a copy of the block with the given access list
+// embedded. Note that the access list is not deep-copied; use WithAccessList
+// if the provided list may be modified by other actors.
+func (b *Block) WithAccessListUnsafe(accessList *bal.BlockAccessList) *Block {
+	return &Block{
+		header:       b.header,
+		transactions: b.transactions,
+		uncles:       b.uncles,
+		withdrawals:  b.withdrawals,
+		accessList:   accessList,
+	}
 }
 
 // Hash returns the keccak256 hash of b's header.

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -355,6 +355,10 @@ func CopyHeader(h *Header) *Header {
 		cpy.RequestsHash = new(common.Hash)
 		*cpy.RequestsHash = *h.RequestsHash
 	}
+	if h.BlockAccessListHash != nil {
+		cpy.BlockAccessListHash = new(common.Hash)
+		*cpy.BlockAccessListHash = *h.BlockAccessListHash
+	}
 	if h.SlotNumber != nil {
 		cpy.SlotNumber = new(uint64)
 		*cpy.SlotNumber = *h.SlotNumber

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -543,6 +543,7 @@ func (b *Block) WithSeal(header *Header) *Block {
 		transactions: b.transactions,
 		uncles:       b.uncles,
 		withdrawals:  b.withdrawals,
+		accessList:   b.accessList,
 	}
 }
 
@@ -554,6 +555,7 @@ func (b *Block) WithBody(body Body) *Block {
 		transactions: slices.Clone(body.Transactions),
 		uncles:       make([]*Header, len(body.Uncles)),
 		withdrawals:  slices.Clone(body.Withdrawals),
+		accessList:   b.accessList,
 	}
 	for i := range body.Uncles {
 		block.uncles[i] = CopyHeader(body.Uncles[i])

--- a/core/types/gen_header_json.go
+++ b/core/types/gen_header_json.go
@@ -16,29 +16,30 @@ var _ = (*headerMarshaling)(nil)
 // MarshalJSON marshals as JSON.
 func (h Header) MarshalJSON() ([]byte, error) {
 	type Header struct {
-		ParentHash       common.Hash     `json:"parentHash"       gencodec:"required"`
-		UncleHash        common.Hash     `json:"sha3Uncles"       gencodec:"required"`
-		Coinbase         common.Address  `json:"miner"`
-		Root             common.Hash     `json:"stateRoot"        gencodec:"required"`
-		TxHash           common.Hash     `json:"transactionsRoot" gencodec:"required"`
-		ReceiptHash      common.Hash     `json:"receiptsRoot"     gencodec:"required"`
-		Bloom            Bloom           `json:"logsBloom"        gencodec:"required"`
-		Difficulty       *hexutil.Big    `json:"difficulty"       gencodec:"required"`
-		Number           *hexutil.Big    `json:"number"           gencodec:"required"`
-		GasLimit         hexutil.Uint64  `json:"gasLimit"         gencodec:"required"`
-		GasUsed          hexutil.Uint64  `json:"gasUsed"          gencodec:"required"`
-		Time             hexutil.Uint64  `json:"timestamp"        gencodec:"required"`
-		Extra            hexutil.Bytes   `json:"extraData"        gencodec:"required"`
-		MixDigest        common.Hash     `json:"mixHash"`
-		Nonce            BlockNonce      `json:"nonce"`
-		BaseFee          *hexutil.Big    `json:"baseFeePerGas" rlp:"optional"`
-		WithdrawalsHash  *common.Hash    `json:"withdrawalsRoot" rlp:"optional"`
-		BlobGasUsed      *hexutil.Uint64 `json:"blobGasUsed" rlp:"optional"`
-		ExcessBlobGas    *hexutil.Uint64 `json:"excessBlobGas" rlp:"optional"`
-		ParentBeaconRoot *common.Hash    `json:"parentBeaconBlockRoot" rlp:"optional"`
-		RequestsHash     *common.Hash    `json:"requestsHash" rlp:"optional"`
-		SlotNumber       *hexutil.Uint64 `json:"slotNumber" rlp:"optional"`
-		Hash             common.Hash     `json:"hash"`
+		ParentHash          common.Hash     `json:"parentHash"       gencodec:"required"`
+		UncleHash           common.Hash     `json:"sha3Uncles"       gencodec:"required"`
+		Coinbase            common.Address  `json:"miner"`
+		Root                common.Hash     `json:"stateRoot"        gencodec:"required"`
+		TxHash              common.Hash     `json:"transactionsRoot" gencodec:"required"`
+		ReceiptHash         common.Hash     `json:"receiptsRoot"     gencodec:"required"`
+		Bloom               Bloom           `json:"logsBloom"        gencodec:"required"`
+		Difficulty          *hexutil.Big    `json:"difficulty"       gencodec:"required"`
+		Number              *hexutil.Big    `json:"number"           gencodec:"required"`
+		GasLimit            hexutil.Uint64  `json:"gasLimit"         gencodec:"required"`
+		GasUsed             hexutil.Uint64  `json:"gasUsed"          gencodec:"required"`
+		Time                hexutil.Uint64  `json:"timestamp"        gencodec:"required"`
+		Extra               hexutil.Bytes   `json:"extraData"        gencodec:"required"`
+		MixDigest           common.Hash     `json:"mixHash"`
+		Nonce               BlockNonce      `json:"nonce"`
+		BaseFee             *hexutil.Big    `json:"baseFeePerGas" rlp:"optional"`
+		WithdrawalsHash     *common.Hash    `json:"withdrawalsRoot" rlp:"optional"`
+		BlobGasUsed         *hexutil.Uint64 `json:"blobGasUsed" rlp:"optional"`
+		ExcessBlobGas       *hexutil.Uint64 `json:"excessBlobGas" rlp:"optional"`
+		ParentBeaconRoot    *common.Hash    `json:"parentBeaconBlockRoot" rlp:"optional"`
+		RequestsHash        *common.Hash    `json:"requestsHash" rlp:"optional"`
+		BlockAccessListHash *common.Hash    `json:"balHash" rlp:"optional"`
+		SlotNumber          *hexutil.Uint64 `json:"slotNumber" rlp:"optional"`
+		Hash                common.Hash     `json:"hash"`
 	}
 	var enc Header
 	enc.ParentHash = h.ParentHash
@@ -62,6 +63,7 @@ func (h Header) MarshalJSON() ([]byte, error) {
 	enc.ExcessBlobGas = (*hexutil.Uint64)(h.ExcessBlobGas)
 	enc.ParentBeaconRoot = h.ParentBeaconRoot
 	enc.RequestsHash = h.RequestsHash
+	enc.BlockAccessListHash = h.BlockAccessListHash
 	enc.SlotNumber = (*hexutil.Uint64)(h.SlotNumber)
 	enc.Hash = h.Hash()
 	return json.Marshal(&enc)
@@ -70,28 +72,29 @@ func (h Header) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON unmarshals from JSON.
 func (h *Header) UnmarshalJSON(input []byte) error {
 	type Header struct {
-		ParentHash       *common.Hash    `json:"parentHash"       gencodec:"required"`
-		UncleHash        *common.Hash    `json:"sha3Uncles"       gencodec:"required"`
-		Coinbase         *common.Address `json:"miner"`
-		Root             *common.Hash    `json:"stateRoot"        gencodec:"required"`
-		TxHash           *common.Hash    `json:"transactionsRoot" gencodec:"required"`
-		ReceiptHash      *common.Hash    `json:"receiptsRoot"     gencodec:"required"`
-		Bloom            *Bloom          `json:"logsBloom"        gencodec:"required"`
-		Difficulty       *hexutil.Big    `json:"difficulty"       gencodec:"required"`
-		Number           *hexutil.Big    `json:"number"           gencodec:"required"`
-		GasLimit         *hexutil.Uint64 `json:"gasLimit"         gencodec:"required"`
-		GasUsed          *hexutil.Uint64 `json:"gasUsed"          gencodec:"required"`
-		Time             *hexutil.Uint64 `json:"timestamp"        gencodec:"required"`
-		Extra            *hexutil.Bytes  `json:"extraData"        gencodec:"required"`
-		MixDigest        *common.Hash    `json:"mixHash"`
-		Nonce            *BlockNonce     `json:"nonce"`
-		BaseFee          *hexutil.Big    `json:"baseFeePerGas" rlp:"optional"`
-		WithdrawalsHash  *common.Hash    `json:"withdrawalsRoot" rlp:"optional"`
-		BlobGasUsed      *hexutil.Uint64 `json:"blobGasUsed" rlp:"optional"`
-		ExcessBlobGas    *hexutil.Uint64 `json:"excessBlobGas" rlp:"optional"`
-		ParentBeaconRoot *common.Hash    `json:"parentBeaconBlockRoot" rlp:"optional"`
-		RequestsHash     *common.Hash    `json:"requestsHash" rlp:"optional"`
-		SlotNumber       *hexutil.Uint64 `json:"slotNumber" rlp:"optional"`
+		ParentHash          *common.Hash    `json:"parentHash"       gencodec:"required"`
+		UncleHash           *common.Hash    `json:"sha3Uncles"       gencodec:"required"`
+		Coinbase            *common.Address `json:"miner"`
+		Root                *common.Hash    `json:"stateRoot"        gencodec:"required"`
+		TxHash              *common.Hash    `json:"transactionsRoot" gencodec:"required"`
+		ReceiptHash         *common.Hash    `json:"receiptsRoot"     gencodec:"required"`
+		Bloom               *Bloom          `json:"logsBloom"        gencodec:"required"`
+		Difficulty          *hexutil.Big    `json:"difficulty"       gencodec:"required"`
+		Number              *hexutil.Big    `json:"number"           gencodec:"required"`
+		GasLimit            *hexutil.Uint64 `json:"gasLimit"         gencodec:"required"`
+		GasUsed             *hexutil.Uint64 `json:"gasUsed"          gencodec:"required"`
+		Time                *hexutil.Uint64 `json:"timestamp"        gencodec:"required"`
+		Extra               *hexutil.Bytes  `json:"extraData"        gencodec:"required"`
+		MixDigest           *common.Hash    `json:"mixHash"`
+		Nonce               *BlockNonce     `json:"nonce"`
+		BaseFee             *hexutil.Big    `json:"baseFeePerGas" rlp:"optional"`
+		WithdrawalsHash     *common.Hash    `json:"withdrawalsRoot" rlp:"optional"`
+		BlobGasUsed         *hexutil.Uint64 `json:"blobGasUsed" rlp:"optional"`
+		ExcessBlobGas       *hexutil.Uint64 `json:"excessBlobGas" rlp:"optional"`
+		ParentBeaconRoot    *common.Hash    `json:"parentBeaconBlockRoot" rlp:"optional"`
+		RequestsHash        *common.Hash    `json:"requestsHash" rlp:"optional"`
+		BlockAccessListHash *common.Hash    `json:"balHash" rlp:"optional"`
+		SlotNumber          *hexutil.Uint64 `json:"slotNumber" rlp:"optional"`
 	}
 	var dec Header
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -171,6 +174,9 @@ func (h *Header) UnmarshalJSON(input []byte) error {
 	}
 	if dec.RequestsHash != nil {
 		h.RequestsHash = dec.RequestsHash
+	}
+	if dec.BlockAccessListHash != nil {
+		h.BlockAccessListHash = dec.BlockAccessListHash
 	}
 	if dec.SlotNumber != nil {
 		h.SlotNumber = (*uint64)(dec.SlotNumber)

--- a/core/types/gen_header_rlp.go
+++ b/core/types/gen_header_rlp.go
@@ -43,8 +43,9 @@ func (obj *Header) EncodeRLP(_w io.Writer) error {
 	_tmp4 := obj.ExcessBlobGas != nil
 	_tmp5 := obj.ParentBeaconRoot != nil
 	_tmp6 := obj.RequestsHash != nil
-	_tmp7 := obj.SlotNumber != nil
-	if _tmp1 || _tmp2 || _tmp3 || _tmp4 || _tmp5 || _tmp6 || _tmp7 {
+	_tmp7 := obj.BlockAccessListHash != nil
+	_tmp8 := obj.SlotNumber != nil
+	if _tmp1 || _tmp2 || _tmp3 || _tmp4 || _tmp5 || _tmp6 || _tmp7 || _tmp8 {
 		if obj.BaseFee == nil {
 			w.Write(rlp.EmptyString)
 		} else {
@@ -54,42 +55,49 @@ func (obj *Header) EncodeRLP(_w io.Writer) error {
 			w.WriteBigInt(obj.BaseFee)
 		}
 	}
-	if _tmp2 || _tmp3 || _tmp4 || _tmp5 || _tmp6 || _tmp7 {
+	if _tmp2 || _tmp3 || _tmp4 || _tmp5 || _tmp6 || _tmp7 || _tmp8 {
 		if obj.WithdrawalsHash == nil {
 			w.Write([]byte{0x80})
 		} else {
 			w.WriteBytes(obj.WithdrawalsHash[:])
 		}
 	}
-	if _tmp3 || _tmp4 || _tmp5 || _tmp6 || _tmp7 {
+	if _tmp3 || _tmp4 || _tmp5 || _tmp6 || _tmp7 || _tmp8 {
 		if obj.BlobGasUsed == nil {
 			w.Write([]byte{0x80})
 		} else {
 			w.WriteUint64((*obj.BlobGasUsed))
 		}
 	}
-	if _tmp4 || _tmp5 || _tmp6 || _tmp7 {
+	if _tmp4 || _tmp5 || _tmp6 || _tmp7 || _tmp8 {
 		if obj.ExcessBlobGas == nil {
 			w.Write([]byte{0x80})
 		} else {
 			w.WriteUint64((*obj.ExcessBlobGas))
 		}
 	}
-	if _tmp5 || _tmp6 || _tmp7 {
+	if _tmp5 || _tmp6 || _tmp7 || _tmp8 {
 		if obj.ParentBeaconRoot == nil {
 			w.Write([]byte{0x80})
 		} else {
 			w.WriteBytes(obj.ParentBeaconRoot[:])
 		}
 	}
-	if _tmp6 || _tmp7 {
+	if _tmp6 || _tmp7 || _tmp8 {
 		if obj.RequestsHash == nil {
 			w.Write([]byte{0x80})
 		} else {
 			w.WriteBytes(obj.RequestsHash[:])
 		}
 	}
-	if _tmp7 {
+	if _tmp7 || _tmp8 {
+		if obj.BlockAccessListHash == nil {
+			w.Write([]byte{0x80})
+		} else {
+			w.WriteBytes(obj.BlockAccessListHash[:])
+		}
+	}
+	if _tmp8 {
 		if obj.SlotNumber == nil {
 			w.Write([]byte{0x80})
 		} else {


### PR DESCRIPTION
We only need the header changes for op-node.

Found these commits by doing `git log v1.17.2..v1.17.3 --format="%H" core/types/block.go`. I needed one manual adjustment to fix a bug in upstream v1.17.3 that is fixed on upstream master but fails to cherry-pick cleanly.

[Monorepo PR](https://github.com/ethereum-optimism/optimism/pull/21051)