### PR TITLE
ci: remove docker image signing step from pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,29 +147,6 @@ jobs:
                 name: Tag
                 command: |
                   ./.circleci/ci-docker-tag-op-geth-release.sh <<parameters.registry>>/<<parameters.repo>> $CIRCLE_TAG $CIRCLE_SHA1
-      - when:
-          condition:
-            equal: [optimism, << pipeline.git.branch >>]
-          steps:
-            - gcp-oidc-authenticate:
-                service_account_email: GCP_SERVICE_ATTESTOR_ACCOUNT_EMAIL
-            - run:
-                name: Sign
-                command: |
-                  git clone --branch v1.0.3 --depth 1 https://github.com/ethereum-optimism/binary_signer
-                  cd binary_signer/signer
-
-                  IMAGE_PATH="<<parameters.registry>>/<<parameters.repo>>/<<parameters.docker_name>>:<<pipeline.git.revision>>"
-                  echo $IMAGE_PATH
-                  pip3 install -r requirements.txt
-
-                  python3 ./sign_image.py --command="sign"\
-                      --attestor-project-name="$ATTESTOR_PROJECT_NAME"\
-                      --attestor-name="$ATTESTOR_NAME"\
-                      --image-path="$IMAGE_PATH"\
-                      --signer-logging-level="INFO"\
-                      --attestor-key-id="//cloudkms.googleapis.com/v1/projects/$ATTESTOR_PROJECT_NAME/locations/global/keyRings/$ATTESTOR_NAME-key-ring/cryptoKeys/$ATTESTOR_NAME-key/cryptoKeyVersions/1"
-
   build-geth:
     docker:
       - image: cimg/go:<<pipeline.parameters.go_version>>


### PR DESCRIPTION
## Summary
- Remove the `binary_signer` attestation step from the `docker-release` job that runs on the `optimism` branch
- Step is no longer needed and was causing CI failures

## Test plan
- [ ] CI passes without the signing step