### PR TITLE
feat: EIP-8130 types

### DIFF
--- a/core/types/eip8130_account_changes.go
+++ b/core/types/eip8130_account_changes.go
@@ -1,0 +1,315 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package types
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+// EIP-8130 account_changes entry type bytes. On the wire each entry is a single
+// flat RLP list whose first element is the type byte: rlp([type_byte, fields...]).
+const (
+	accountChangeTypeCreate     = 0x00
+	accountChangeTypeConfig     = 0x01
+	accountChangeTypeDelegation = 0x02
+)
+
+// ActorChangeType is the operation performed by an ActorChange. The value is the
+// on-wire op byte; in RLP it encodes as a bare uint, in JSON as a string.
+type ActorChangeType uint8
+
+const (
+	ActorChangeAuthorize ActorChangeType = 0x01
+	ActorChangeRevoke    ActorChangeType = 0x02
+)
+
+func (t ActorChangeType) MarshalJSON() ([]byte, error) {
+	switch t {
+	case ActorChangeAuthorize:
+		return []byte(`"Authorize"`), nil
+	case ActorChangeRevoke:
+		return []byte(`"Revoke"`), nil
+	default:
+		return nil, fmt.Errorf("eip8130: invalid actor change type %d", uint8(t))
+	}
+}
+
+func (t *ActorChangeType) UnmarshalJSON(input []byte) error {
+	switch string(input) {
+	case `"Authorize"`:
+		*t = ActorChangeAuthorize
+	case `"Revoke"`:
+		*t = ActorChangeRevoke
+	default:
+		return fmt.Errorf("eip8130: invalid actor change type %s", input)
+	}
+	return nil
+}
+
+// DecodeRLP reads the op byte and rejects any value other than Authorize (0x01)
+// or Revoke (0x02), matching the Rust strict decode (ActorChangeType::from_op_byte).
+// Without this, the derived uint8 decoder would accept any byte 0x00..0xff.
+func (t *ActorChangeType) DecodeRLP(s *rlp.Stream) error {
+	b, err := s.Uint8()
+	if err != nil {
+		return err
+	}
+	switch ActorChangeType(b) {
+	case ActorChangeAuthorize, ActorChangeRevoke:
+		*t = ActorChangeType(b)
+		return nil
+	default:
+		return fmt.Errorf("eip8130: invalid actor change type byte 0x%x", b)
+	}
+}
+
+// InitialActor is an actor installed on a newly-created account. Wire form is
+// rlp([actorId, authenticator, scope, policyData]); scope is stored verbatim
+// (0x00 = unrestricted admin) and policyData is empty unless scope sets the
+// POLICY bit.
+type InitialActor struct {
+	ActorID       common.Hash    `json:"actorId"`
+	Authenticator common.Address `json:"authenticator"`
+	Scope         uint8          `json:"scope"`
+	PolicyData    hexutil.Bytes  `json:"policyData"`
+}
+
+// ActorChange is a single actor authorize/revoke operation inside a ConfigChange.
+// Wire form is rlp([changeType, actorId, data]); data is opaque at this layer.
+type ActorChange struct {
+	ChangeType ActorChangeType `json:"changeType"`
+	ActorID    common.Hash     `json:"actorId"`
+	Data       hexutil.Bytes   `json:"data"`
+}
+
+// CreateEntry is the body of an AccountChange create entry. Wire form is
+// rlp([userSalt, code, [InitialActor, ...]]).
+type CreateEntry struct {
+	UserSalt      common.Hash    `json:"userSalt"`
+	Code          hexutil.Bytes  `json:"code"`
+	InitialActors []InitialActor `json:"initialActors"`
+}
+
+// ConfigChange is the body of an AccountChange config-change entry. Wire form is
+// rlp([chainId, sequence, [ActorChange, ...], auth]).
+type ConfigChange struct {
+	ChainID      uint64        `json:"chainId"`
+	Sequence     uint64        `json:"sequence"`
+	ActorChanges []ActorChange `json:"actorChanges"`
+	Auth         hexutil.Bytes `json:"auth"`
+}
+
+// Delegation is the body of an AccountChange delegation entry. Wire form is
+// rlp([target]); a zero target clears the existing delegation.
+type Delegation struct {
+	Target common.Address `json:"target"`
+}
+
+// AccountChange is a tagged-union entry inside Eip8130Tx.AccountChanges. Exactly
+// one of the body pointers is set. On the wire each entry is a single flat RLP
+// list whose first element is the type byte, followed by the body fields inline:
+// rlp([type_byte, body fields...]). The type byte is a genuine list element (not
+// an EIP-2718-style type_byte || rlp(...) prefix), so each entry is one
+// self-contained RLP item. In JSON it is the body object with an added "type"
+// discriminator ("create" / "configChange" / "delegation").
+type AccountChange struct {
+	Create       *CreateEntry
+	ConfigChange *ConfigChange
+	Delegation   *Delegation
+}
+
+// resolveBody returns the wire type byte, the JSON discriminator and the body
+// value of the single set body pointer. It enforces the tagged-union invariant
+// that exactly one of Create/ConfigChange/Delegation is set, matching the Rust
+// enum, which can only ever hold a single variant. The returned body has its
+// nil nested slices normalized to empty slices so JSON marshalling emits [] (to
+// match serde's Vec) rather than null; the original AccountChange is never
+// mutated.
+func (a AccountChange) resolveBody() (typeByte byte, typ string, body interface{}, err error) {
+	n := 0
+	if a.Create != nil {
+		n++
+		cpy := *a.Create
+		if cpy.InitialActors == nil {
+			cpy.InitialActors = []InitialActor{}
+		}
+		typeByte, typ, body = accountChangeTypeCreate, "create", &cpy
+	}
+	if a.ConfigChange != nil {
+		n++
+		cpy := *a.ConfigChange
+		if cpy.ActorChanges == nil {
+			cpy.ActorChanges = []ActorChange{}
+		}
+		typeByte, typ, body = accountChangeTypeConfig, "configChange", &cpy
+	}
+	if a.Delegation != nil {
+		n++
+		typeByte, typ, body = accountChangeTypeDelegation, "delegation", a.Delegation
+	}
+	if n != 1 {
+		return 0, "", nil, errors.New("eip8130: account change must set exactly one body")
+	}
+	return typeByte, typ, body, nil
+}
+
+// EncodeRLP writes the entry as a single flat list rlp([type_byte, body
+// fields...]). The type byte is an in-list element encoded as an RLP uint (e.g.
+// 0x00 -> 0x80), followed by the set body's fields inline, mirroring the Rust
+// encoder.
+func (a AccountChange) EncodeRLP(w io.Writer) error {
+	typeByte, _, body, err := a.resolveBody()
+	if err != nil {
+		return err
+	}
+
+	buf := rlp.NewEncoderBuffer(w)
+	list := buf.List()
+	buf.WriteUint64(uint64(typeByte))
+
+	// The body's fields are written inline (no inner list header) so the whole
+	// entry is one flat list.
+	switch b := body.(type) {
+	case *CreateEntry:
+		buf.WriteBytes(b.UserSalt[:])
+		buf.WriteBytes(b.Code)
+		if err := rlp.Encode(buf, b.InitialActors); err != nil {
+			return err
+		}
+	case *ConfigChange:
+		buf.WriteUint64(b.ChainID)
+		buf.WriteUint64(b.Sequence)
+		if err := rlp.Encode(buf, b.ActorChanges); err != nil {
+			return err
+		}
+		buf.WriteBytes(b.Auth)
+	case *Delegation:
+		buf.WriteBytes(b.Target[:])
+	default:
+		return fmt.Errorf("eip8130: unexpected account change body %T", body)
+	}
+
+	buf.ListEnd(list)
+	return buf.Flush()
+}
+
+// DecodeRLP reads the single flat list, reads the type byte as an RLP uint,
+// dispatches on it and decodes the body fields positionally, then enforces that
+// the list is fully consumed. Rejects any unknown type byte. Returns rlp.EOL at
+// the end of the enclosing list so it composes with slice decoding.
+func (a *AccountChange) DecodeRLP(s *rlp.Stream) error {
+	if _, err := s.List(); err != nil {
+		return err
+	}
+	typeByte, err := s.Uint8()
+	if err != nil {
+		return err
+	}
+
+	switch typeByte {
+	case accountChangeTypeCreate:
+		body := new(CreateEntry)
+		if err := s.Decode(&body.UserSalt); err != nil {
+			return err
+		}
+		var code []byte
+		if err := s.Decode(&code); err != nil {
+			return err
+		}
+		body.Code = code
+		if err := s.Decode(&body.InitialActors); err != nil {
+			return err
+		}
+		a.Create = body
+	case accountChangeTypeConfig:
+		body := new(ConfigChange)
+		if err := s.Decode(&body.ChainID); err != nil {
+			return err
+		}
+		if err := s.Decode(&body.Sequence); err != nil {
+			return err
+		}
+		if err := s.Decode(&body.ActorChanges); err != nil {
+			return err
+		}
+		var auth []byte
+		if err := s.Decode(&auth); err != nil {
+			return err
+		}
+		body.Auth = auth
+		a.ConfigChange = body
+	case accountChangeTypeDelegation:
+		body := new(Delegation)
+		if err := s.Decode(&body.Target); err != nil {
+			return err
+		}
+		a.Delegation = body
+	default:
+		return fmt.Errorf("eip8130: invalid account change type byte 0x%x", typeByte)
+	}
+
+	// Enforce that the list is fully consumed (no trailing elements).
+	return s.ListEnd()
+}
+
+// MarshalJSON encodes the entry as its body object plus a "type" discriminator.
+func (a AccountChange) MarshalJSON() ([]byte, error) {
+	_, typ, body, err := a.resolveBody()
+	if err != nil {
+		return nil, err
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	fields := map[string]json.RawMessage{}
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return nil, err
+	}
+	fields["type"], _ = json.Marshal(typ)
+	return json.Marshal(fields)
+}
+
+// UnmarshalJSON dispatches on the "type" discriminator.
+func (a *AccountChange) UnmarshalJSON(input []byte) error {
+	var tag struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(input, &tag); err != nil {
+		return err
+	}
+	switch tag.Type {
+	case "create":
+		a.Create = new(CreateEntry)
+		return json.Unmarshal(input, a.Create)
+	case "configChange":
+		a.ConfigChange = new(ConfigChange)
+		return json.Unmarshal(input, a.ConfigChange)
+	case "delegation":
+		a.Delegation = new(Delegation)
+		return json.Unmarshal(input, a.Delegation)
+	default:
+		return fmt.Errorf("eip8130: unknown account change type %q", tag.Type)
+	}
+}

