### PR TITLE
fix(sdm): include PostExecTxType in Receipts.EncodeIndex

### DIFF
--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -574,7 +574,7 @@ func (rs Receipts) EncodeIndex(i int, w *bytes.Buffer) {
 	}
 	w.WriteByte(r.Type)
 	switch r.Type {
-	case AccessListTxType, DynamicFeeTxType, BlobTxType, SetCodeTxType:
+	case AccessListTxType, DynamicFeeTxType, BlobTxType, SetCodeTxType, PostExecTxType:
 		rlp.Encode(w, data)
 	case DepositTxType:
 		if r.DepositReceiptVersion != nil {

--- a/core/types/receipt_test.go
+++ b/core/types/receipt_test.go
@@ -83,6 +83,12 @@ var (
 		},
 		Type: DynamicFeeTxType,
 	}
+	postExecReceipt = &Receipt{
+		Status:            ReceiptStatusSuccessful,
+		CumulativeGasUsed: 1,
+		Logs:              []*Log{},
+		Type:              PostExecTxType,
+	}
 
 	// Create a few transactions to have receipts for
 	to2 = common.HexToAddress("0x2")
@@ -576,6 +582,26 @@ func TestReceiptMarshalBinary(t *testing.T) {
 	eip1559Want := common.FromHex("02f901c58001b9010000000000000010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000500000000000000000000000000000000000014000000000000000000000000000000000000000000000000000000000000000000000000000010000080000000000000000000004000000000000000000000000000040000000000000000000000000000800000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000f8bef85d940000000000000000000000000000000000000011f842a0000000000000000000000000000000000000000000000000000000000000deada0000000000000000000000000000000000000000000000000000000000000beef830100fff85d940000000000000000000000000000000000000111f842a0000000000000000000000000000000000000000000000000000000000000deada0000000000000000000000000000000000000000000000000000000000000beef830100ff")
 	if !bytes.Equal(have, eip1559Want) {
 		t.Errorf("encoded RLP mismatch, got %x want %x", have, eip1559Want)
+	}
+
+	// PostExec Receipt: same envelope shape as the typed receipts above,
+	// just prefixed by the 0x7d type byte. EncodeIndex must produce the
+	// same bytes as MarshalBinary so that DeriveSha matches what op-reth
+	// commits to in the block header.
+	buf.Reset()
+	postExecReceipt.Bloom = CreateBloom(postExecReceipt)
+	have, err = postExecReceipt.MarshalBinary()
+	if err != nil {
+		t.Fatalf("marshal binary error: %v", err)
+	}
+	postExecReceipts := Receipts{postExecReceipt}
+	postExecReceipts.EncodeIndex(0, buf)
+	haveEncodeIndex = buf.Bytes()
+	if !bytes.Equal(have, haveEncodeIndex) {
+		t.Errorf("BinaryMarshal and EncodeIndex mismatch, got %x want %x", have, haveEncodeIndex)
+	}
+	if len(have) == 0 || have[0] != PostExecTxType {
+		t.Errorf("expected encoded receipt to start with PostExecTxType (0x%x), got %x", PostExecTxType, have)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `PostExecTxType` to the typed-receipt case in `Receipts.EncodeIndex` so `DeriveSha` produces the same bytes as `Receipt.MarshalBinary` for PostExec receipts.
- Extend `TestReceiptMarshalBinary` with a PostExec assertion; without this fix the test fails with the `EncodeIndex` output being just the single `0x7d` type byte.

## Background

PR #789 added `PostExecTxType` (`0x7D`) to `Receipt.decodeTyped` at `core/types/receipt.go:344`, but the matching `Receipts.EncodeIndex` switch at line 577 was not updated. PostExec receipts therefore fell into the `default` branch of `EncodeIndex`, which writes nothing after the type byte.

This breaks any consumer that fetches receipts via JSON-RPC and re-derives the receipt root locally. Concretely, ethereum-optimism/optimism's `op-service/sources/receipts.go` validates each block by comparing `types.DeriveSha(receipts, …)` against the header's `receiptHash`. For blocks containing a PostExec tx, the supernode loops with:

```
expected receipt root 0xf3728b… but computed 0x2fb91b… from retrieved receipts
```

…which prevents super-roots from validating and causes `TestInteropSingleChainFaultProofsWithSDM` to time out in https://github.com/ethereum-optimism/optimism/pull/21034.

## Test plan

- [x] `go test ./core/types/...` (passes with the fix)
- [x] Re-ran `TestReceiptMarshalBinary` with `core/types/receipt.go` reverted: fails as expected, confirming the new assertion guards the regression
- [ ] Bump `op-geth` in ethereum-optimism/optimism and re-run the failing acceptance tests