### PR TITLE
fix(sdm): core/types: hash PostExecTx over its canonical encoding

### DIFF
--- a/core/types/post_exec_tx_test.go
+++ b/core/types/post_exec_tx_test.go
@@ -7,8 +7,21 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
 )
+
+// TestPostExecTxHashIsCanonicalEncoding pins the universal typed-tx rule: the hash is keccak256 of
+// the canonical EIP-2718 encoding (0x7D || Data), the same rule DepositTx follows. It must not wrap
+// Data in the inner struct's RLP — PostExecTx.encode writes Data verbatim, so the hash preimage
+// must equal MarshalBinary, not RLP([Data]).
+func TestPostExecTxHashIsCanonicalEncoding(t *testing.T) {
+	tx := NewTx(&PostExecTx{Data: hexutil.MustDecode("0xc201c0")})
+
+	bin, err := tx.MarshalBinary()
+	require.NoError(t, err)
+	require.Equal(t, crypto.Keccak256Hash(bin), tx.Hash())
+}
 
 func TestPostExecTxUnmarshalJSON(t *testing.T) {
 	var tx Transaction

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -700,9 +700,14 @@ func (tx *Transaction) Hash() common.Hash {
 	}
 
 	var h common.Hash
-	if tx.Type() == LegacyTxType {
+	switch tx.Type() {
+	case LegacyTxType:
 		h = rlpHash(tx.inner)
-	} else {
+	case PostExecTxType:
+		// Canonical encoding is 0x7D || Data (not RLP of the inner struct); hash that, like every
+		// other typed tx.
+		h = crypto.Keccak256Hash([]byte{PostExecTxType}, tx.Data())
+	default:
 		h = prefixedRlpHash(tx.Type(), tx.inner)
 	}
 	tx.hash.Store(&h)


### PR DESCRIPTION
## Problem

`PostExecTx.encode` writes `Data` verbatim, so a post-exec (0x7D) transaction's canonical EIP-2718 encoding is `0x7D || Data`. But `Transaction.Hash` routed every non-legacy tx through `prefixedRlpHash(type, inner)`, which RLP-encodes the *inner struct* — yielding `keccak256(0x7D || RLP([Data]))`, a hash preimage that does not match the wire encoding.

Every other typed tx satisfies `hash preimage == canonical encoding` because its `encode()` is `rlp.Encode(b, tx)` (the struct's RLP). `PostExecTx` is the sole outlier — its `encode()` writes an already-RLP-encoded payload verbatim, with no struct envelope — so the generic path hashed the wrong preimage.

The consequence is cross-client: op-reth (op-alloy `TxPostExec::tx_hash`) hashes the canonical encoding `keccak256(0x7D || Data)`, matching `DepositTx` and every standard typed tx. op-geth exposed a *different* tx hash over RPC and indexed receipts under it, so a consumer that derives the hash from block contents (e.g. `op-service/sources`) cannot fetch the post-exec receipt across a mixed op-geth/op-reth fleet.

## Fix

Special-case `PostExecTxType` in `Transaction.Hash` to hash the canonical EIP-2718 encoding directly:

```go
case PostExecTxType:
    h = crypto.Keccak256Hash([]byte{PostExecTxType}, tx.Data())
```

## Safety

The canonical encoding is unchanged, so the transactions-root and block hashes are unaffected — only the transaction hash / receipt key changes (an RPC/index identifier, not consensus over block validity).

## Test

`TestPostExecTxHashIsCanonicalEncoding` pins the universal rule `Hash() == keccak256(MarshalBinary())`. It fails on the baseline (`0xcd47…4bb7` vs canonical `0xf5fa…0184`) and passes with the fix. Full `core/types` package: 195/195 pass; `DepositTx` hashes are unchanged.

## Related

- op-reth/op-alloy is already correct — no change needed there.
- Follow-ups in the monorepo (not part of this PR): bump the op-geth pin, and correct the `op-service/sources` post-exec codec (PR #21907), which currently reproduces the old `RLP([Data])` value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)