### PR TITLE
consensus/beacon: add Karst deprecation kill switch

### DIFF
--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -52,7 +52,18 @@ var (
 	errInvalidNonce     = errors.New("invalid nonce")
 	errInvalidUncleHash = errors.New("invalid uncle hash")
 	errInvalidTimestamp = errors.New("invalid timestamp")
+	errKarstDeprecated  = errors.New("op-geth is deprecated as of the Karst fork; refusing to process block")
 )
+
+// karstKillSwitch returns an error if the given block timestamp activates Karst.
+// op-geth must never build, seal, or import a block at or after Karst, so this
+// is used as a deprecation kill switch across the consensus engine's entry points.
+func karstKillSwitch(cfg *params.ChainConfig, time uint64) error {
+	if cfg.IsOptimismKarst(time) {
+		return fmt.Errorf("%w: block timestamp %d", errKarstDeprecated, time)
+	}
+	return nil
+}
 
 // Beacon is a consensus engine that combines the eth1 consensus and proof-of-stake
 // algorithm. There is a special flag inside to decide whether to use legacy consensus
@@ -233,6 +244,9 @@ func (beacon *Beacon) VerifyUncles(chain consensus.ChainReader, block *types.Blo
 // (b) we don't verify if a block is in the future anymore
 // (c) the extradata is limited to 32 bytes
 func (beacon *Beacon) verifyHeader(chain consensus.ChainHeaderReader, header, parent *types.Header) error {
+	if err := karstKillSwitch(chain.Config(), header.Time); err != nil {
+		return err
+	}
 	// Ensure that the header's extra-data section is of a reasonable size
 	if len(header.Extra) > int(params.MaximumExtraDataSize) {
 		return fmt.Errorf("extra-data longer than 32 bytes (%d)", len(header.Extra))
@@ -355,6 +369,9 @@ func (beacon *Beacon) verifyHeaders(chain consensus.ChainHeaderReader, headers [
 // Prepare implements consensus.Engine, initializing the difficulty field of a
 // header to conform to the beacon protocol. The changes are done inline.
 func (beacon *Beacon) Prepare(chain consensus.ChainHeaderReader, header *types.Header) error {
+	if err := karstKillSwitch(chain.Config(), header.Time); err != nil {
+		return err
+	}
 	if !chain.Config().IsPostMerge(header.Number.Uint64(), header.Time) {
 		return beacon.ethone.Prepare(chain, header)
 	}
@@ -381,6 +398,10 @@ func (beacon *Beacon) Finalize(chain consensus.ChainHeaderReader, header *types.
 // FinalizeAndAssemble implements consensus.Engine, setting the final state and
 // assembling the block.
 func (beacon *Beacon) FinalizeAndAssemble(ctx context.Context, chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, body *types.Body, receipts []*types.Receipt) (result *types.Block, err error) {
+	if err := karstKillSwitch(chain.Config(), header.Time); err != nil {
+		return nil, err
+	}
+
 	ctx, _, spanEnd := telemetry.StartSpan(ctx, "consensus.beacon.FinalizeAndAssemble",
 		telemetry.Int64Attribute("block.number", int64(header.Number.Uint64())),
 		telemetry.Int64Attribute("txs.count", int64(len(body.Transactions))),

--- a/consensus/beacon/consensus_test.go
+++ b/consensus/beacon/consensus_test.go
@@ -1,0 +1,109 @@
+// Copyright 2025 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package beacon
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+// mockChainHeaderReader is a minimal consensus.ChainHeaderReader that only
+// serves a chain config, which is all the Karst kill switch needs.
+type mockChainHeaderReader struct {
+	config *params.ChainConfig
+}
+
+func (m *mockChainHeaderReader) Config() *params.ChainConfig                 { return m.config }
+func (m *mockChainHeaderReader) CurrentHeader() *types.Header                { return nil }
+func (m *mockChainHeaderReader) GetHeader(common.Hash, uint64) *types.Header { return nil }
+func (m *mockChainHeaderReader) GetHeaderByNumber(uint64) *types.Header      { return nil }
+func (m *mockChainHeaderReader) GetHeaderByHash(common.Hash) *types.Header   { return nil }
+
+// karstConfig returns an Optimism test config with Karst activating at the given
+// timestamp.
+func karstConfig(karstTime uint64) *params.ChainConfig {
+	conf := *params.OptimismTestConfig
+	conf.KarstTime = &karstTime
+	return &conf
+}
+
+func TestKarstKillSwitch(t *testing.T) {
+	const karstTime = uint64(20000)
+
+	nonOptimism := *params.OptimismTestConfig
+	nonOptimism.Optimism = nil
+	nonOptimism.KarstTime = &[]uint64{karstTime}[0]
+
+	tests := []struct {
+		name    string
+		config  *params.ChainConfig
+		time    uint64
+		blocked bool
+	}{
+		{"karst-unset", params.OptimismTestConfig, karstTime, false},
+		{"before-karst", karstConfig(karstTime), karstTime - 1, false},
+		{"activation-block", karstConfig(karstTime), karstTime, true},
+		{"after-karst", karstConfig(karstTime), karstTime + 1, true},
+		{"non-optimism-chain", &nonOptimism, karstTime + 1, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := karstKillSwitch(tt.config, tt.time)
+			if got := errors.Is(err, errKarstDeprecated); got != tt.blocked {
+				t.Fatalf("karstKillSwitch blocked = %v, want %v (err: %v)", got, tt.blocked, err)
+			}
+		})
+	}
+}
+
+// TestBeaconKarstKillSwitchEntryPoints verifies that every consensus-engine
+// entry point that touches a block refuses a block at or after Karst, so an
+// op-geth node can neither import nor build a chain that crosses Karst.
+func TestBeaconKarstKillSwitchEntryPoints(t *testing.T) {
+	const karstTime = uint64(20000)
+	engine := New(nil)
+
+	// At and after the Karst activation timestamp every entry point must refuse.
+	for _, time := range []uint64{karstTime, karstTime + 1} {
+		chain := &mockChainHeaderReader{config: karstConfig(karstTime)}
+		header := &types.Header{Number: big.NewInt(1), Time: time}
+
+		if err := engine.verifyHeader(chain, header, &types.Header{Number: big.NewInt(0)}); !errors.Is(err, errKarstDeprecated) {
+			t.Errorf("verifyHeader(time=%d) = %v, want errKarstDeprecated", time, err)
+		}
+		if err := engine.Prepare(chain, header); !errors.Is(err, errKarstDeprecated) {
+			t.Errorf("Prepare(time=%d) = %v, want errKarstDeprecated", time, err)
+		}
+		if _, err := engine.FinalizeAndAssemble(context.Background(), chain, header, nil, &types.Body{}, nil); !errors.Is(err, errKarstDeprecated) {
+			t.Errorf("FinalizeAndAssemble(time=%d) = %v, want errKarstDeprecated", time, err)
+		}
+	}
+
+	// With Karst unset, the kill switch must not fire. Prepare is a real entry
+	// point we can exercise without a full valid header/parent.
+	chain := &mockChainHeaderReader{config: params.OptimismTestConfig}
+	header := &types.Header{Number: big.NewInt(1), Time: karstTime + 1}
+	if err := engine.Prepare(chain, header); errors.Is(err, errKarstDeprecated) {
+		t.Errorf("Prepare with Karst unset returned errKarstDeprecated: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

op-geth is being deprecated as of the **Karst** fork. This adds a kill switch in the beacon consensus engine so an op-geth node can never build, seal, or import a block that crosses the Karst activation — **including the activation block itself** — instead of silently producing or accepting an invalid post-deprecation chain.

Karst is already a fully-wired fork (`KarstTime`, `IsKarst`, `IsOptimismKarst`), so no config plumbing was needed. The switch keys off the existing `IsOptimismKarst` predicate and engages **automatically** once `KarstTime` is configured (e.g. via the superchain registry). There is no override flag — that is the point of a deprecation kill switch.

## Changes

`consensus/beacon/consensus.go`:
- New `errKarstDeprecated` sentinel + `karstKillSwitch(cfg, time)` helper. Because `IsKarst` is a `>=` check, this catches the activation block and everything after it.
- Wired into the three engine entry points that touch a block, each as the first action:
  - `verifyHeader` — gates **import/execution** (reached by both `VerifyHeader` and `VerifyHeaders` during `insertChain`).
  - `Prepare` — **fail-fast** at the start of block building, before transactions execute.
  - `FinalizeAndAssemble` — gates **build/seal** at the assembly choke point.

`consensus/beacon/consensus_test.go` (new): table test on the helper (unset / before / activation / after / non-Optimism chain) plus an entry-point test asserting all three gates return `errKarstDeprecated` at and after Karst, and stay dormant when `KarstTime` is unset.

## Compatibility

No behavioral change for existing chains/tests: `OptimismTestConfig.KarstTime` is `nil` by default, so the switch is dormant unless `KarstTime` is explicitly set. `go build ./...`, `go test ./consensus/beacon/... ./miner/... ./core/...` all pass.

Fixes https://github.com/ethereum-optimism/protocol-team/issues/98

🤖 Generated with [Claude Code](https://claude.com/claude-code)