### PR TITLE
core/types, beacon/engine: add Glamsterdam compatibility types

### DIFF
--- a/beacon/engine/gen_blockparams.go
+++ b/beacon/engine/gen_blockparams.go
@@ -22,6 +22,7 @@ func (p PayloadAttributes) MarshalJSON() ([]byte, error) {
 		Withdrawals           []*types.Withdrawal `json:"withdrawals"`
 		BeaconRoot            *common.Hash        `json:"parentBeaconBlockRoot"`
 		SlotNumber            *hexutil.Uint64     `json:"slotNumber"`
+		TargetGasLimit        *hexutil.Uint64     `json:"targetGasLimit"`
 		Transactions          []hexutil.Bytes     `json:"transactions,omitempty"  gencodec:"optional"`
 		NoTxPool              bool                `json:"noTxPool,omitempty" gencodec:"optional"`
 		GasLimit              *hexutil.Uint64     `json:"gasLimit,omitempty" gencodec:"optional"`
@@ -35,6 +36,7 @@ func (p PayloadAttributes) MarshalJSON() ([]byte, error) {
 	enc.Withdrawals = p.Withdrawals
 	enc.BeaconRoot = p.BeaconRoot
 	enc.SlotNumber = (*hexutil.Uint64)(p.SlotNumber)
+	enc.TargetGasLimit = (*hexutil.Uint64)(p.TargetGasLimit)
 	if p.Transactions != nil {
 		enc.Transactions = make([]hexutil.Bytes, len(p.Transactions))
 		for k, v := range p.Transactions {
@@ -57,6 +59,7 @@ func (p *PayloadAttributes) UnmarshalJSON(input []byte) error {
 		Withdrawals           []*types.Withdrawal `json:"withdrawals"`
 		BeaconRoot            *common.Hash        `json:"parentBeaconBlockRoot"`
 		SlotNumber            *hexutil.Uint64     `json:"slotNumber"`
+		TargetGasLimit        *hexutil.Uint64     `json:"targetGasLimit"`
 		Transactions          []hexutil.Bytes     `json:"transactions,omitempty"  gencodec:"optional"`
 		NoTxPool              *bool               `json:"noTxPool,omitempty" gencodec:"optional"`
 		GasLimit              *hexutil.Uint64     `json:"gasLimit,omitempty" gencodec:"optional"`
@@ -87,6 +90,9 @@ func (p *PayloadAttributes) UnmarshalJSON(input []byte) error {
 	}
 	if dec.SlotNumber != nil {
 		p.SlotNumber = (*uint64)(dec.SlotNumber)
+	}
+	if dec.TargetGasLimit != nil {
+		p.TargetGasLimit = (*uint64)(dec.TargetGasLimit)
 	}
 	if dec.Transactions != nil {
 		p.Transactions = make([][]byte, len(dec.Transactions))

--- a/beacon/engine/gen_ed.go
+++ b/beacon/engine/gen_ed.go
@@ -35,6 +35,7 @@ func (e ExecutableData) MarshalJSON() ([]byte, error) {
 		BlobGasUsed     *hexutil.Uint64     `json:"blobGasUsed"`
 		ExcessBlobGas   *hexutil.Uint64     `json:"excessBlobGas"`
 		SlotNumber      *hexutil.Uint64     `json:"slotNumber"`
+		BlockAccessList *hexutil.Bytes      `json:"blockAccessList,omitempty"`
 		WithdrawalsRoot *common.Hash        `json:"withdrawalsRoot,omitempty"`
 	}
 	var enc ExecutableData
@@ -61,6 +62,7 @@ func (e ExecutableData) MarshalJSON() ([]byte, error) {
 	enc.BlobGasUsed = (*hexutil.Uint64)(e.BlobGasUsed)
 	enc.ExcessBlobGas = (*hexutil.Uint64)(e.ExcessBlobGas)
 	enc.SlotNumber = (*hexutil.Uint64)(e.SlotNumber)
+	enc.BlockAccessList = e.BlockAccessList
 	enc.WithdrawalsRoot = e.WithdrawalsRoot
 	return json.Marshal(&enc)
 }
@@ -86,6 +88,7 @@ func (e *ExecutableData) UnmarshalJSON(input []byte) error {
 		BlobGasUsed     *hexutil.Uint64     `json:"blobGasUsed"`
 		ExcessBlobGas   *hexutil.Uint64     `json:"excessBlobGas"`
 		SlotNumber      *hexutil.Uint64     `json:"slotNumber"`
+		BlockAccessList *hexutil.Bytes      `json:"blockAccessList,omitempty"`
 		WithdrawalsRoot *common.Hash        `json:"withdrawalsRoot,omitempty"`
 	}
 	var dec ExecutableData
@@ -162,6 +165,9 @@ func (e *ExecutableData) UnmarshalJSON(input []byte) error {
 	}
 	if dec.SlotNumber != nil {
 		e.SlotNumber = (*uint64)(dec.SlotNumber)
+	}
+	if dec.BlockAccessList != nil {
+		e.BlockAccessList = dec.BlockAccessList
 	}
 	if dec.WithdrawalsRoot != nil {
 		e.WithdrawalsRoot = dec.WithdrawalsRoot

--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/trie"
 )
@@ -350,9 +351,13 @@ func ExecutableDataToBlockNoHash(data ExecutableData, versionedHashes []common.H
 	} else if isthmusEnabled {
 		return nil, fmt.Errorf("requests must be an empty array for Isthmus blocks")
 	}
+	if data.SlotNumber != nil && data.BlockAccessList == nil {
+		return nil, fmt.Errorf("attribute BlockAccessList is required for Amsterdam blocks")
+	}
 	var blockAccessListHash *common.Hash
-	if data.SlotNumber != nil {
-		blockAccessListHash = &types.EmptyBlockAccessListHash
+	if data.BlockAccessList != nil {
+		hash := crypto.Keccak256Hash(*data.BlockAccessList)
+		blockAccessListHash = &hash
 	}
 
 	header := &types.Header{

--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -70,6 +70,7 @@ type PayloadAttributes struct {
 	Withdrawals           []*types.Withdrawal `json:"withdrawals"`
 	BeaconRoot            *common.Hash        `json:"parentBeaconBlockRoot"`
 	SlotNumber            *uint64             `json:"slotNumber"`
+	TargetGasLimit        *uint64             `json:"targetGasLimit"`
 
 	// Transactions is a field for rollups: the transactions list is forced into the block
 	Transactions [][]byte `json:"transactions,omitempty"  gencodec:"optional"`
@@ -89,11 +90,12 @@ type PayloadAttributes struct {
 
 // JSON type overrides for PayloadAttributes.
 type payloadAttributesMarshaling struct {
-	Transactions  []hexutil.Bytes
-	GasLimit      *hexutil.Uint64
-	EIP1559Params hexutil.Bytes
-	Timestamp     hexutil.Uint64
-	SlotNumber    *hexutil.Uint64
+	Transactions   []hexutil.Bytes
+	GasLimit       *hexutil.Uint64
+	EIP1559Params  hexutil.Bytes
+	Timestamp      hexutil.Uint64
+	SlotNumber     *hexutil.Uint64
+	TargetGasLimit *hexutil.Uint64
 }
 
 //go:generate go run github.com/fjl/gencodec -type ExecutableData -field-override executableDataMarshaling -out gen_ed.go
@@ -118,6 +120,10 @@ type ExecutableData struct {
 	BlobGasUsed   *uint64             `json:"blobGasUsed"`
 	ExcessBlobGas *uint64             `json:"excessBlobGas"`
 	SlotNumber    *uint64             `json:"slotNumber"`
+	// BlockAccessList carries the EIP-7928 RLP payload as an Engine API hex value.
+	// op-geth does not execute BALs yet; keeping this field opaque lets clients use
+	// op-geth's Engine API types to drive a newer geth subprocess without data loss.
+	BlockAccessList *hexutil.Bytes `json:"blockAccessList,omitempty"`
 
 	// OP-Stack Isthmus specific field:
 	// instead of computing the root from a withdrawals list, set it directly.

--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -344,29 +344,34 @@ func ExecutableDataToBlockNoHash(data ExecutableData, versionedHashes []common.H
 	} else if isthmusEnabled {
 		return nil, fmt.Errorf("requests must be an empty array for Isthmus blocks")
 	}
+	var blockAccessListHash *common.Hash
+	if data.SlotNumber != nil {
+		blockAccessListHash = &types.EmptyBlockAccessListHash
+	}
 
 	header := &types.Header{
-		ParentHash:       data.ParentHash,
-		UncleHash:        types.EmptyUncleHash,
-		Coinbase:         data.FeeRecipient,
-		Root:             data.StateRoot,
-		TxHash:           types.DeriveSha(types.Transactions(txs), trie.NewStackTrie(nil)),
-		ReceiptHash:      data.ReceiptsRoot,
-		Bloom:            types.BytesToBloom(data.LogsBloom),
-		Difficulty:       common.Big0,
-		Number:           new(big.Int).SetUint64(data.Number),
-		GasLimit:         data.GasLimit,
-		GasUsed:          data.GasUsed,
-		Time:             data.Timestamp,
-		BaseFee:          data.BaseFeePerGas,
-		Extra:            data.ExtraData,
-		MixDigest:        data.Random,
-		WithdrawalsHash:  withdrawalsRoot,
-		ExcessBlobGas:    data.ExcessBlobGas,
-		BlobGasUsed:      data.BlobGasUsed,
-		ParentBeaconRoot: beaconRoot,
-		RequestsHash:     requestsHash,
-		SlotNumber:       data.SlotNumber,
+		ParentHash:          data.ParentHash,
+		UncleHash:           types.EmptyUncleHash,
+		Coinbase:            data.FeeRecipient,
+		Root:                data.StateRoot,
+		TxHash:              types.DeriveSha(types.Transactions(txs), trie.NewStackTrie(nil)),
+		ReceiptHash:         data.ReceiptsRoot,
+		Bloom:               types.BytesToBloom(data.LogsBloom),
+		Difficulty:          common.Big0,
+		Number:              new(big.Int).SetUint64(data.Number),
+		GasLimit:            data.GasLimit,
+		GasUsed:             data.GasUsed,
+		Time:                data.Timestamp,
+		BaseFee:             data.BaseFeePerGas,
+		Extra:               data.ExtraData,
+		MixDigest:           data.Random,
+		WithdrawalsHash:     withdrawalsRoot,
+		ExcessBlobGas:       data.ExcessBlobGas,
+		BlobGasUsed:         data.BlobGasUsed,
+		ParentBeaconRoot:    beaconRoot,
+		RequestsHash:        requestsHash,
+		BlockAccessListHash: blockAccessListHash,
+		SlotNumber:          data.SlotNumber,
 	}
 	return types.NewBlockWithHeader(header).
 			WithBody(types.Body{Transactions: txs, Uncles: nil, Withdrawals: data.Withdrawals}),

--- a/beacon/engine/types_test.go
+++ b/beacon/engine/types_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/kzg4844"
 )
 
@@ -65,18 +66,26 @@ func TestGlamsterdamEngineWireFields(t *testing.T) {
 
 func TestExecutableDataToBlockSetsAmsterdamBlockAccessListHash(t *testing.T) {
 	slotNumber := uint64(1)
+	blockAccessList := hexutil.Bytes{0xc1, 0x80}
 	data := ExecutableData{
-		LogsBloom:     make([]byte, 256),
-		BaseFeePerGas: big.NewInt(1),
-		Transactions:  make([][]byte, 0),
-		SlotNumber:    &slotNumber,
+		LogsBloom:       make([]byte, 256),
+		BaseFeePerGas:   big.NewInt(1),
+		Transactions:    make([][]byte, 0),
+		SlotNumber:      &slotNumber,
+		BlockAccessList: &blockAccessList,
 	}
 	block, err := ExecutableDataToBlockNoHash(data, []common.Hash{}, nil, nil, types.DefaultBlockConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if hash := block.Header().BlockAccessListHash; hash == nil || *hash != types.EmptyBlockAccessListHash {
-		t.Fatalf("unexpected block access list hash: %v", hash)
+	want := crypto.Keccak256Hash(blockAccessList)
+	if hash := block.Header().BlockAccessListHash; hash == nil || *hash != want {
+		t.Fatalf("unexpected block access list hash: have %v, want %v", hash, want)
+	}
+
+	data.BlockAccessList = nil
+	if _, err := ExecutableDataToBlockNoHash(data, []common.Hash{}, nil, nil, types.DefaultBlockConfig); err == nil {
+		t.Fatal("expected missing block access list to be rejected")
 	}
 }
 

--- a/beacon/engine/types_test.go
+++ b/beacon/engine/types_test.go
@@ -17,12 +17,30 @@
 package engine
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto/kzg4844"
 )
+
+func TestExecutableDataToBlockSetsAmsterdamBlockAccessListHash(t *testing.T) {
+	slotNumber := uint64(1)
+	data := ExecutableData{
+		LogsBloom:     make([]byte, 256),
+		BaseFeePerGas: big.NewInt(1),
+		Transactions:  make([][]byte, 0),
+		SlotNumber:    &slotNumber,
+	}
+	block, err := ExecutableDataToBlockNoHash(data, []common.Hash{}, nil, nil, types.DefaultBlockConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hash := block.Header().BlockAccessListHash; hash == nil || *hash != types.EmptyBlockAccessListHash {
+		t.Fatalf("unexpected block access list hash: %v", hash)
+	}
+}
 
 func TestBlobs(t *testing.T) {
 	var (

--- a/beacon/engine/types_test.go
+++ b/beacon/engine/types_test.go
@@ -17,13 +17,51 @@
 package engine
 
 import (
+	"bytes"
+	"encoding/json"
 	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto/kzg4844"
 )
+
+func TestGlamsterdamEngineWireFields(t *testing.T) {
+	targetGasLimit := uint64(60_000_000)
+	attrs := PayloadAttributes{TargetGasLimit: &targetGasLimit}
+	encodedAttrs, err := json.Marshal(attrs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decodedAttrs PayloadAttributes
+	if err := json.Unmarshal(encodedAttrs, &decodedAttrs); err != nil {
+		t.Fatal(err)
+	}
+	if decodedAttrs.TargetGasLimit == nil || *decodedAttrs.TargetGasLimit != targetGasLimit {
+		t.Fatalf("unexpected target gas limit: %v", decodedAttrs.TargetGasLimit)
+	}
+
+	emptyBAL := hexutil.Bytes{0xc0}
+	payload := ExecutableData{
+		LogsBloom:       make([]byte, 256),
+		BaseFeePerGas:   big.NewInt(1),
+		Transactions:    make([][]byte, 0),
+		BlockAccessList: &emptyBAL,
+	}
+	encodedPayload, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decodedPayload ExecutableData
+	if err := json.Unmarshal(encodedPayload, &decodedPayload); err != nil {
+		t.Fatal(err)
+	}
+	if decodedPayload.BlockAccessList == nil || !bytes.Equal(*decodedPayload.BlockAccessList, emptyBAL) {
+		t.Fatalf("unexpected block access list: %x", decodedPayload.BlockAccessList)
+	}
+}
 
 func TestExecutableDataToBlockSetsAmsterdamBlockAccessListHash(t *testing.T) {
 	slotNumber := uint64(1)

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -707,6 +707,7 @@ func (g *Genesis) toBlockWithRoot(stateRoot, storageRootMessagePasser common.Has
 			if head.SlotNumber == nil {
 				head.SlotNumber = new(uint64)
 			}
+			head.BlockAccessListHash = &types.EmptyBlockAccessListHash
 		}
 		// If Isthmus is active at genesis, set the WithdrawalRoot to the storage root of the L2ToL1MessagePasser contract.
 		if g.Config.IsOptimismIsthmus(g.Timestamp) {

--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -221,6 +221,32 @@ func TestGenesisCommit(t *testing.T) {
 	}
 }
 
+func TestAmsterdamGenesisCommit(t *testing.T) {
+	config := *params.AllDevChainProtocolChanges
+	config.AmsterdamTime = new(uint64)
+	blobSchedule := *config.BlobScheduleConfig
+	blobSchedule.Amsterdam = blobSchedule.Osaka
+	config.BlobScheduleConfig = &blobSchedule
+	genesis := &Genesis{
+		BaseFee:    big.NewInt(params.InitialBaseFee),
+		Config:     &config,
+		GasLimit:   params.GenesisGasLimit,
+		Difficulty: big.NewInt(0),
+	}
+
+	db := rawdb.NewMemoryDatabase()
+	block := genesis.MustCommit(db, triedb.NewDatabase(db, triedb.HashDefaults))
+	if block.Header().BlockAccessListHash == nil {
+		t.Fatal("Amsterdam genesis is missing block access list hash")
+	}
+	if *block.Header().BlockAccessListHash != types.EmptyBlockAccessListHash {
+		t.Fatalf("unexpected Amsterdam genesis block access list hash: %s", block.Header().BlockAccessListHash)
+	}
+	if stored := rawdb.ReadBlock(db, block.Hash(), 0); stored == nil {
+		t.Fatal("Amsterdam genesis block could not be read back from database")
+	}
+}
+
 func TestReadWriteGenesisAlloc(t *testing.T) {
 	var (
 		db    = rawdb.NewMemoryDatabase()

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -100,6 +100,9 @@ type Header struct {
 	// RequestsHash was added by EIP-7685 and is ignored in legacy headers.
 	RequestsHash *common.Hash `json:"requestsHash" rlp:"optional"`
 
+	// BlockAccessListHash was added by EIP-7928 and is ignored in legacy headers.
+	BlockAccessListHash *common.Hash `json:"blockAccessListHash" rlp:"optional"`
+
 	// SlotNumber was added by EIP-7843 and is ignored in legacy headers.
 	SlotNumber *uint64 `json:"slotNumber" rlp:"optional"`
 }
@@ -349,6 +352,10 @@ func CopyHeader(h *Header) *Header {
 	if h.RequestsHash != nil {
 		cpy.RequestsHash = new(common.Hash)
 		*cpy.RequestsHash = *h.RequestsHash
+	}
+	if h.BlockAccessListHash != nil {
+		cpy.BlockAccessListHash = new(common.Hash)
+		*cpy.BlockAccessListHash = *h.BlockAccessListHash
 	}
 	if h.SlotNumber != nil {
 		cpy.SlotNumber = new(uint64)

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -100,11 +100,11 @@ type Header struct {
 	// RequestsHash was added by EIP-7685 and is ignored in legacy headers.
 	RequestsHash *common.Hash `json:"requestsHash" rlp:"optional"`
 
-	// SlotNumber was added by EIP-7843 and is ignored in legacy headers.
-	SlotNumber *uint64 `json:"slotNumber" rlp:"optional"`
-
 	// BlockAccessListHash was added by EIP-7928 and is ignored in legacy headers.
 	BlockAccessListHash *common.Hash `json:"blockAccessListHash" rlp:"optional"`
+
+	// SlotNumber was added by EIP-7843 and is ignored in legacy headers.
+	SlotNumber *uint64 `json:"slotNumber" rlp:"optional"`
 }
 
 // field type overrides for gencodec
@@ -353,13 +353,13 @@ func CopyHeader(h *Header) *Header {
 		cpy.RequestsHash = new(common.Hash)
 		*cpy.RequestsHash = *h.RequestsHash
 	}
-	if h.SlotNumber != nil {
-		cpy.SlotNumber = new(uint64)
-		*cpy.SlotNumber = *h.SlotNumber
-	}
 	if h.BlockAccessListHash != nil {
 		cpy.BlockAccessListHash = new(common.Hash)
 		*cpy.BlockAccessListHash = *h.BlockAccessListHash
+	}
+	if h.SlotNumber != nil {
+		cpy.SlotNumber = new(uint64)
+		*cpy.SlotNumber = *h.SlotNumber
 	}
 	return &cpy
 }

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -100,11 +100,11 @@ type Header struct {
 	// RequestsHash was added by EIP-7685 and is ignored in legacy headers.
 	RequestsHash *common.Hash `json:"requestsHash" rlp:"optional"`
 
-	// BlockAccessListHash was added by EIP-7928 and is ignored in legacy headers.
-	BlockAccessListHash *common.Hash `json:"blockAccessListHash" rlp:"optional"`
-
 	// SlotNumber was added by EIP-7843 and is ignored in legacy headers.
 	SlotNumber *uint64 `json:"slotNumber" rlp:"optional"`
+
+	// BlockAccessListHash was added by EIP-7928 and is ignored in legacy headers.
+	BlockAccessListHash *common.Hash `json:"blockAccessListHash" rlp:"optional"`
 }
 
 // field type overrides for gencodec
@@ -353,13 +353,13 @@ func CopyHeader(h *Header) *Header {
 		cpy.RequestsHash = new(common.Hash)
 		*cpy.RequestsHash = *h.RequestsHash
 	}
-	if h.BlockAccessListHash != nil {
-		cpy.BlockAccessListHash = new(common.Hash)
-		*cpy.BlockAccessListHash = *h.BlockAccessListHash
-	}
 	if h.SlotNumber != nil {
 		cpy.SlotNumber = new(uint64)
 		*cpy.SlotNumber = *h.SlotNumber
+	}
+	if h.BlockAccessListHash != nil {
+		cpy.BlockAccessListHash = new(common.Hash)
+		*cpy.BlockAccessListHash = *h.BlockAccessListHash
 	}
 	return &cpy
 }

--- a/core/types/block_test.go
+++ b/core/types/block_test.go
@@ -250,6 +250,41 @@ func TestEIP4844BlockEncoding(t *testing.T) {
 	}
 }
 
+func TestAmsterdamHeaderRLPRoundTrip(t *testing.T) {
+	slotNumber := uint64(1)
+	blockAccessListHash := EmptyBlockAccessListHash
+	withdrawalsHash := EmptyRootHash
+	blobGasUsed := uint64(0)
+	excessBlobGas := uint64(0)
+	parentBeaconRoot := common.Hash{}
+	requestsHash := EmptyRequestsHash
+	for _, balHash := range []*common.Hash{nil, &blockAccessListHash} {
+		header := &Header{
+			Difficulty:          new(big.Int),
+			Number:              big.NewInt(1),
+			BaseFee:             big.NewInt(1),
+			WithdrawalsHash:     &withdrawalsHash,
+			BlobGasUsed:         &blobGasUsed,
+			ExcessBlobGas:       &excessBlobGas,
+			ParentBeaconRoot:    &parentBeaconRoot,
+			RequestsHash:        &requestsHash,
+			SlotNumber:          &slotNumber,
+			BlockAccessListHash: balHash,
+		}
+		encoded, err := rlp.EncodeToBytes(header)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var decoded Header
+		if err := rlp.DecodeBytes(encoded, &decoded); err != nil {
+			t.Fatal(err)
+		}
+		if header.Hash() != decoded.Hash() {
+			t.Fatalf("header hash mismatch: have %s, want %s", decoded.Hash(), header.Hash())
+		}
+	}
+}
+
 func TestUncleHash(t *testing.T) {
 	uncles := make([]*Header, 0)
 	h := CalcUncleHash(uncles)

--- a/core/types/block_test.go
+++ b/core/types/block_test.go
@@ -258,30 +258,28 @@ func TestAmsterdamHeaderRLPRoundTrip(t *testing.T) {
 	excessBlobGas := uint64(0)
 	parentBeaconRoot := common.Hash{}
 	requestsHash := EmptyRequestsHash
-	for _, balHash := range []*common.Hash{nil, &blockAccessListHash} {
-		header := &Header{
-			Difficulty:          new(big.Int),
-			Number:              big.NewInt(1),
-			BaseFee:             big.NewInt(1),
-			WithdrawalsHash:     &withdrawalsHash,
-			BlobGasUsed:         &blobGasUsed,
-			ExcessBlobGas:       &excessBlobGas,
-			ParentBeaconRoot:    &parentBeaconRoot,
-			RequestsHash:        &requestsHash,
-			SlotNumber:          &slotNumber,
-			BlockAccessListHash: balHash,
-		}
-		encoded, err := rlp.EncodeToBytes(header)
-		if err != nil {
-			t.Fatal(err)
-		}
-		var decoded Header
-		if err := rlp.DecodeBytes(encoded, &decoded); err != nil {
-			t.Fatal(err)
-		}
-		if header.Hash() != decoded.Hash() {
-			t.Fatalf("header hash mismatch: have %s, want %s", decoded.Hash(), header.Hash())
-		}
+	header := &Header{
+		Difficulty:          new(big.Int),
+		Number:              big.NewInt(1),
+		BaseFee:             big.NewInt(1),
+		WithdrawalsHash:     &withdrawalsHash,
+		BlobGasUsed:         &blobGasUsed,
+		ExcessBlobGas:       &excessBlobGas,
+		ParentBeaconRoot:    &parentBeaconRoot,
+		RequestsHash:        &requestsHash,
+		SlotNumber:          &slotNumber,
+		BlockAccessListHash: &blockAccessListHash,
+	}
+	encoded, err := rlp.EncodeToBytes(header)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded Header
+	if err := rlp.DecodeBytes(encoded, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if header.Hash() != decoded.Hash() {
+		t.Fatalf("header hash mismatch: have %s, want %s", decoded.Hash(), header.Hash())
 	}
 }
 

--- a/core/types/custody_bitmap.go
+++ b/core/types/custody_bitmap.go
@@ -1,0 +1,44 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package types
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
+
+// CustodyBitmap is the Engine API wire representation of the custody-column set.
+type CustodyBitmap [16]byte
+
+// MarshalText implements encoding.TextMarshaler.
+func (b CustodyBitmap) MarshalText() ([]byte, error) {
+	return []byte(hexutil.Encode(b[:])), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (b *CustodyBitmap) UnmarshalText(input []byte) error {
+	decoded, err := hexutil.Decode(string(input))
+	if err != nil {
+		return fmt.Errorf("custody bitmap: %v", err)
+	}
+	if len(decoded) != len(b) {
+		return fmt.Errorf("custody bitmap: invalid length %d, want %d", len(decoded), len(b))
+	}
+	copy(b[:], decoded)
+	return nil
+}

--- a/core/types/gen_header_json.go
+++ b/core/types/gen_header_json.go
@@ -16,29 +16,30 @@ var _ = (*headerMarshaling)(nil)
 // MarshalJSON marshals as JSON.
 func (h Header) MarshalJSON() ([]byte, error) {
 	type Header struct {
-		ParentHash       common.Hash     `json:"parentHash"       gencodec:"required"`
-		UncleHash        common.Hash     `json:"sha3Uncles"       gencodec:"required"`
-		Coinbase         common.Address  `json:"miner"`
-		Root             common.Hash     `json:"stateRoot"        gencodec:"required"`
-		TxHash           common.Hash     `json:"transactionsRoot" gencodec:"required"`
-		ReceiptHash      common.Hash     `json:"receiptsRoot"     gencodec:"required"`
-		Bloom            Bloom           `json:"logsBloom"        gencodec:"required"`
-		Difficulty       *hexutil.Big    `json:"difficulty"       gencodec:"required"`
-		Number           *hexutil.Big    `json:"number"           gencodec:"required"`
-		GasLimit         hexutil.Uint64  `json:"gasLimit"         gencodec:"required"`
-		GasUsed          hexutil.Uint64  `json:"gasUsed"          gencodec:"required"`
-		Time             hexutil.Uint64  `json:"timestamp"        gencodec:"required"`
-		Extra            hexutil.Bytes   `json:"extraData"        gencodec:"required"`
-		MixDigest        common.Hash     `json:"mixHash"`
-		Nonce            BlockNonce      `json:"nonce"`
-		BaseFee          *hexutil.Big    `json:"baseFeePerGas" rlp:"optional"`
-		WithdrawalsHash  *common.Hash    `json:"withdrawalsRoot" rlp:"optional"`
-		BlobGasUsed      *hexutil.Uint64 `json:"blobGasUsed" rlp:"optional"`
-		ExcessBlobGas    *hexutil.Uint64 `json:"excessBlobGas" rlp:"optional"`
-		ParentBeaconRoot *common.Hash    `json:"parentBeaconBlockRoot" rlp:"optional"`
-		RequestsHash     *common.Hash    `json:"requestsHash" rlp:"optional"`
-		SlotNumber       *hexutil.Uint64 `json:"slotNumber" rlp:"optional"`
-		Hash             common.Hash     `json:"hash"`
+		ParentHash          common.Hash     `json:"parentHash"       gencodec:"required"`
+		UncleHash           common.Hash     `json:"sha3Uncles"       gencodec:"required"`
+		Coinbase            common.Address  `json:"miner"`
+		Root                common.Hash     `json:"stateRoot"        gencodec:"required"`
+		TxHash              common.Hash     `json:"transactionsRoot" gencodec:"required"`
+		ReceiptHash         common.Hash     `json:"receiptsRoot"     gencodec:"required"`
+		Bloom               Bloom           `json:"logsBloom"        gencodec:"required"`
+		Difficulty          *hexutil.Big    `json:"difficulty"       gencodec:"required"`
+		Number              *hexutil.Big    `json:"number"           gencodec:"required"`
+		GasLimit            hexutil.Uint64  `json:"gasLimit"         gencodec:"required"`
+		GasUsed             hexutil.Uint64  `json:"gasUsed"          gencodec:"required"`
+		Time                hexutil.Uint64  `json:"timestamp"        gencodec:"required"`
+		Extra               hexutil.Bytes   `json:"extraData"        gencodec:"required"`
+		MixDigest           common.Hash     `json:"mixHash"`
+		Nonce               BlockNonce      `json:"nonce"`
+		BaseFee             *hexutil.Big    `json:"baseFeePerGas" rlp:"optional"`
+		WithdrawalsHash     *common.Hash    `json:"withdrawalsRoot" rlp:"optional"`
+		BlobGasUsed         *hexutil.Uint64 `json:"blobGasUsed" rlp:"optional"`
+		ExcessBlobGas       *hexutil.Uint64 `json:"excessBlobGas" rlp:"optional"`
+		ParentBeaconRoot    *common.Hash    `json:"parentBeaconBlockRoot" rlp:"optional"`
+		RequestsHash        *common.Hash    `json:"requestsHash" rlp:"optional"`
+		BlockAccessListHash *common.Hash    `json:"blockAccessListHash" rlp:"optional"`
+		SlotNumber          *hexutil.Uint64 `json:"slotNumber" rlp:"optional"`
+		Hash                common.Hash     `json:"hash"`
 	}
 	var enc Header
 	enc.ParentHash = h.ParentHash
@@ -62,6 +63,7 @@ func (h Header) MarshalJSON() ([]byte, error) {
 	enc.ExcessBlobGas = (*hexutil.Uint64)(h.ExcessBlobGas)
 	enc.ParentBeaconRoot = h.ParentBeaconRoot
 	enc.RequestsHash = h.RequestsHash
+	enc.BlockAccessListHash = h.BlockAccessListHash
 	enc.SlotNumber = (*hexutil.Uint64)(h.SlotNumber)
 	enc.Hash = h.Hash()
 	return json.Marshal(&enc)
@@ -70,28 +72,29 @@ func (h Header) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON unmarshals from JSON.
 func (h *Header) UnmarshalJSON(input []byte) error {
 	type Header struct {
-		ParentHash       *common.Hash    `json:"parentHash"       gencodec:"required"`
-		UncleHash        *common.Hash    `json:"sha3Uncles"       gencodec:"required"`
-		Coinbase         *common.Address `json:"miner"`
-		Root             *common.Hash    `json:"stateRoot"        gencodec:"required"`
-		TxHash           *common.Hash    `json:"transactionsRoot" gencodec:"required"`
-		ReceiptHash      *common.Hash    `json:"receiptsRoot"     gencodec:"required"`
-		Bloom            *Bloom          `json:"logsBloom"        gencodec:"required"`
-		Difficulty       *hexutil.Big    `json:"difficulty"       gencodec:"required"`
-		Number           *hexutil.Big    `json:"number"           gencodec:"required"`
-		GasLimit         *hexutil.Uint64 `json:"gasLimit"         gencodec:"required"`
-		GasUsed          *hexutil.Uint64 `json:"gasUsed"          gencodec:"required"`
-		Time             *hexutil.Uint64 `json:"timestamp"        gencodec:"required"`
-		Extra            *hexutil.Bytes  `json:"extraData"        gencodec:"required"`
-		MixDigest        *common.Hash    `json:"mixHash"`
-		Nonce            *BlockNonce     `json:"nonce"`
-		BaseFee          *hexutil.Big    `json:"baseFeePerGas" rlp:"optional"`
-		WithdrawalsHash  *common.Hash    `json:"withdrawalsRoot" rlp:"optional"`
-		BlobGasUsed      *hexutil.Uint64 `json:"blobGasUsed" rlp:"optional"`
-		ExcessBlobGas    *hexutil.Uint64 `json:"excessBlobGas" rlp:"optional"`
-		ParentBeaconRoot *common.Hash    `json:"parentBeaconBlockRoot" rlp:"optional"`
-		RequestsHash     *common.Hash    `json:"requestsHash" rlp:"optional"`
-		SlotNumber       *hexutil.Uint64 `json:"slotNumber" rlp:"optional"`
+		ParentHash          *common.Hash    `json:"parentHash"       gencodec:"required"`
+		UncleHash           *common.Hash    `json:"sha3Uncles"       gencodec:"required"`
+		Coinbase            *common.Address `json:"miner"`
+		Root                *common.Hash    `json:"stateRoot"        gencodec:"required"`
+		TxHash              *common.Hash    `json:"transactionsRoot" gencodec:"required"`
+		ReceiptHash         *common.Hash    `json:"receiptsRoot"     gencodec:"required"`
+		Bloom               *Bloom          `json:"logsBloom"        gencodec:"required"`
+		Difficulty          *hexutil.Big    `json:"difficulty"       gencodec:"required"`
+		Number              *hexutil.Big    `json:"number"           gencodec:"required"`
+		GasLimit            *hexutil.Uint64 `json:"gasLimit"         gencodec:"required"`
+		GasUsed             *hexutil.Uint64 `json:"gasUsed"          gencodec:"required"`
+		Time                *hexutil.Uint64 `json:"timestamp"        gencodec:"required"`
+		Extra               *hexutil.Bytes  `json:"extraData"        gencodec:"required"`
+		MixDigest           *common.Hash    `json:"mixHash"`
+		Nonce               *BlockNonce     `json:"nonce"`
+		BaseFee             *hexutil.Big    `json:"baseFeePerGas" rlp:"optional"`
+		WithdrawalsHash     *common.Hash    `json:"withdrawalsRoot" rlp:"optional"`
+		BlobGasUsed         *hexutil.Uint64 `json:"blobGasUsed" rlp:"optional"`
+		ExcessBlobGas       *hexutil.Uint64 `json:"excessBlobGas" rlp:"optional"`
+		ParentBeaconRoot    *common.Hash    `json:"parentBeaconBlockRoot" rlp:"optional"`
+		RequestsHash        *common.Hash    `json:"requestsHash" rlp:"optional"`
+		BlockAccessListHash *common.Hash    `json:"blockAccessListHash" rlp:"optional"`
+		SlotNumber          *hexutil.Uint64 `json:"slotNumber" rlp:"optional"`
 	}
 	var dec Header
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -171,6 +174,9 @@ func (h *Header) UnmarshalJSON(input []byte) error {
 	}
 	if dec.RequestsHash != nil {
 		h.RequestsHash = dec.RequestsHash
+	}
+	if dec.BlockAccessListHash != nil {
+		h.BlockAccessListHash = dec.BlockAccessListHash
 	}
 	if dec.SlotNumber != nil {
 		h.SlotNumber = (*uint64)(dec.SlotNumber)

--- a/core/types/gen_header_json.go
+++ b/core/types/gen_header_json.go
@@ -37,8 +37,8 @@ func (h Header) MarshalJSON() ([]byte, error) {
 		ExcessBlobGas       *hexutil.Uint64 `json:"excessBlobGas" rlp:"optional"`
 		ParentBeaconRoot    *common.Hash    `json:"parentBeaconBlockRoot" rlp:"optional"`
 		RequestsHash        *common.Hash    `json:"requestsHash" rlp:"optional"`
-		SlotNumber          *hexutil.Uint64 `json:"slotNumber" rlp:"optional"`
 		BlockAccessListHash *common.Hash    `json:"blockAccessListHash" rlp:"optional"`
+		SlotNumber          *hexutil.Uint64 `json:"slotNumber" rlp:"optional"`
 		Hash                common.Hash     `json:"hash"`
 	}
 	var enc Header
@@ -63,8 +63,8 @@ func (h Header) MarshalJSON() ([]byte, error) {
 	enc.ExcessBlobGas = (*hexutil.Uint64)(h.ExcessBlobGas)
 	enc.ParentBeaconRoot = h.ParentBeaconRoot
 	enc.RequestsHash = h.RequestsHash
-	enc.SlotNumber = (*hexutil.Uint64)(h.SlotNumber)
 	enc.BlockAccessListHash = h.BlockAccessListHash
+	enc.SlotNumber = (*hexutil.Uint64)(h.SlotNumber)
 	enc.Hash = h.Hash()
 	return json.Marshal(&enc)
 }
@@ -93,8 +93,8 @@ func (h *Header) UnmarshalJSON(input []byte) error {
 		ExcessBlobGas       *hexutil.Uint64 `json:"excessBlobGas" rlp:"optional"`
 		ParentBeaconRoot    *common.Hash    `json:"parentBeaconBlockRoot" rlp:"optional"`
 		RequestsHash        *common.Hash    `json:"requestsHash" rlp:"optional"`
-		SlotNumber          *hexutil.Uint64 `json:"slotNumber" rlp:"optional"`
 		BlockAccessListHash *common.Hash    `json:"blockAccessListHash" rlp:"optional"`
+		SlotNumber          *hexutil.Uint64 `json:"slotNumber" rlp:"optional"`
 	}
 	var dec Header
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -175,11 +175,11 @@ func (h *Header) UnmarshalJSON(input []byte) error {
 	if dec.RequestsHash != nil {
 		h.RequestsHash = dec.RequestsHash
 	}
-	if dec.SlotNumber != nil {
-		h.SlotNumber = (*uint64)(dec.SlotNumber)
-	}
 	if dec.BlockAccessListHash != nil {
 		h.BlockAccessListHash = dec.BlockAccessListHash
+	}
+	if dec.SlotNumber != nil {
+		h.SlotNumber = (*uint64)(dec.SlotNumber)
 	}
 	return nil
 }

--- a/core/types/gen_header_json.go
+++ b/core/types/gen_header_json.go
@@ -37,8 +37,8 @@ func (h Header) MarshalJSON() ([]byte, error) {
 		ExcessBlobGas       *hexutil.Uint64 `json:"excessBlobGas" rlp:"optional"`
 		ParentBeaconRoot    *common.Hash    `json:"parentBeaconBlockRoot" rlp:"optional"`
 		RequestsHash        *common.Hash    `json:"requestsHash" rlp:"optional"`
-		BlockAccessListHash *common.Hash    `json:"blockAccessListHash" rlp:"optional"`
 		SlotNumber          *hexutil.Uint64 `json:"slotNumber" rlp:"optional"`
+		BlockAccessListHash *common.Hash    `json:"blockAccessListHash" rlp:"optional"`
 		Hash                common.Hash     `json:"hash"`
 	}
 	var enc Header
@@ -63,8 +63,8 @@ func (h Header) MarshalJSON() ([]byte, error) {
 	enc.ExcessBlobGas = (*hexutil.Uint64)(h.ExcessBlobGas)
 	enc.ParentBeaconRoot = h.ParentBeaconRoot
 	enc.RequestsHash = h.RequestsHash
-	enc.BlockAccessListHash = h.BlockAccessListHash
 	enc.SlotNumber = (*hexutil.Uint64)(h.SlotNumber)
+	enc.BlockAccessListHash = h.BlockAccessListHash
 	enc.Hash = h.Hash()
 	return json.Marshal(&enc)
 }
@@ -93,8 +93,8 @@ func (h *Header) UnmarshalJSON(input []byte) error {
 		ExcessBlobGas       *hexutil.Uint64 `json:"excessBlobGas" rlp:"optional"`
 		ParentBeaconRoot    *common.Hash    `json:"parentBeaconBlockRoot" rlp:"optional"`
 		RequestsHash        *common.Hash    `json:"requestsHash" rlp:"optional"`
-		BlockAccessListHash *common.Hash    `json:"blockAccessListHash" rlp:"optional"`
 		SlotNumber          *hexutil.Uint64 `json:"slotNumber" rlp:"optional"`
+		BlockAccessListHash *common.Hash    `json:"blockAccessListHash" rlp:"optional"`
 	}
 	var dec Header
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -175,11 +175,11 @@ func (h *Header) UnmarshalJSON(input []byte) error {
 	if dec.RequestsHash != nil {
 		h.RequestsHash = dec.RequestsHash
 	}
-	if dec.BlockAccessListHash != nil {
-		h.BlockAccessListHash = dec.BlockAccessListHash
-	}
 	if dec.SlotNumber != nil {
 		h.SlotNumber = (*uint64)(dec.SlotNumber)
+	}
+	if dec.BlockAccessListHash != nil {
+		h.BlockAccessListHash = dec.BlockAccessListHash
 	}
 	return nil
 }

--- a/core/types/gen_header_rlp.go
+++ b/core/types/gen_header_rlp.go
@@ -43,8 +43,9 @@ func (obj *Header) EncodeRLP(_w io.Writer) error {
 	_tmp4 := obj.ExcessBlobGas != nil
 	_tmp5 := obj.ParentBeaconRoot != nil
 	_tmp6 := obj.RequestsHash != nil
-	_tmp7 := obj.SlotNumber != nil
-	if _tmp1 || _tmp2 || _tmp3 || _tmp4 || _tmp5 || _tmp6 || _tmp7 {
+	_tmp7 := obj.BlockAccessListHash != nil
+	_tmp8 := obj.SlotNumber != nil
+	if _tmp1 || _tmp2 || _tmp3 || _tmp4 || _tmp5 || _tmp6 || _tmp7 || _tmp8 {
 		if obj.BaseFee == nil {
 			w.Write(rlp.EmptyString)
 		} else {
@@ -54,42 +55,49 @@ func (obj *Header) EncodeRLP(_w io.Writer) error {
 			w.WriteBigInt(obj.BaseFee)
 		}
 	}
-	if _tmp2 || _tmp3 || _tmp4 || _tmp5 || _tmp6 || _tmp7 {
+	if _tmp2 || _tmp3 || _tmp4 || _tmp5 || _tmp6 || _tmp7 || _tmp8 {
 		if obj.WithdrawalsHash == nil {
 			w.Write([]byte{0x80})
 		} else {
 			w.WriteBytes(obj.WithdrawalsHash[:])
 		}
 	}
-	if _tmp3 || _tmp4 || _tmp5 || _tmp6 || _tmp7 {
+	if _tmp3 || _tmp4 || _tmp5 || _tmp6 || _tmp7 || _tmp8 {
 		if obj.BlobGasUsed == nil {
 			w.Write([]byte{0x80})
 		} else {
 			w.WriteUint64((*obj.BlobGasUsed))
 		}
 	}
-	if _tmp4 || _tmp5 || _tmp6 || _tmp7 {
+	if _tmp4 || _tmp5 || _tmp6 || _tmp7 || _tmp8 {
 		if obj.ExcessBlobGas == nil {
 			w.Write([]byte{0x80})
 		} else {
 			w.WriteUint64((*obj.ExcessBlobGas))
 		}
 	}
-	if _tmp5 || _tmp6 || _tmp7 {
+	if _tmp5 || _tmp6 || _tmp7 || _tmp8 {
 		if obj.ParentBeaconRoot == nil {
 			w.Write([]byte{0x80})
 		} else {
 			w.WriteBytes(obj.ParentBeaconRoot[:])
 		}
 	}
-	if _tmp6 || _tmp7 {
+	if _tmp6 || _tmp7 || _tmp8 {
 		if obj.RequestsHash == nil {
 			w.Write([]byte{0x80})
 		} else {
 			w.WriteBytes(obj.RequestsHash[:])
 		}
 	}
-	if _tmp7 {
+	if _tmp7 || _tmp8 {
+		if obj.BlockAccessListHash == nil {
+			w.Write([]byte{0x80})
+		} else {
+			w.WriteBytes(obj.BlockAccessListHash[:])
+		}
+	}
+	if _tmp8 {
 		if obj.SlotNumber == nil {
 			w.Write([]byte{0x80})
 		} else {

--- a/core/types/gen_header_rlp.go
+++ b/core/types/gen_header_rlp.go
@@ -43,8 +43,8 @@ func (obj *Header) EncodeRLP(_w io.Writer) error {
 	_tmp4 := obj.ExcessBlobGas != nil
 	_tmp5 := obj.ParentBeaconRoot != nil
 	_tmp6 := obj.RequestsHash != nil
-	_tmp7 := obj.SlotNumber != nil
-	_tmp8 := obj.BlockAccessListHash != nil
+	_tmp7 := obj.BlockAccessListHash != nil
+	_tmp8 := obj.SlotNumber != nil
 	if _tmp1 || _tmp2 || _tmp3 || _tmp4 || _tmp5 || _tmp6 || _tmp7 || _tmp8 {
 		if obj.BaseFee == nil {
 			w.Write(rlp.EmptyString)
@@ -91,17 +91,17 @@ func (obj *Header) EncodeRLP(_w io.Writer) error {
 		}
 	}
 	if _tmp7 || _tmp8 {
-		if obj.SlotNumber == nil {
-			w.Write([]byte{0x80})
-		} else {
-			w.WriteUint64((*obj.SlotNumber))
-		}
-	}
-	if _tmp8 {
 		if obj.BlockAccessListHash == nil {
 			w.Write([]byte{0x80})
 		} else {
 			w.WriteBytes(obj.BlockAccessListHash[:])
+		}
+	}
+	if _tmp8 {
+		if obj.SlotNumber == nil {
+			w.Write([]byte{0x80})
+		} else {
+			w.WriteUint64((*obj.SlotNumber))
 		}
 	}
 	w.ListEnd(_tmp0)

--- a/core/types/gen_header_rlp.go
+++ b/core/types/gen_header_rlp.go
@@ -43,8 +43,8 @@ func (obj *Header) EncodeRLP(_w io.Writer) error {
 	_tmp4 := obj.ExcessBlobGas != nil
 	_tmp5 := obj.ParentBeaconRoot != nil
 	_tmp6 := obj.RequestsHash != nil
-	_tmp7 := obj.BlockAccessListHash != nil
-	_tmp8 := obj.SlotNumber != nil
+	_tmp7 := obj.SlotNumber != nil
+	_tmp8 := obj.BlockAccessListHash != nil
 	if _tmp1 || _tmp2 || _tmp3 || _tmp4 || _tmp5 || _tmp6 || _tmp7 || _tmp8 {
 		if obj.BaseFee == nil {
 			w.Write(rlp.EmptyString)
@@ -91,17 +91,17 @@ func (obj *Header) EncodeRLP(_w io.Writer) error {
 		}
 	}
 	if _tmp7 || _tmp8 {
-		if obj.BlockAccessListHash == nil {
-			w.Write([]byte{0x80})
-		} else {
-			w.WriteBytes(obj.BlockAccessListHash[:])
-		}
-	}
-	if _tmp8 {
 		if obj.SlotNumber == nil {
 			w.Write([]byte{0x80})
 		} else {
 			w.WriteUint64((*obj.SlotNumber))
+		}
+	}
+	if _tmp8 {
+		if obj.BlockAccessListHash == nil {
+			w.Write([]byte{0x80})
+		} else {
+			w.WriteBytes(obj.BlockAccessListHash[:])
 		}
 	}
 	w.ListEnd(_tmp0)

--- a/core/types/hashes.go
+++ b/core/types/hashes.go
@@ -43,6 +43,9 @@ var (
 	// EmptyRequestsHash is the known hash of an empty request set, sha256("").
 	EmptyRequestsHash = common.HexToHash("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
 
+	// EmptyBlockAccessListHash is the known hash of an empty block access list, keccak256(rlp.encode([])).
+	EmptyBlockAccessListHash = common.HexToHash("0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347")
+
 	// EmptyVerkleHash is the known hash of an empty verkle trie.
 	EmptyVerkleHash = common.Hash{}
 

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -215,7 +215,7 @@ func (api *ConsensusAPI) ForkchoiceUpdatedV3(ctx context.Context, update engine.
 
 // ForkchoiceUpdatedV4 is equivalent to V3 with the addition of slot number
 // in the payload attributes. It supports only PayloadAttributesV4.
-func (api *ConsensusAPI) ForkchoiceUpdatedV4(ctx context.Context, update engine.ForkchoiceStateV1, params *engine.PayloadAttributes) (engine.ForkChoiceResponse, error) {
+func (api *ConsensusAPI) ForkchoiceUpdatedV4(ctx context.Context, update engine.ForkchoiceStateV1, params *engine.PayloadAttributes, _ *types.CustodyBitmap) (engine.ForkChoiceResponse, error) {
 	if params != nil {
 		switch {
 		case params.Withdrawals == nil:
@@ -224,6 +224,8 @@ func (api *ConsensusAPI) ForkchoiceUpdatedV4(ctx context.Context, update engine.
 			return engine.STATUS_INVALID, attributesErr("missing beacon root")
 		case params.SlotNumber == nil:
 			return engine.STATUS_INVALID, attributesErr("missing slot number")
+		case params.TargetGasLimit == nil:
+			return engine.STATUS_INVALID, attributesErr("missing target gas limit")
 		case !api.checkFork(params.Timestamp, forks.Amsterdam):
 			return engine.STATUS_INVALID, unsupportedForkErr("fcuV4 must only be called for amsterdam payloads")
 		}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1106,6 +1106,9 @@ func RPCMarshalHeader(head *types.Header) map[string]interface{} {
 	if head.RequestsHash != nil {
 		result["requestsHash"] = head.RequestsHash
 	}
+	if head.BlockAccessListHash != nil {
+		result["blockAccessListHash"] = head.BlockAccessListHash
+	}
 	if head.SlotNumber != nil {
 		result["slotNumber"] = hexutil.Uint64(*head.SlotNumber)
 	}

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -3412,6 +3412,21 @@ func TestRPCMarshalBlock(t *testing.T) {
 	}
 }
 
+func TestRPCMarshalHeaderAmsterdamFields(t *testing.T) {
+	blockAccessListHash := types.EmptyBlockAccessListHash
+	slotNumber := uint64(42)
+	header := &types.Header{
+		Number:              big.NewInt(0),
+		Difficulty:          big.NewInt(0),
+		BlockAccessListHash: &blockAccessListHash,
+		SlotNumber:          &slotNumber,
+	}
+
+	result := RPCMarshalHeader(header)
+	require.Equal(t, &blockAccessListHash, result["blockAccessListHash"])
+	require.Equal(t, hexutil.Uint64(slotNumber), result["slotNumber"])
+}
+
 func TestRPCGetBlockOrHeader(t *testing.T) {
 	t.Parallel()
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -404,6 +404,7 @@ func (miner *Miner) prepareWork(ctx context.Context, genParams *generateParams, 
 		if genParams.slotNum == nil {
 			return nil, errors.New("no slot number set post-amsterdam")
 		}
+		header.BlockAccessListHash = &types.EmptyBlockAccessListHash
 		header.SlotNumber = genParams.slotNum
 	}
 	// Could potentially happen if starting to mine in an odd state.


### PR DESCRIPTION
## Summary

- add the EIP-7928 block-access-list commitment to header JSON, RLP, copying, and hashing
- expose the commitment through RPC and initialize the empty commitment for Amsterdam genesis/test construction
- add the Glamsterdam Engine API wire shapes used by the Optimism monorepo: opaque `blockAccessList` bytes, `targetGasLimit`, and `CustodyBitmap`
- derive the header commitment from the opaque RLP-encoded block access list when reconstructing an execution payload

## Scope

This is a **type and wire-compatibility backport**, not a full EIP-7928 implementation.

The Optimism monorepo still resolves go-ethereum imports to op-geth. [optimism#21920](https://github.com/ethereum-optimism/optimism/pull/21920) needs these upstream-compatible types to decode and hash post-Amsterdam L1 headers and to speak the Glamsterdam Engine API. The stacked transition test in [optimism#21921](https://github.com/ethereum-optimism/optimism/pull/21921) uses an upstream Glamsterdam-capable Geth subprocess for actual L1 execution.

This PR deliberately does not add BAL collection/execution, body storage or historical serving, sync support, complete target-gas-limit block building, or complete Amsterdam consensus validation to op-geth. We are accepting the limited in-process test coverage gap rather than porting the full feature into op-geth.