--- a/core/types/eip8130_call.go
+++ b/core/types/eip8130_call.go
@@ -1,0 +1,31 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package types
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
+
+// Call is a single call dispatched by the protocol during EIP-8130 transaction
+// execution. The wire form is rlp([to, data]); the dispatched call carries no
+// value. Calls are grouped into phases on the transaction as [][]Call, which
+// encodes as rlp([rlp([Call, ...]), ...]).
+type Call struct {
+	To   common.Address `json:"to"`
+	Data hexutil.Bytes  `json:"data"`
+}

--- a/core/types/eip8130_tx.go
+++ b/core/types/eip8130_tx.go
@@ -1,0 +1,226 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package types
+
+import (
+	"bytes"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+// Eip8130Tx is a field-aware representation of an EIP-8130 transaction. The nested
+// account_changes and calls structures are modelled as typed Go values; the
+// authorization blobs are kept as raw bytes.
+type Eip8130Tx struct {
+	ChainID        *big.Int
+	Sender         *common.Address `rlp:"nil"` // nil means the empty EOA path
+	NonceKey       *big.Int
+	NonceSequence  uint64
+	Expiry         uint64
+	GasTipCap      *big.Int // a.k.a. maxPriorityFeePerGas
+	GasFeeCap      *big.Int // a.k.a. maxFeePerGas
+	GasLimit       uint64
+	AccountChanges []AccountChange // account-mutation entries applied before calls execute
+	Calls          [][]Call        // calls grouped into phases
+	Metadata       []byte          // opaque attribution bytes; not interpreted by the protocol
+	Payer          *common.Address `rlp:"nil"` // nil means self-pay
+	SenderAuth     []byte
+	PayerAuth      []byte
+}
+
+// copy creates a deep copy of the transaction data and initializes all fields.
+func (tx *Eip8130Tx) copy() TxData {
+	cpy := &Eip8130Tx{
+		Sender:         copyAddressPtr(tx.Sender),
+		NonceSequence:  tx.NonceSequence,
+		Expiry:         tx.Expiry,
+		GasLimit:       tx.GasLimit,
+		AccountChanges: copyAccountChanges(tx.AccountChanges),
+		Calls:          copyCalls(tx.Calls),
+		Metadata:       common.CopyBytes(tx.Metadata),
+		Payer:          copyAddressPtr(tx.Payer),
+		SenderAuth:     common.CopyBytes(tx.SenderAuth),
+		PayerAuth:      common.CopyBytes(tx.PayerAuth),
+		// These are copied below.
+		ChainID:   new(big.Int),
+		NonceKey:  new(big.Int),
+		GasTipCap: new(big.Int),
+		GasFeeCap: new(big.Int),
+	}
+	if tx.ChainID != nil {
+		cpy.ChainID.Set(tx.ChainID)
+	}
+	if tx.NonceKey != nil {
+		cpy.NonceKey.Set(tx.NonceKey)
+	}
+	if tx.GasTipCap != nil {
+		cpy.GasTipCap.Set(tx.GasTipCap)
+	}
+	if tx.GasFeeCap != nil {
+		cpy.GasFeeCap.Set(tx.GasFeeCap)
+	}
+	return cpy
+}
+
+// accessors for innerTx.
+func (tx *Eip8130Tx) txType() byte           { return Eip8130TxType }
+func (tx *Eip8130Tx) chainID() *big.Int      { return tx.ChainID }
+func (tx *Eip8130Tx) accessList() AccessList { return nil }
+func (tx *Eip8130Tx) data() []byte           { return nil }
+func (tx *Eip8130Tx) gas() uint64            { return tx.GasLimit }
+func (tx *Eip8130Tx) gasFeeCap() *big.Int    { return tx.GasFeeCap }
+func (tx *Eip8130Tx) gasTipCap() *big.Int    { return tx.GasTipCap }
+
+// gasPrice returns GasFeeCap. Precondition: GasFeeCap is always non-nil; see
+// effectiveGasPrice for where this is guaranteed.
+func (tx *Eip8130Tx) gasPrice() *big.Int  { return tx.GasFeeCap }
+func (tx *Eip8130Tx) value() *big.Int     { return common.Big0 }
+func (tx *Eip8130Tx) nonce() uint64       { return tx.NonceSequence }
+func (tx *Eip8130Tx) to() *common.Address { return nil }
+func (tx *Eip8130Tx) isSystemTx() bool    { return false }
+
+// effectiveGasPrice computes the effective gas price from the fee caps and base
+// fee. Precondition: GasFeeCap and GasTipCap are always non-nil. This holds
+// because RLP decode always populates the *big.Int fields and JSON decode
+// requires maxFeePerGas/maxPriorityFeePerGas (see UnmarshalJSON's
+// missing-required-field checks); an in-memory tx is expected to set them too.
+func (tx *Eip8130Tx) effectiveGasPrice(dst *big.Int, baseFee *big.Int) *big.Int {
+	if baseFee == nil {
+		return dst.Set(tx.GasFeeCap)
+	}
+	tip := dst.Sub(tx.GasFeeCap, baseFee)
+	if tip.Cmp(tx.GasTipCap) > 0 {
+		tip.Set(tx.GasTipCap)
+	}
+	return tip.Add(tip, baseFee)
+}
+
+// rawSignatureValues returns zeroes. EIP-8130 carries its authorization in the
+// sender_auth and payer_auth fields rather than in v, r, s.
+func (tx *Eip8130Tx) rawSignatureValues() (v, r, s *big.Int) {
+	return common.Big0, common.Big0, common.Big0
+}
+
+// setSignatureValues only records the chain ID. EIP-8130 has no canonical
+// v, r, s; the authorization lives in the transaction fields.
+func (tx *Eip8130Tx) setSignatureValues(chainID, v, r, s *big.Int) {
+	tx.ChainID = chainID
+}
+
+// copyCalls deep-copies the call phases, including each call's Data slice, so the
+// copy shares no backing array with the original.
+func copyCalls(calls [][]Call) [][]Call {
+	if calls == nil {
+		return nil
+	}
+	cpy := make([][]Call, len(calls))
+	for i, phase := range calls {
+		if phase == nil {
+			continue
+		}
+		cpyPhase := make([]Call, len(phase))
+		for j, c := range phase {
+			cpyPhase[j] = Call{To: c.To, Data: common.CopyBytes(c.Data)}
+		}
+		cpy[i] = cpyPhase
+	}
+	return cpy
+}
+
+// copyAccountChanges deep-copies the account-change entries, cloning the body
+// pointers and every inner slice so the copy cannot alias the original.
+func copyAccountChanges(changes []AccountChange) []AccountChange {
+	if changes == nil {
+		return nil
+	}
+	cpy := make([]AccountChange, len(changes))
+	for i, ac := range changes {
+		cpy[i] = ac.copy()
+	}
+	return cpy
+}
+
+// copy returns a deep copy of the entry: the set body pointer and all of its
+// inner slices are cloned so neither the copy nor the original aliases the other.
+func (a AccountChange) copy() AccountChange {
+	switch {
+	case a.Create != nil:
+		var actors []InitialActor
+		if a.Create.InitialActors != nil {
+			actors = make([]InitialActor, len(a.Create.InitialActors))
+			for i, ia := range a.Create.InitialActors {
+				actors[i] = InitialActor{
+					ActorID:       ia.ActorID,
+					Authenticator: ia.Authenticator,
+					Scope:         ia.Scope,
+					PolicyData:    common.CopyBytes(ia.PolicyData),
+				}
+			}
+		}
+
+		return AccountChange{Create: &CreateEntry{
+			UserSalt:      a.Create.UserSalt,
+			Code:          common.CopyBytes(a.Create.Code),
+			InitialActors: actors,
+		}}
+	case a.ConfigChange != nil:
+		var changes []ActorChange
+		if a.ConfigChange.ActorChanges != nil {
+			changes = make([]ActorChange, len(a.ConfigChange.ActorChanges))
+			for i, c := range a.ConfigChange.ActorChanges {
+				changes[i] = ActorChange{
+					ChangeType: c.ChangeType,
+					ActorID:    c.ActorID,
+					Data:       common.CopyBytes(c.Data),
+				}
+			}
+		}
+
+		return AccountChange{ConfigChange: &ConfigChange{
+			ChainID:      a.ConfigChange.ChainID,
+			Sequence:     a.ConfigChange.Sequence,
+			ActorChanges: changes,
+			Auth:         common.CopyBytes(a.ConfigChange.Auth),
+		}}
+	case a.Delegation != nil:
+		return AccountChange{Delegation: &Delegation{Target: a.Delegation.Target}}
+	default:
+		return AccountChange{}
+	}
+}
+
+func (tx *Eip8130Tx) encode(b *bytes.Buffer) error {
+	// Empty account_changes and calls slices encode as the canonical RLP empty
+	// list (0xc0), keeping the 2718 stream's element count stable.
+	return rlp.Encode(b, tx)
+}
+
+func (tx *Eip8130Tx) decode(input []byte) error {
+	return rlp.DecodeBytes(input, tx)
+}
+
+// sigHash has no meaningful value for EIP-8130: authorization lives in the
+// sender_auth and payer_auth fields, not in the canonical (v, r, s) fields, and
+// any recovery uses an EIP-8130-specific payload, so the generic signing-hash
+// path does not apply. It returns the zero hash as a sentinel rather than
+// panicking; the signer never consumes it (modernSigner.Sender short-circuits
+// 0x79 before reaching the hash path).
+func (tx *Eip8130Tx) sigHash(*big.Int) common.Hash {
+	return common.Hash{}
+}

--- a/core/types/eip8130_tx_test.go
+++ b/core/types/eip8130_tx_test.go
@@ -1,0 +1,692 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package types
+
+import (
+	"bytes"
+	"encoding/json"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+func ptrAddr(b byte) *common.Address {
+	a := common.Address{b}
+	return &a
+}
+
+// roundTripEip8130 marshals tx, decodes it back and re-marshals it, asserting the
+// canonical 2718 encoding is byte-identical across the round-trip. It returns the
+// canonical encoding.
+func roundTripEip8130(t *testing.T, inner *Eip8130Tx) []byte {
+	t.Helper()
+	enc, err := NewTx(inner).MarshalBinary()
+	if err != nil {
+		t.Fatalf("MarshalBinary: %v", err)
+	}
+	if enc[0] != Eip8130TxType {
+		t.Fatalf("type byte = %#x, want %#x", enc[0], Eip8130TxType)
+	}
+	var got Transaction
+	if err := got.UnmarshalBinary(enc); err != nil {
+		t.Fatalf("UnmarshalBinary: %v", err)
+	}
+	reEnc, err := got.MarshalBinary()
+	if err != nil {
+		t.Fatalf("re-MarshalBinary: %v", err)
+	}
+	if !bytes.Equal(enc, reEnc) {
+		t.Fatalf("round-trip not byte-exact:\n got %x\nwant %x", reEnc, enc)
+	}
+	return enc
+}
+
+// TestEip8130TxBinaryRoundTrip verifies that encoding an EIP-8130 transaction and
+// decoding it back yields a byte-identical canonical encoding for the EOA,
+// configured self-pay and configured-with-payer cases.
+func TestEip8130TxBinaryRoundTrip(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		tx   *Eip8130Tx
+	}{
+		{
+			name: "eoa self-pay",
+			tx: &Eip8130Tx{
+				ChainID:       big.NewInt(8453),
+				Sender:        nil,
+				NonceKey:      big.NewInt(0),
+				NonceSequence: 7,
+				Expiry:        100,
+				GasTipCap:     big.NewInt(1),
+				GasFeeCap:     big.NewInt(2),
+				GasLimit:      21000,
+				SenderAuth:    bytes.Repeat([]byte{0xaa}, 65), // r||s||v
+				PayerAuth:     nil,
+			},
+		},
+		{
+			name: "configured self-pay",
+			tx: &Eip8130Tx{
+				ChainID:       big.NewInt(8453),
+				Sender:        ptrAddr(0x11),
+				NonceKey:      big.NewInt(3),
+				NonceSequence: 8,
+				Expiry:        200,
+				GasTipCap:     big.NewInt(5),
+				GasFeeCap:     big.NewInt(9),
+				GasLimit:      50000,
+				// authenticator(20B) || data
+				SenderAuth: append(bytes.Repeat([]byte{0xbb}, 20), []byte{0x01, 0x02, 0x03}...),
+				PayerAuth:  nil,
+			},
+		},
+		{
+			name: "configured with payer",
+			tx: &Eip8130Tx{
+				ChainID:       big.NewInt(8453),
+				Sender:        ptrAddr(0x22),
+				NonceKey:      big.NewInt(4),
+				NonceSequence: 9,
+				Expiry:        300,
+				GasTipCap:     big.NewInt(6),
+				GasFeeCap:     big.NewInt(10),
+				GasLimit:      60000,
+				Payer:         ptrAddr(0x33),
+				SenderAuth:    append(bytes.Repeat([]byte{0xcc}, 20), []byte{0x04, 0x05}...),
+				PayerAuth:     append(bytes.Repeat([]byte{0xdd}, 20), []byte{0x06, 0x07}...),
+			},
+		},
+		{
+			// Non-empty account_changes/calls and a zero-but-non-nil sender, which
+			// must encode distinctly from the nil EOA path (0x94 00.. vs 0x80).
+			name: "non-empty changes, zero sender",
+			tx: &Eip8130Tx{
+				ChainID:       big.NewInt(8453),
+				Sender:        ptrAddr(0x00),
+				NonceKey:      big.NewInt(0),
+				NonceSequence: 10,
+				Expiry:        0,
+				GasTipCap:     big.NewInt(7),
+				GasFeeCap:     big.NewInt(11),
+				GasLimit:      70000,
+				AccountChanges: []AccountChange{
+					{Delegation: &Delegation{Target: common.Address{0xdd}}},
+				},
+				Calls: [][]Call{
+					{{To: common.Address{0xaa}, Data: []byte{0xde, 0xad, 0xbe, 0xef}}},
+				},
+				Payer:      nil,
+				SenderAuth: append(bytes.Repeat([]byte{0xee}, 20), []byte{0x08}...),
+				PayerAuth:  nil,
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			roundTripEip8130(t, tt.tx)
+		})
+	}
+}
+
+// TestEip8130TxAccountChangesRoundTrip exercises every account_changes variant,
+// multi-phase calls and a mixed-variant transaction, asserting each survives a
+// binary round-trip byte-for-byte.
+func TestEip8130TxAccountChangesRoundTrip(t *testing.T) {
+	base := func() *Eip8130Tx {
+		return &Eip8130Tx{
+			ChainID:       big.NewInt(8453),
+			Sender:        ptrAddr(0x11),
+			NonceKey:      big.NewInt(0),
+			NonceSequence: 7,
+			GasTipCap:     big.NewInt(1),
+			GasFeeCap:     big.NewInt(2),
+			GasLimit:      1000000,
+			SenderAuth:    bytes.Repeat([]byte{0xab}, 32),
+		}
+	}
+	create := AccountChange{Create: &CreateEntry{
+		UserSalt: common.Hash{0x22},
+		Code:     []byte{0x60, 0x80, 0x60, 0x40, 0x52},
+		InitialActors: []InitialActor{
+			{ActorID: common.Hash{0x33}, Authenticator: common.Address{0xbb}},
+			{ActorID: common.Hash{0x66}, Authenticator: common.Address{0xcc}, Scope: 0x04, PolicyData: []byte{0xde, 0xad}},
+		},
+	}}
+	configChange := AccountChange{ConfigChange: &ConfigChange{
+		ChainID:  8453,
+		Sequence: 7,
+		ActorChanges: []ActorChange{
+			{ChangeType: ActorChangeAuthorize, ActorID: common.Hash{0x44}, Data: []byte{0xaa, 0xbb}},
+			{ChangeType: ActorChangeRevoke, ActorID: common.Hash{0x55}, Data: nil},
+		},
+		Auth: []byte{0xab, 0xcd},
+	}}
+	delegation := AccountChange{Delegation: &Delegation{Target: common.Address{0xdd}}}
+
+	for _, tt := range []struct {
+		name           string
+		accountChanges []AccountChange
+		calls          [][]Call
+	}{
+		{
+			name:           "create",
+			accountChanges: []AccountChange{create},
+		},
+		{
+			name:           "config change authorize and revoke",
+			accountChanges: []AccountChange{configChange},
+		},
+		{
+			name:           "delegation",
+			accountChanges: []AccountChange{delegation},
+		},
+		{
+			name: "calls two phases",
+			calls: [][]Call{
+				{{To: common.Address{0xaa}, Data: []byte{0xde, 0xad}}},
+				{
+					{To: common.Address{0xbb}, Data: []byte{0xbe, 0xef}},
+					{To: common.Address{0xcc}, Data: []byte{0x01}},
+				},
+			},
+		},
+		{
+			name:           "mixed variants and calls",
+			accountChanges: []AccountChange{create, configChange, delegation},
+			calls: [][]Call{
+				{{To: common.Address{0xaa}, Data: []byte{0xde, 0xad, 0xbe, 0xef}}},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			tx := base()
+			tx.AccountChanges = tt.accountChanges
+			tx.Calls = tt.calls
+			roundTripEip8130(t, tx)
+		})
+	}
+}
+
+// TestEip8130TxWireLiteralRoundTrip starts from a hand-built canonical
+// 0x79||rlp(...) wire encoding with empty account_changes / calls (0xc0) and empty
+// auth, decodes it, and re-encodes it. It also checks that a transaction built with
+// nil account_changes / calls encodes to that same canonical wire: empty fields must
+// become the RLP empty list (0xc0) so the 2718 stream keeps its full element count.
+func TestEip8130TxWireLiteralRoundTrip(t *testing.T) {
+	want := []byte{
+		Eip8130TxType,
+		0xd0,             // list, 16 payload bytes
+		0x01,             // chainID = 1
+		0x80,             // sender = nil
+		0x80,             // nonceKey = 0
+		0x07,             // nonceSequence = 7
+		0x80,             // expiry = 0
+		0x01,             // gasTipCap = 1
+		0x02,             // gasFeeCap = 2
+		0x82, 0x52, 0x08, // gasLimit = 21000
+		0xc0, // accountChanges = empty list
+		0xc0, // calls = empty list
+		0x80, // metadata = empty
+		0x80, // payer = nil
+		0x80, // senderAuth = empty
+		0x80, // payerAuth = empty
+	}
+
+	var tx Transaction
+	if err := tx.UnmarshalBinary(want); err != nil {
+		t.Fatalf("UnmarshalBinary: %v", err)
+	}
+	got, err := tx.MarshalBinary()
+	if err != nil {
+		t.Fatalf("MarshalBinary: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("wire round-trip not byte-exact:\n got %x\nwant %x", got, want)
+	}
+
+	// Building with nil account_changes / calls must yield the same canonical wire.
+	built := NewTx(&Eip8130Tx{
+		ChainID:       big.NewInt(1),
+		NonceKey:      big.NewInt(0),
+		NonceSequence: 7,
+		GasTipCap:     big.NewInt(1),
+		GasFeeCap:     big.NewInt(2),
+		GasLimit:      21000,
+	})
+	builtEnc, err := built.MarshalBinary()
+	if err != nil {
+		t.Fatalf("MarshalBinary(built): %v", err)
+	}
+	if !bytes.Equal(builtEnc, want) {
+		t.Fatalf("nil empties not encoded as canonical 0xc0:\n got %x\nwant %x", builtEnc, want)
+	}
+}
+
+// TestEip8130TxJSONRoundTrip verifies that the JSON representation preserves all
+// EIP-8130 fields.
+func TestEip8130TxJSONRoundTrip(t *testing.T) {
+	tx := NewTx(&Eip8130Tx{
+		ChainID:       big.NewInt(8453),
+		Sender:        ptrAddr(0x22),
+		NonceKey:      big.NewInt(4),
+		NonceSequence: 9,
+		Expiry:        300,
+		GasTipCap:     big.NewInt(6),
+		GasFeeCap:     big.NewInt(10),
+		GasLimit:      60000,
+		AccountChanges: []AccountChange{
+			{Delegation: &Delegation{Target: common.Address{0xdd}}},
+		},
+		Calls: [][]Call{
+			{{To: common.Address{0xaa}, Data: []byte{0xde, 0xad, 0xbe, 0xef}}},
+		},
+		Payer:      ptrAddr(0x33),
+		SenderAuth: append(bytes.Repeat([]byte{0xcc}, 20), []byte{0x04, 0x05}...),
+		PayerAuth:  append(bytes.Repeat([]byte{0xdd}, 20), []byte{0x06, 0x07}...),
+	})
+
+	data, err := tx.MarshalJSON()
+	if err != nil {
+		t.Fatalf("MarshalJSON: %v", err)
+	}
+	var got Transaction
+	if err := got.UnmarshalJSON(data); err != nil {
+		t.Fatalf("UnmarshalJSON: %v", err)
+	}
+
+	want, _ := tx.MarshalBinary()
+	have, _ := got.MarshalBinary()
+	if !bytes.Equal(want, have) {
+		t.Fatalf("JSON round-trip not byte-exact:\n got %x\nwant %x", have, want)
+	}
+}
+
+// TestEip8130TxCopyDeepCopy verifies that copy() produces a fully independent
+// clone: mutating every inner byte slice, nested body and big.Int of the original
+// after the copy must not affect the copy, and the body pointers must differ.
+func TestEip8130TxCopyDeepCopy(t *testing.T) {
+	orig := &Eip8130Tx{
+		ChainID:       big.NewInt(8453),
+		Sender:        ptrAddr(0x11),
+		NonceKey:      big.NewInt(3),
+		NonceSequence: 7,
+		Expiry:        100,
+		GasTipCap:     big.NewInt(1),
+		GasFeeCap:     big.NewInt(2),
+		GasLimit:      1000000,
+		AccountChanges: []AccountChange{
+			{Create: &CreateEntry{
+				UserSalt:      common.Hash{0x22},
+				Code:          []byte{0x60, 0x80},
+				InitialActors: []InitialActor{{ActorID: common.Hash{0x33}, Authenticator: common.Address{0xbb}, Scope: 0x04, PolicyData: []byte{0xde, 0xad}}},
+			}},
+			{ConfigChange: &ConfigChange{
+				ChainID:      8453,
+				Sequence:     7,
+				ActorChanges: []ActorChange{{ChangeType: ActorChangeAuthorize, ActorID: common.Hash{0x44}, Data: []byte{0xaa, 0xbb}}},
+				Auth:         []byte{0xab, 0xcd},
+			}},
+			{Delegation: &Delegation{Target: common.Address{0xdd}}},
+		},
+		Calls:      [][]Call{{{To: common.Address{0xaa}, Data: []byte{0xde, 0xad}}}},
+		Metadata:   []byte{0x01, 0x02},
+		Payer:      ptrAddr(0x55),
+		SenderAuth: []byte{0xee},
+		PayerAuth:  []byte{0xff},
+	}
+
+	cpy := orig.copy().(*Eip8130Tx)
+
+	// Body pointers must not alias.
+	if cpy.AccountChanges[0].Create == orig.AccountChanges[0].Create {
+		t.Fatal("Create body pointer aliases original")
+	}
+	if cpy.AccountChanges[1].ConfigChange == orig.AccountChanges[1].ConfigChange {
+		t.Fatal("ConfigChange body pointer aliases original")
+	}
+	if cpy.AccountChanges[2].Delegation == orig.AccountChanges[2].Delegation {
+		t.Fatal("Delegation body pointer aliases original")
+	}
+
+	// Snapshot the copy via binary encoding before mutating the original.
+	before, err := NewTx(cpy).MarshalBinary()
+	if err != nil {
+		t.Fatalf("MarshalBinary(copy): %v", err)
+	}
+
+	// Mutate every mutable part of the original in place.
+	orig.ChainID.SetInt64(9999)
+	orig.NonceKey.SetInt64(8888)
+	orig.GasTipCap.SetInt64(7777)
+	orig.GasFeeCap.SetInt64(6666)
+	orig.AccountChanges[0].Create.Code[0] = 0xff
+	orig.AccountChanges[0].Create.InitialActors[0].ActorID[0] = 0xff
+	orig.AccountChanges[0].Create.InitialActors[0].PolicyData[0] = 0xff
+	orig.AccountChanges[1].ConfigChange.ActorChanges[0].Data[0] = 0xff
+	orig.AccountChanges[1].ConfigChange.Auth[0] = 0xff
+	orig.Calls[0][0].Data[0] = 0xff
+	orig.Metadata[0] = 0xff
+	orig.SenderAuth[0] = 0xff
+	orig.PayerAuth[0] = 0xff
+
+	after, err := NewTx(cpy).MarshalBinary()
+	if err != nil {
+		t.Fatalf("MarshalBinary(copy after mutation): %v", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatalf("copy changed after mutating original:\n before %x\n after  %x", before, after)
+	}
+}
+
+// TestEip8130TxJSONVariants asserts the create and configChange account-change
+// variants survive a JSON round-trip byte-stably, that a non-empty Metadata
+// round-trips, and that nil nested slices marshal as [] (not null) to match the
+// Rust serde shape.
+func TestEip8130TxJSONVariants(t *testing.T) {
+	base := func() *Eip8130Tx {
+		return &Eip8130Tx{
+			ChainID:       big.NewInt(8453),
+			Sender:        ptrAddr(0x11),
+			NonceKey:      big.NewInt(0),
+			NonceSequence: 7,
+			Expiry:        100,
+			GasTipCap:     big.NewInt(1),
+			GasFeeCap:     big.NewInt(2),
+			GasLimit:      1000000,
+			Metadata:      []byte{0xca, 0xfe},
+			SenderAuth:    bytes.Repeat([]byte{0xab}, 32),
+		}
+	}
+
+	for _, tt := range []struct {
+		name       string
+		change     AccountChange
+		emptyField string // nested slice field that must marshal as "[]"
+	}{
+		{
+			name: "create empty initial actors",
+			change: AccountChange{Create: &CreateEntry{
+				UserSalt: common.Hash{0x22},
+				Code:     []byte{0x60, 0x80},
+			}},
+			emptyField: "initialActors",
+		},
+		{
+			name: "config change empty actor changes",
+			change: AccountChange{ConfigChange: &ConfigChange{
+				ChainID:  8453,
+				Sequence: 7,
+				Auth:     []byte{0xab, 0xcd},
+			}},
+			emptyField: "actorChanges",
+		},
+		{
+			name: "config change with actor changes",
+			change: AccountChange{ConfigChange: &ConfigChange{
+				ChainID:  8453,
+				Sequence: 7,
+				ActorChanges: []ActorChange{
+					{ChangeType: ActorChangeAuthorize, ActorID: common.Hash{0x44}, Data: []byte{0xaa, 0xbb}},
+				},
+				Auth: []byte{0xab, 0xcd},
+			}},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			inner := base()
+			inner.AccountChanges = []AccountChange{tt.change}
+			tx := NewTx(inner)
+
+			data, err := tx.MarshalJSON()
+			if err != nil {
+				t.Fatalf("MarshalJSON: %v", err)
+			}
+
+			// Nil nested slice must serialize as [], not null.
+			if tt.emptyField != "" {
+				var top map[string]json.RawMessage
+				if err := json.Unmarshal(data, &top); err != nil {
+					t.Fatalf("unmarshal output: %v", err)
+				}
+				var body map[string]json.RawMessage
+				if err := json.Unmarshal(top["tx"], &body); err != nil {
+					t.Fatalf("unmarshal tx body: %v", err)
+				}
+				var changes []map[string]json.RawMessage
+				if err := json.Unmarshal(body["accountChanges"], &changes); err != nil {
+					t.Fatalf("unmarshal accountChanges: %v", err)
+				}
+				if got := string(changes[0][tt.emptyField]); got != "[]" {
+					t.Fatalf("%s = %s, want []", tt.emptyField, got)
+				}
+			}
+
+			// JSON must round-trip to the same binary encoding (covers Metadata).
+			var got Transaction
+			if err := got.UnmarshalJSON(data); err != nil {
+				t.Fatalf("UnmarshalJSON: %v", err)
+			}
+			want, _ := tx.MarshalBinary()
+			have, _ := got.MarshalBinary()
+			if !bytes.Equal(want, have) {
+				t.Fatalf("JSON round-trip not byte-exact:\n got %x\nwant %x", have, want)
+			}
+		})
+	}
+}
+
+// TestEip8130TxJSONRethShape decodes a hand-written JSON literal in base-reth's
+// exact RPC shape (mirroring rpc-types' can_serialize_eip8130) and asserts that
+// op-geth accepts it, that the decoded tx re-encodes byte-stably, and that
+// MarshalJSON reproduces the same nested shape (chainId as a number, nonceKey as
+// "0x0", fee caps as hex quantities, nested account_changes / calls objects).
+func TestEip8130TxJSONRethShape(t *testing.T) {
+	senderAuth := "0x" + strings.Repeat("ab", 32)
+	input := `{
+		"type":"0x79",
+		"tx":{
+			"chainId":8453,
+			"sender":"0x0000000000000000000000000000000000000011",
+			"nonceKey":"0x0",
+			"nonceSequence":7,
+			"expiry":0,
+			"maxPriorityFeePerGas":"0x3b9aca00",
+			"maxFeePerGas":"0x12a05f200",
+			"gasLimit":1000000,
+			"accountChanges":[{"type":"delegation","target":"0x00000000000000000000000000000000000000dd"}],
+			"calls":[[{"to":"0x00000000000000000000000000000000000000aa","data":"0xdeadbeef"}]],
+			"metadata":"0x",
+			"payer":null
+		},
+		"senderAuth":"` + senderAuth + `",
+		"payerAuth":"0x"
+	}`
+
+	var tx Transaction
+	if err := tx.UnmarshalJSON([]byte(input)); err != nil {
+		t.Fatalf("UnmarshalJSON: %v", err)
+	}
+	if tx.Type() != Eip8130TxType {
+		t.Fatalf("type = %#x, want %#x", tx.Type(), Eip8130TxType)
+	}
+	inner, ok := tx.inner.(*Eip8130Tx)
+	if !ok {
+		t.Fatalf("inner type = %T, want *Eip8130Tx", tx.inner)
+	}
+	if inner.ChainID.Uint64() != 8453 || inner.NonceSequence != 7 || inner.GasLimit != 1000000 {
+		t.Fatalf("decoded scalars mismatch: %+v", inner)
+	}
+	if len(inner.AccountChanges) != 1 || inner.AccountChanges[0].Delegation == nil {
+		t.Fatalf("account_changes not decoded: %+v", inner.AccountChanges)
+	}
+	wantTarget := common.HexToAddress("0x00000000000000000000000000000000000000dd")
+	if got := inner.AccountChanges[0].Delegation.Target; got != wantTarget {
+		t.Fatalf("delegation target = %x, want %x", got, wantTarget)
+	}
+	if len(inner.Calls) != 1 || len(inner.Calls[0]) != 1 {
+		t.Fatalf("calls not decoded: %+v", inner.Calls)
+	}
+	wantTo := common.HexToAddress("0x00000000000000000000000000000000000000aa")
+	if got := inner.Calls[0][0]; got.To != wantTo || !bytes.Equal(got.Data, []byte{0xde, 0xad, 0xbe, 0xef}) {
+		t.Fatalf("call mismatch: %+v", got)
+	}
+
+	// Decoded tx must re-encode byte-stably through the binary codec.
+	bin, err := tx.MarshalBinary()
+	if err != nil {
+		t.Fatalf("MarshalBinary: %v", err)
+	}
+	var tx2 Transaction
+	if err := tx2.UnmarshalBinary(bin); err != nil {
+		t.Fatalf("UnmarshalBinary: %v", err)
+	}
+	bin2, err := tx2.MarshalBinary()
+	if err != nil {
+		t.Fatalf("re-MarshalBinary: %v", err)
+	}
+	if !bytes.Equal(bin, bin2) {
+		t.Fatalf("binary not stable:\n got %x\nwant %x", bin2, bin)
+	}
+
+	// MarshalJSON must reproduce reth's nested shape and field representations.
+	out, err := tx.MarshalJSON()
+	if err != nil {
+		t.Fatalf("MarshalJSON: %v", err)
+	}
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(out, &top); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	for k, want := range map[string]string{
+		"type":       `"0x79"`,
+		"senderAuth": `"` + senderAuth + `"`,
+		"payerAuth":  `"0x"`,
+	} {
+		if string(top[k]) != want {
+			t.Fatalf("top-level %q = %s, want %s", k, top[k], want)
+		}
+	}
+	var body map[string]json.RawMessage
+	if err := json.Unmarshal(top["tx"], &body); err != nil {
+		t.Fatalf("unmarshal tx body: %v", err)
+	}
+	for k, want := range map[string]string{
+		"chainId":              `8453`,    // JSON number
+		"nonceKey":             `"0x0"`,   // hex quantity
+		"nonceSequence":        `7`,       // JSON number
+		"gasLimit":             `1000000`, // JSON number
+		"maxPriorityFeePerGas": `"0x3b9aca00"`,
+		"maxFeePerGas":         `"0x12a05f200"`,
+		"metadata":             `"0x"`,
+		"payer":                `null`,
+		"sender":               `"0x0000000000000000000000000000000000000011"`,
+	} {
+		if string(body[k]) != want {
+			t.Fatalf("tx body %q = %s, want %s", k, body[k], want)
+		}
+	}
+
+	// Nested account_changes / calls keep reth's structured JSON shape.
+	var changes []map[string]json.RawMessage
+	if err := json.Unmarshal(body["accountChanges"], &changes); err != nil {
+		t.Fatalf("unmarshal accountChanges: %v", err)
+	}
+	if len(changes) != 1 || string(changes[0]["type"]) != `"delegation"` ||
+		string(changes[0]["target"]) != `"0x00000000000000000000000000000000000000dd"` {
+		t.Fatalf("accountChanges shape mismatch: %s", body["accountChanges"])
+	}
+	var calls [][]map[string]json.RawMessage
+	if err := json.Unmarshal(body["calls"], &calls); err != nil {
+		t.Fatalf("unmarshal calls: %v", err)
+	}
+	if len(calls) != 1 || len(calls[0]) != 1 ||
+		string(calls[0][0]["to"]) != `"0x00000000000000000000000000000000000000aa"` ||
+		string(calls[0][0]["data"]) != `"0xdeadbeef"` {
+		t.Fatalf("calls shape mismatch: %s", body["calls"])
+	}
+}
+
+// TestEip8130AccountChangeRejectsMalformedRLP locks the strict-decode rejection
+// branches: an unknown account-change type byte inside an otherwise well-formed
+// entry list, trailing elements after the body fields, and an actor-change op
+// byte other than Authorize/Revoke. Round-trip tests only exercise valid input,
+// so these malformed-input paths would otherwise be unguarded.
+func TestEip8130AccountChangeRejectsMalformedRLP(t *testing.T) {
+	t.Run("unknown type byte", func(t *testing.T) {
+		// [0x03]: a well-formed one-element RLP list whose type byte is not a
+		// known account-change type. (0xc1 = list of 1 byte, 0x03 = type byte.)
+		var ac AccountChange
+		err := rlp.DecodeBytes([]byte{0xc1, 0x03}, &ac)
+		if err == nil || !strings.Contains(err.Error(), "invalid account change type byte") {
+			t.Fatalf("want invalid-type-byte error, got %v", err)
+		}
+	})
+
+	t.Run("trailing elements", func(t *testing.T) {
+		// A delegation entry [0x02, target] with an extra trailing element must be
+		// rejected: the list has to be fully consumed after the body fields.
+		body, err := rlp.EncodeToBytes([]interface{}{
+			uint8(accountChangeTypeDelegation),
+			common.Address{0xdd},
+			uint8(0xff), // trailing element
+		})
+		if err != nil {
+			t.Fatalf("encode trailing entry: %v", err)
+		}
+
+		var ac AccountChange
+		if err := rlp.DecodeBytes(body, &ac); err == nil {
+			t.Fatalf("want error for trailing elements, got nil")
+		}
+	})
+
+	t.Run("invalid actor change op byte", func(t *testing.T) {
+		buf, err := rlp.EncodeToBytes(uint8(0x03))
+		if err != nil {
+			t.Fatalf("encode op byte: %v", err)
+		}
+		var op ActorChangeType
+		if err := rlp.DecodeBytes(buf, &op); err == nil ||
+			!strings.Contains(err.Error(), "invalid actor change type byte") {
+			t.Fatalf("want invalid-op-byte error, got %v", err)
+		}
+	})
+}
+
+// TestEip8130AccountChangeRequiresExactlyOneBody locks the tagged-union invariant:
+// encoding (RLP or JSON) an AccountChange with zero or multiple body pointers set
+// errors instead of silently preferring one.
+func TestEip8130AccountChangeRequiresExactlyOneBody(t *testing.T) {
+	cases := map[string]AccountChange{
+		"no body":    {},
+		"two bodies": {Create: &CreateEntry{}, Delegation: &Delegation{Target: common.Address{0xdd}}},
+	}
+	for name, ac := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := rlp.EncodeToBytes(ac); err == nil ||
+				!strings.Contains(err.Error(), "exactly one body") {
+				t.Fatalf("EncodeRLP: want exactly-one-body error, got %v", err)
+			}
+			if _, err := json.Marshal(ac); err == nil ||
+				!strings.Contains(err.Error(), "exactly one body") {
+				t.Fatalf("MarshalJSON: want exactly-one-body error, got %v", err)
+			}
+		})
+	}
+}

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -51,6 +51,7 @@ const (
 	DynamicFeeTxType = 0x02
 	BlobTxType       = 0x03
 	SetCodeTxType    = 0x04
+	Eip8130TxType    = 0x79
 )
 
 // Transaction is an Ethereum transaction.
