### PR TITLE
ci: fetch full history for forkdiff instead of fixed --depth

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,11 +58,14 @@ jobs:
       image: ubuntu-2004:current
     steps:
       - checkout
-      # Fetch more history for diffing
+      # Fetch full history for diffing. forkdiff has to walk every op-geth
+      # commit down to the go-ethereum base, and the deepest of those is well
+      # past a fixed --depth, so a shallow fetch hits the shallow boundary and
+      # fails with "object not found". Unshallow if needed, otherwise no-op.
       - run:
           name: Fetch git history
           command: |
-            git fetch --depth 1000
+            git fetch --unshallow || git fetch
 
       # Build forkdiff using Docker
       - run:


### PR DESCRIPTION
## Problem

The `build-and-deploy` job (the `merge` workflow) was failing at the **Build forkdiff** step:

```
failed to compute patch between base and fork
error: object not found
```

(e.g. [pipeline 4192, job 16136](https://app.circleci.com/pipelines/github/ethereum-optimism/op-geth/4192/workflows/b79a55d2-bbd1-479c-a1c5-9bea71abe53e/jobs/16136))

## Root cause

`protolambda/forkdiff` (go-git based) builds the fork-diff page by walking *every* op-geth-specific commit down to the go-ethereum base commit pinned in `fork.yaml` (currently `16783c16…`, v1.17.1). There are ~980 such commits, but they're interleaved with go-ethereum's own history in the commit graph, so the oldest one sits at depth ~3751.

The CI step only ran `git fetch --depth 1000`, so in CircleCI's genuine shallow checkout the deeper objects were never fetched — go-git hit the shallow boundary and reported `object not found`. The recent `all: Merge go-ethereum v1.17.1` moved the base hash and surfaced this, but the underlying fragility is the fixed `--depth`, which history growth eventually outruns.

> Note: this is hard to reproduce with a *full* clone + `git fetch --depth 1000`, because that leaves the deep objects physically present (the repo is merely *marked* shallow). Only a genuine shallow checkout like CircleCI's exposes the missing objects.

## Fix

Replace `git fetch --depth 1000` with `git fetch --unshallow || git fetch` — fetch the complete history when the repo is shallow, and fall back to a harmless no-op fetch when it's already complete.

## Verification

Reproduced against a real shallow clone of the failing commit `3f89c08af`:

- Before: forkdiff fails with `object not found` (deepest required commit absent).
- After `git fetch --unshallow`: repo is no longer shallow, the deepest required commit is present, and the real forkdiff Docker run exits 0 and produces `index.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)