@@ -223,6 +224,8 @@ func (tx *Transaction) decodeTyped(b []byte) (TxData, error) {
 		inner = new(BlobTx)
 	case SetCodeTxType:
 		inner = new(SetCodeTx)
+	case Eip8130TxType:
+		inner = new(Eip8130Tx)
 	case PostExecTxType:
 		inner = new(PostExecTx)
 	case DepositTxType:
@@ -646,6 +649,13 @@ func (tx *Transaction) WithBlobTxSidecar(sideCar *BlobTxSidecar) *Transaction {
 		cpy.from.Store(f)
 	}
 	return cpy
+}
+
+// Eip8130 returns the inner EIP-8130 transaction, or nil if tx is not one. It
+// exposes the EIP-8130-specific fields, which have no generic accessors on Transaction.
+func (tx *Transaction) Eip8130() *Eip8130Tx {
+	inner, _ := tx.inner.(*Eip8130Tx)
+	return inner
 }
 
 // SetCodeAuthorizations returns the authorizations list of the transaction.

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -51,6 +51,12 @@ type txJSON struct {
 	S                    *hexutil.Big           `json:"s"`
 	YParity              *hexutil.Uint64        `json:"yParity,omitempty"`
 
+	// EIP-8130 fields: the transaction body is nested under "tx"; the two
+	// authorization blobs live at the top level.
+	Tx         *eip8130TxJSON `json:"tx,omitempty"`
+	SenderAuth *hexutil.Bytes `json:"senderAuth,omitempty"`
+	PayerAuth  *hexutil.Bytes `json:"payerAuth,omitempty"`
+
 	// Deposit transaction fields
 	SourceHash *common.Hash    `json:"sourceHash,omitempty"`
 	From       *common.Address `json:"from,omitempty"`
@@ -64,6 +70,27 @@ type txJSON struct {
 
 	// Only used for encoding:
 	Hash common.Hash `json:"hash"`
+}
+
+// eip8130TxJSON is the nested "tx" body of an EIP-8130 transaction. chainId,
+// nonceSequence, expiry and gasLimit are JSON numbers; nonceKey and the fee caps
+// are hex-string quantities; metadata is hex bytes. chainId, nonceSequence,
+// expiry, gasLimit and the fee caps are required (pointer fields whose absence is
+// reported by UnmarshalJSON), matching the Rust consensus type where these have
+// no default.
+type eip8130TxJSON struct {
+	ChainID              *uint64         `json:"chainId"`
+	Sender               *common.Address `json:"sender"`
+	NonceKey             *hexutil.Big    `json:"nonceKey"`
+	NonceSequence        *uint64         `json:"nonceSequence"`
+	Expiry               *uint64         `json:"expiry"`
+	MaxPriorityFeePerGas *hexutil.Big    `json:"maxPriorityFeePerGas"`
+	MaxFeePerGas         *hexutil.Big    `json:"maxFeePerGas"`
+	GasLimit             *uint64         `json:"gasLimit"`
+	AccountChanges       []AccountChange `json:"accountChanges"`
+	Calls                [][]Call        `json:"calls"`
+	Metadata             hexutil.Bytes   `json:"metadata"`
+	Payer                *common.Address `json:"payer"`
 }
 
 // yParityValue returns the YParity value from JSON. For backwards-compatibility reasons,
@@ -178,6 +205,42 @@ func (tx *Transaction) MarshalJSON() ([]byte, error) {
 		enc.S = (*hexutil.Big)(itx.S.ToBig())
 		yparity := itx.V.Uint64()
 		enc.YParity = (*hexutil.Uint64)(&yparity)
+
+	case *Eip8130Tx:
+		// Empty account_changes and calls serialize as JSON arrays, not null.
+		accountChanges := itx.AccountChanges
+		if accountChanges == nil {
+			accountChanges = []AccountChange{}
+		}
+		calls := itx.Calls
+		if calls == nil {
+			calls = [][]Call{}
+		}
+		nonceSequence := itx.NonceSequence
+		expiry := itx.Expiry
+		gasLimit := itx.GasLimit
+		body := &eip8130TxJSON{
+			Sender:               itx.Sender,
+			NonceKey:             (*hexutil.Big)(itx.NonceKey),
+			NonceSequence:        &nonceSequence,
+			Expiry:               &expiry,
+			MaxPriorityFeePerGas: (*hexutil.Big)(itx.GasTipCap),
+			MaxFeePerGas:         (*hexutil.Big)(itx.GasFeeCap),
+			GasLimit:             &gasLimit,
+			AccountChanges:       accountChanges,
+			Calls:                calls,
+			Metadata:             hexutil.Bytes(itx.Metadata),
+			Payer:                itx.Payer,
+		}
+		if itx.ChainID != nil {
+			chainID := itx.ChainID.Uint64()
+			body.ChainID = &chainID
+		}
+		enc.Tx = body
+		senderAuth := hexutil.Bytes(itx.SenderAuth)
+		enc.SenderAuth = &senderAuth
+		payerAuth := hexutil.Bytes(itx.PayerAuth)
+		enc.PayerAuth = &payerAuth
 
 	case *PostExecTx:
 		enc.Gas = (*hexutil.Uint64)(new(uint64))
@@ -621,6 +684,60 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 			return errors.New("missing required field 'input' in transaction")
 		}
 		inner = &PostExecTx{Data: *dec.Input}
+
+	case Eip8130TxType:
+		var itx Eip8130Tx
+		inner = &itx
+		if dec.Tx == nil {
+			return errors.New("missing required field 'tx' in transaction")
+		}
+		body := dec.Tx
+		if body.ChainID == nil {
+			return errors.New("missing required field 'chainId' for txdata")
+		}
+		itx.ChainID = new(big.Int).SetUint64(*body.ChainID)
+		itx.Sender = body.Sender
+		if body.NonceKey != nil {
+			if (*big.Int)(body.NonceKey).BitLen() > 256 {
+				return errors.New("'nonceKey' value overflows uint256")
+			}
+			itx.NonceKey = (*big.Int)(body.NonceKey)
+		} else {
+			itx.NonceKey = new(big.Int)
+		}
+		if body.NonceSequence == nil {
+			return errors.New("missing required field 'nonceSequence' for txdata")
+		}
+		itx.NonceSequence = *body.NonceSequence
+		if body.Expiry == nil {
+			return errors.New("missing required field 'expiry' for txdata")
+		}
+		itx.Expiry = *body.Expiry
+		if body.MaxPriorityFeePerGas == nil {
+			return errors.New("missing required field 'maxPriorityFeePerGas' for txdata")
+		}
+		itx.GasTipCap = (*big.Int)(body.MaxPriorityFeePerGas)
+		if body.MaxFeePerGas == nil {
+			return errors.New("missing required field 'maxFeePerGas' for txdata")
+		}
+		itx.GasFeeCap = (*big.Int)(body.MaxFeePerGas)
+		if body.GasLimit == nil {
+			return errors.New("missing required field 'gasLimit' for txdata")
+		}
+		itx.GasLimit = *body.GasLimit
+		// Empty account_changes and calls encode as the canonical RLP empty list
+		// (0xc0); nil and empty slices are equivalent here.
+		itx.AccountChanges = body.AccountChanges
+		itx.Calls = body.Calls
+		itx.Metadata = body.Metadata
+		itx.Payer = body.Payer
+		if dec.SenderAuth != nil {
+			itx.SenderAuth = *dec.SenderAuth
+		}
+		if dec.PayerAuth != nil {
+			itx.PayerAuth = *dec.PayerAuth
+		}
+
 	default:
 		return ErrTxTypeNotSupported
 	}

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -274,6 +274,20 @@ func (s *modernSigner) Sender(tx *Transaction) (common.Address, error) {
 	if tt == PostExecTxType {
 		return common.Address{}, nil
 	}
+	// EIP-8130 sender derivation is account-abstraction-specific: authorization
+	// lives in the sender_auth and payer_auth fields, not in the canonical
+	// (v, r, s) fields. The generic modernSigner intentionally returns the zero
+	// address here (a deliberate divergence from DepositTx, which stores From
+	// directly above); real sender resolution happens in EIP-8130 execution /
+	// authorization, not the signer.
+	//
+	// This branch also short-circuits before the generic chain-id check below:
+	// chain-id / replay binding for 0x79 is not enforced by the signer layer but
+	// by EIP-8130 execution validation (per-ConfigChange chain_id and the tx
+	// chain_id bound during authorization).
+	if tt == Eip8130TxType {
+		return common.Address{}, nil
+	}
 
 	if !s.supportsType(tt) {
 		return common.Address{}, ErrTxTypeNotSupported


### PR DESCRIPTION
**Description**

Adds the Go representation of the [EIP-8130](https://eips.ethereum.org/EIPS/eip-8130)
account-abstraction transaction type (`0x79`): types, RLP, and JSON only. No EVM, no state
transition, no tx-pool, no gas accounting. Execution of `0x79` belongs to op-reth and kona and is
deliberately out of scope here.

Both `op-node` and `op-node` depend on this type, via the shared `op-node/rollup/derive` package.

- **op-batcher** runs the encode side. `ChannelBuilder.NewChannelOut` constructs a
  `derive.SpanChannelOut`, and `AddBlock` reaches `spanBatchTxs.AddTxs`, which reads the inner type
  via `tx.Eip8130()` to split the authorization blob.
- **op-node** runs the decode side during derivation. `convertToFullTx` constructs the inner type
  when reconstructing a batch.

Without a Go `Eip8130Tx`, the batcher cannot encode a block containing a `0x79` transaction and
op-node cannot decode one, so such a transaction cannot reach L1 or be derived back.

Contents:

- `eip8130_tx.go`: `Eip8130Tx` and its `TxData` implementation
- `eip8130_account_changes.go`: the `account_changes` tagged union (create / config change /
  delegation), `InitialActor`, `ActorChange`, with RLP and JSON codecs
- `eip8130_call.go`: `Call`
- `transaction.go`: `Eip8130TxType = 0x79`, a `decodeTyped` case, the `Eip8130()` accessor
- `transaction_signing.go`: `modernSigner.Sender` returns the zero address for `0x79`
- `transaction_marshalling.go`: JSON marshal/unmarshal

**Tests**

Nine test functions in `eip8130_tx_test.go`.

- `TestEip8130TxWireLiteralRoundTrip` pins an explicit byte vector, asserts it decodes and
  re-encodes byte-exact, and asserts that constructing the same transaction with nil `AccountChanges`
  and `Calls` produces identical bytes (empties must encode as the canonical `0xc0`).
- `TestEip8130TxJSONRethShape` pins the JSON shape against the Rust consensus type, including
  nil-slice normalization to `[]` to match serde's `Vec`.

Also covered: RLP round-trips for every account-change variant and for multi-phase calls; JSON
round-trip and per-variant JSON shapes; deep-copy independence across every nested slice;
malformed-RLP rejection (unknown entry type byte, trailing list elements, invalid `ActorChange` op
byte); and the exactly-one-body union invariant.

Untested here by design: sender resolution and the EIP-8130 signature payloads. `Sender()` returns
the zero address for `0x79` (see below), so there is no behavior to assert beyond that; real
resolution is an execution-layer concern and will be tested where it lives.